### PR TITLE
ci: bump setup-go to 1.25 (closes #35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: go vet
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: integration tests
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - uses: golangci/golangci-lint-action@v7
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: install govulncheck
@@ -148,7 +148,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: install containerlab
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: install containerlab


### PR DESCRIPTION
## Summary

Closes #35. Bumps all six `actions/setup-go@v5` invocations in `.github/workflows/ci.yml` from `'1.24'` to `'1.25'` to match `go.mod`'s `go 1.25.0` directive.

This should:
- Resolve the `vulnerability scan` CI job (currently red on main due to `GO-2025-4007` and `GO-2025-4008` in `crypto/x509` / `crypto/tls`, both fixed in Go 1.25.2 / 1.25.3).
- Eliminate the auto-toolchain-download path that surfaced the `go: no such tool "covdata"` failure on PR #34's first run.

## Test plan

- [ ] All six setup-go matrix entries resolve to a 1.25.x patch ≥ 1.25.3 (CI's checkout log will show the exact version)
- [ ] `build + unit tests` job green
- [ ] `vulnerability scan` job green (GO-2025-4007 / GO-2025-4008 drop off the report)
- [ ] No regression in other jobs (lint failures are pre-existing — tracked separately in #36)