### PR TITLE
feat(metrics): add snapshot_drops_total counter (closes #42)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -25,6 +25,7 @@ All metrics use the `network_` prefix. No metric uses a raw IP address or free-f
 | `network_topology_graph_stale` | gauge (0/1) | 1 while serving snapshot on startup; 0 after first live cycle. Alert: `network_topology_graph_stale == 1 for 15m` |
 | `network_topology_snapshot_last_written_timestamp_seconds` | gauge | Alert: absent or stopped advancing after two cycle intervals. |
 | `network_topology_snapshot_loaded_devices_total` | gauge | Sanity check at startup; compare to expected fleet size. |
+| `network_topology_snapshot_drops_total` | counter | Snapshot writes dropped because the persistence pipeline could not absorb them. `reason` ∈ {`queue_full`, `write_in_flight`}. Issue #42. Alert: `rate(...) > 0 for 5m` — persistent drops mean on-disk state is going stale; restart will cold-start from a worse position the longer the stall lasts. |
 
 ## Discovery cycle health
 

--- a/docs/operator/cardinality.md
+++ b/docs/operator/cardinality.md
@@ -29,6 +29,22 @@ per-row instance OID. The type system enforces this via `snmputil.TableOID`.
 Current table OIDs walked: ~12. `module` is one of the ~9 discovery modules.
 `reason` is one of: `invalid_type`, `invalid_oid`. Maximum cardinality: ~200.
 
+## network_topology_snapshot_drops_total
+Labels: `reason`
+
+Cardinality = 2 (closed enum: `queue_full`, `write_in_flight`). Counter
+increments when the snapshot persistence pipeline cannot absorb a write
+(typically during a storage stall — slow NFS, full disk, EBS hang). The
+two reasons surface the same underlying condition at different layers:
+
+- `queue_full` — caller couldn't enqueue (bounded snapshot channel full).
+- `write_in_flight` — writer goroutine dequeued a new snapshot but found
+  its previous write still pending from an earlier timed-out goroutine.
+
+Alert: `rate(network_topology_snapshot_drops_total[10m]) > 0` for 5m.
+Persistent drops mean the on-disk state is increasingly stale and a
+restart will cold-start from a worse position the longer the stall lasts.
+
 ## network_topology_federation_spoke_last_push_timestamp_seconds
 Labels: `spoke_id`
 

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -195,6 +195,7 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 						// would emit this Warn every cycle until the stall
 						// clears. Limiter keeps the operator alerted at first
 						// occurrence and re-alerted hourly, not every minute.
+						lc.M.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonWriteInFlight)).Inc()
 						lc.WarnSnapshot(ctx, "snapshot_write_in_flight",
 							"snapshot write still in flight; dropping snapshot (NFS stall?)")
 						continue
@@ -322,6 +323,7 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 				// symptom of the same chronic-NFS stall as the two branches
 				// in the writer goroutine. Keys are distinct so each path
 				// surfaces independently on first occurrence.
+				lc.M.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonQueueFull)).Inc()
 				lc.WarnSnapshot(ctx, "snapshot_queue_full",
 					"snapshot write queue full; dropping (previous write still in flight)")
 			}

--- a/internal/federation/hub.go
+++ b/internal/federation/hub.go
@@ -1030,6 +1030,7 @@ func (h *Hub) runSnapshotWriter(ctx context.Context) {
 				select {
 				case <-writeDone:
 				default:
+					h.m.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonWriteInFlight)).Inc()
 					h.logger.Warn("hub: snapshot write still in flight; dropping snapshot (NFS stall?)")
 					continue
 				}
@@ -1072,6 +1073,7 @@ func (h *Hub) writeSnapshotAsync(g discovery.Graph) {
 	select {
 	case h.snapshotCh <- g:
 	default:
+		h.m.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonQueueFull)).Inc()
 		h.logger.Warn("hub: snapshot write queue full; dropping (NFS stall?)")
 	}
 }

--- a/internal/federation/hub_test.go
+++ b/internal/federation/hub_test.go
@@ -750,6 +750,116 @@ func TestWriteSnapshotAsyncIsNonBlocking(t *testing.T) {
 	}
 }
 
