### PR TITLE
fix(test): unblock e2e suites — snmpwalk.Params.Community is []byte (issue #5)

### DIFF
--- a/tests/e2e/lldp_test.go
+++ b/tests/e2e/lldp_test.go
@@ -18,7 +18,10 @@ func snmpParams(node string) snmpwalk.Params {
 		IP:        nodeIPs[node],
 		Port:      161,
 		Timeout:   10 * time.Second,
-		Community: snmpCommunity,
+		// snmpwalk.Params.Community is []byte (issue #5: zeroization).
+		// gsnmp.GoSNMP.Community in e2e_test.go's snmpAlive stays a string
+		// because gosnmp's own struct hasn't moved to []byte upstream.
+		Community: []byte(snmpCommunity),
 	}
 }
 

--- a/tests/e2e/srl/srl_test.go
+++ b/tests/e2e/srl/srl_test.go
@@ -195,7 +195,10 @@ func snmpParams(node string) snmpwalk.Params {
 		IP:        nodeIPs[node],
 		Port:      161,
 		Timeout:   10 * time.Second,
-		Community: snmpCommunity,
+		// snmpwalk.Params.Community is []byte (issue #5: zeroization).
+		// gsnmp.GoSNMP.Community above stays a plain string because gosnmp's
+		// own struct hasn't moved to []byte upstream.
+		Community: []byte(snmpCommunity),
 	}
 }
 


### PR DESCRIPTION
## Summary

Both e2e CI jobs (containerlab and SR Linux) have been red on every push to main since issue #5 (SNMP credential zeroization) changed `snmpwalk.Params.Community` from `string` to `[]byte`. They were invisible during the bulk of this session because the workflow gates them to push-to-main events only (not PR runs), so they only surfaced after the unrelated PR queue cleared and merges started landing on main.

Identical drift to the integration-test compile error fixed in #41 — same trailing edge of issue #5's API change.

## What changes

Two struct types are at play in these files and they intentionally diverge:

| Type | Field | Source | Action |
|---|---|---|---|
| `snmpwalk.Params` (ours) | `Community []byte` | `internal/discovery/snmp` | sites updated to `[]byte(snmpCommunity)` |
| `gsnmp.GoSNMP` (upstream) | `Community string` | `github.com/gosnmp/gosnmp` | sites unchanged — gosnmp's struct is still `string` |

Specifically:
- ✏️ `tests/e2e/lldp_test.go:21` — was `Community: snmpCommunity`, now `Community: []byte(snmpCommunity)` (uses `snmpwalk.Params`)
- ✏️ `tests/e2e/srl/srl_test.go:198` — same fix (uses `snmpwalk.Params`)
- 🟰 `tests/e2e/e2e_test.go:221` — unchanged (uses `gsnmp.GoSNMP` for a single sysUpTime liveness probe)
- 🟰 `tests/e2e/srl/srl_test.go:179` — unchanged (same, uses `gsnmp.GoSNMP`)

Added clarifying comments at both `snmpwalk.Params` sites so the next contributor doesn't try to "unify" the two conventions and reintroduce the regression.

## Test plan

- [x] `go build -tags e2e ./tests/e2e/...` clean
- [x] `go build -tags e2e_srl ./tests/e2e/srl/...` clean
- [ ] CI `e2e tests (containerlab)` job green on main push after merge
- [ ] CI `e2e tests (SR Linux)` job green on main push after merge

Note: these jobs run only on pushes to `main`, not on PR runs. CI on this PR will not exercise them; the proof is post-merge.