### PR TITLE
ci(docker): bump builder image to golang:1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ─── builder ────────────────────────────────────────────────────────────────
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

CI's `docker build` job started failing once the lint and integration-test gates went green earlier this session (the failure was previously masked by earlier-job failures that prevented docker-build from running). Builder stage hits:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

`go.mod` has required `go 1.25.0` since the v1.3.0 cycle. CI's `setup-go` was bumped to 1.25 in `bc0fa50` (closes #35); this is the parallel fix for the **container build path**, which runs with `GOTOOLCHAIN=local` and so cannot auto-download a newer toolchain at build time.

One-line change: `FROM golang:1.24-alpine` → `FROM golang:1.25-alpine`.

## Test plan

- [x] One-line diff verified — Dockerfile line 4 only
- [ ] CI `docker build` job green on this branch
- [ ] No other Go-version reference in the Dockerfile (verified — `grep -n golang Dockerfile` returns only line 4)