+// TestWriteSnapshotAsyncIncrementsDropsOnQueueFull verifies that the
+// queue-full drop path on writeSnapshotAsync increments
+// SnapshotDropsTotal{reason="queue_full"}. Issue #42.
+func TestWriteSnapshotAsyncIncrementsDropsOnQueueFull(t *testing.T) {
+	m := metrics.New(false)
+	h := NewHub(config.FederationConfig{}, m, nil, t.TempDir()+"/snap.json")
+
+	before := testutil.ToFloat64(m.SnapshotDropsTotal.WithLabelValues(
+		string(metrics.SnapshotDropReasonQueueFull)))
+
+	h.snapshotCh <- discovery.Graph{}       // fill cap-1 channel
+	h.writeSnapshotAsync(discovery.Graph{}) // must drop
+
+	after := testutil.ToFloat64(m.SnapshotDropsTotal.WithLabelValues(
+		string(metrics.SnapshotDropReasonQueueFull)))
+	if got := after - before; got != 1 {
+		t.Errorf("SnapshotDropsTotal{queue_full} delta = %v, want 1", got)
+	}
+}
+
+// TestRunSnapshotWriterIncrementsDropsOnWriteInFlight verifies that when
+// runSnapshotWriter dequeues a snapshot while a previous write goroutine
+// is still in-flight, the new snapshot is dropped and
+// SnapshotDropsTotal{reason="write_in_flight"} increments. Issue #42.
+//
+// Test shape mirrors TestRunSnapshotWriterTimeoutContinues: stall the first
+// write past the timeout (so writeDone is still non-nil when the next
+// snapshot arrives), then enqueue a second snapshot before unblocking the
+// first. The writer's `if writeDone != nil` check finds the previous write
+// still pending and takes the drop branch.
+func TestRunSnapshotWriterIncrementsDropsOnWriteInFlight(t *testing.T) {
+	dir := t.TempDir()
+	m := metrics.New(false)
+	h := NewHub(config.FederationConfig{SpokeTimeout: 5 * time.Minute}, m, nil, filepath.Join(dir, "snap.json"))
+
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	firstWriteDone := make(chan struct{})
+	firstDone := false
+	var mu sync.Mutex
+
+	h.snapshotWriteFn = func(_ string, _ snapshot.File) error {
+		mu.Lock()
+		isFirst := !firstDone
+		if isFirst {
+			firstDone = true
+		}
+		mu.Unlock()
+
+		if isFirst {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			close(firstWriteDone)
+		}
+		return nil
+	}
+	h.snapshotWriteTimeout = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go h.runSnapshotWriter(ctx)
+
+	// First write: enqueue and wait for it to start.
+	h.writeSnapshotAsync(discovery.Graph{Devices: []discovery.Device{{ID: "first"}}})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first write never started")
+	}
+
+	// Wait for the writer's outer-select timeout to fire (20ms + margin). The
+	// first write goroutine is still blocked on `block`; writeDone is still
+	// non-nil from the writer's perspective.
+	time.Sleep(100 * time.Millisecond)
+
+	before := testutil.ToFloat64(m.SnapshotDropsTotal.WithLabelValues(
+		string(metrics.SnapshotDropReasonWriteInFlight)))
+
+	// Second snapshot arrives while writeDone is still pending — must drop.
+	h.writeSnapshotAsync(discovery.Graph{Devices: []discovery.Device{{ID: "second"}}})
+
+	// Give runSnapshotWriter a chance to dequeue + take the drop branch.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		after := testutil.ToFloat64(m.SnapshotDropsTotal.WithLabelValues(
+			string(metrics.SnapshotDropReasonWriteInFlight)))
+		if after-before >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	after := testutil.ToFloat64(m.SnapshotDropsTotal.WithLabelValues(
+		string(metrics.SnapshotDropReasonWriteInFlight)))
+	if got := after - before; got != 1 {
+		t.Errorf("SnapshotDropsTotal{write_in_flight} delta = %v, want 1", got)
+	}
+
+	// Unblock the stalled write so the test cleans up without leaking.
+	close(block)
+	select {
+	case <-firstWriteDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stalled write never unblocked")
+	}
+}
+
 // TestHubWriteSnapshotNoopWhenPathEmpty verifies that writeSnapshot is a no-op
 // when snapshotPath is empty (the normal test configuration).
 func TestHubWriteSnapshotNoopWhenPathEmpty(_ *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -101,6 +101,18 @@ type Metrics struct {
 	// writing (0 or 1 for the capacity-1 channel).
 	SnapshotQueueDepth prometheus.Gauge
 
+	// SnapshotDropsTotal counts snapshot writes that were dropped because
+	// the snapshot pipeline could not absorb them. Partitioned by `reason`:
+	//   - queue_full:      caller couldn't enqueue (snapshot channel full)
+	//   - write_in_flight: writer found previous write still pending
+	//
+	// Both reasons surface the same underlying condition (storage stall
+	// preventing the previous snapshot from completing) at different
+	// layers; they are kept distinct so operators can tell whether the
+	// upstream cycle has started outpacing the writer, or the writer
+	// itself is stalled. Issue #42.
+	SnapshotDropsTotal *prometheus.CounterVec
+
 	// CycleBudgetSkipsTotal counts targets that were never polled in a discovery
 	// cycle because the cycle budget deadline expired before their goroutine could
 	// acquire the parallelism semaphore.
@@ -257,6 +269,10 @@ func New(emitBoundaryObs bool) *Metrics {
 			Name: "network_topology_snapshot_queue_depth",
 			Help: "Current number of snapshots queued for writing.",
 		}),
+		SnapshotDropsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "network_topology_snapshot_drops_total",
+			Help: "Snapshot writes dropped because the pipeline could not absorb them. reason ∈ {queue_full, write_in_flight}.",
+		}, []string{"reason"}),
 		CycleBudgetSkipsTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "network_topology_cycle_budget_skips_total",
 			Help: "Targets skipped in a discovery cycle because the cycle budget deadline expired before their goroutine could start.",
@@ -312,6 +328,7 @@ func New(emitBoundaryObs bool) *Metrics {
 		m.FDBSuppressedMACs,
 		m.GoRoutines,
 		m.SnapshotQueueDepth,
+		m.SnapshotDropsTotal,
 		m.CycleBudgetSkipsTotal,
 		m.MetricsRenderDuration,
 		m.MetricsPayloadBytes,

--- a/internal/metrics/snapshot_drop_reason.go
+++ b/internal/metrics/snapshot_drop_reason.go
@@ -1,0 +1,38 @@
+package metrics
+
+// SnapshotDropReason is the closed-enum label value for
+// SnapshotDropsTotal's `reason` field. Each value describes a distinct
+// layer at which a snapshot was lost; the two values together let an
+// operator distinguish "upstream cycle is outpacing the writer"
+// (queue_full) from "writer goroutine itself is stalled"
+// (write_in_flight). Both ultimately surface the same operational
+// condition (storage stalled).
+type SnapshotDropReason string
+
+// String returns the underlying wire value, satisfying fmt.Stringer.
+func (r SnapshotDropReason) String() string { return string(r) }
+
+// Valid reports whether r is one of the declared SnapshotDropReason
+// constants. Used by tests to pin the closed-enum contract.
+func (r SnapshotDropReason) Valid() bool {
+	switch r {
+	case SnapshotDropReasonQueueFull,
+		SnapshotDropReasonWriteInFlight:
+		return true
+	}
+	return false
+}
+
+// SnapshotDropReason values.
+const (
+	// SnapshotDropReasonQueueFull means the caller could not enqueue a new
+	// snapshot because the bounded snapshot channel was full — the writer
+	// goroutine is still working on (or stuck on) the previous one.
+	SnapshotDropReasonQueueFull SnapshotDropReason = "queue_full"
+
+	// SnapshotDropReasonWriteInFlight means the writer goroutine pulled a
+	// new snapshot off the channel but found its previous write still
+	// in-flight (from an earlier timed-out write goroutine). The new
+	// snapshot is dropped rather than spawning a second concurrent writer.
+	SnapshotDropReasonWriteInFlight SnapshotDropReason = "write_in_flight"
+)

--- a/internal/metrics/snapshot_drop_reason_test.go
+++ b/internal/metrics/snapshot_drop_reason_test.go
@@ -1,0 +1,44 @@
+package metrics
+
+import "testing"
+
+// TestSnapshotDropReasonWireValuesPinned locks the underlying string for every
+// SnapshotDropReason constant to its on-wire value. These strings appear as
+// the `reason` label on network_topology_snapshot_drops_total; alert rules
+// and dashboards branch on them. Failures of this test should be paired
+// with a CHANGELOG entry and a docs update, not silently fixed by updating
+// `want`.
+func TestSnapshotDropReasonWireValuesPinned(t *testing.T) {
+	cases := []struct {
+		r    SnapshotDropReason
+		want string
+	}{
+		{SnapshotDropReasonQueueFull, "queue_full"},
+		{SnapshotDropReasonWriteInFlight, "write_in_flight"},
+	}
+	for _, c := range cases {
+		if string(c.r) != c.want {
+			t.Errorf("SnapshotDropReason(%s) = %q, want %q (wire-format contract)",
+				c.want, string(c.r), c.want)
+		}
+		if !c.r.Valid() {
+			t.Errorf("SnapshotDropReason(%q).Valid() = false, want true", string(c.r))
+		}
+	}
+}
+
+// TestSnapshotDropReasonValidRejectsUnknown ensures Valid() returns false for
+// strings that look like reasons but are not declared constants.
+func TestSnapshotDropReasonValidRejectsUnknown(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"queue-full",      // hyphens, not underscores
+		"WRITE_IN_FLIGHT", // wrong case
+		"timeout",         // we deliberately do NOT count timeouts as drops
+		"unknown",
+	} {
+		if SnapshotDropReason(s).Valid() {
+			t.Errorf("SnapshotDropReason(%q).Valid() = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #42. Surfaces snapshot persistence-pipeline drops as a discrete Prometheus counter so operators can alert on snapshot loss during storage stalls. Until now the four drop sites only logged (rate-limited) via `WarnSnapshot`; there was no way to quantify or alert on the condition.

Surfaced by the 2026-05-20 adversarial review (the "NFS-stall kill-switch" finding).

## The metric

`network_topology_snapshot_drops_total` — counter, partitioned by `reason`:

| reason | meaning |
|---|---|
| `queue_full` | caller couldn't enqueue (bounded snapshot channel full) |
| `write_in_flight` | writer dequeued a new snapshot but found previous write still pending from an earlier timed-out goroutine |

Both reasons surface the same underlying condition (storage stalled) at different layers; kept distinct so operators can tell whether the upstream cycle is outpacing the writer or the writer itself is stuck. Cardinality: 2 series total.

## Drop sites wired

| Site | Reason |
|---|---|
| `internal/app/loop.go` writer (loop: previous write pending) | `write_in_flight` |
| `internal/app/loop.go` enqueue (loop: queue full) | `queue_full` |
| `internal/federation/hub.go:1033` writer (hub: previous write pending) | `write_in_flight` |
| `internal/federation/hub.go:1075` enqueue (hub: queue full) | `queue_full` |

## New types & tests

- `metrics.SnapshotDropReason` — closed-enum string type with `Valid()`, mirroring `RejectReason` / `WalkReason`
- `metrics.SnapshotDropReasonQueueFull` / `SnapshotDropReasonWriteInFlight`
- `TestSnapshotDropReasonWireValuesPinned` — wire-format contract pin (alerts/dashboards branch on these strings)
- `TestSnapshotDropReasonValidRejectsUnknown` — `Valid()` defense
- `TestWriteSnapshotAsyncIncrementsDropsOnQueueFull` (hub)
- `TestRunSnapshotWriterIncrementsDropsOnWriteInFlight` (hub) — stalls first write past timeout, enqueues second, asserts the writer's `if writeDone != nil` branch increments the counter

## Docs

- `docs/metrics.md` — new row under "Graph freshness"
- `docs/operator/cardinality.md` — new section + suggested alert query

## What this is NOT

- **Not a behavior change beyond the counter increments.** The existing `WarnSnapshot` log path stays as the first-incident signal — operators can alert on logs and/or the counter as they prefer.
- **Not a timeout counter.** Snapshot-write timeouts (`loop.go:216`) are NOT counted as drops because the operation continues in the background; only subsequent cycles that have to drop _because_ of the stall are counted. Timeouts remain visible through the rate-limited `snapshot_write_timeout` warn key.

## Test plan

- [x] `go test -race -count=1 ./...` passes (all 23 packages)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] Two new hub tests pass; both assert deterministic counter increments
- [ ] CI green