### PR TITLE
fix(lab): drop invalid snmpwalk -Ovq=0 flag in capture scripts

### DIFF
--- a/lab/arista-ceos-bgp/capture.sh
+++ b/lab/arista-ceos-bgp/capture.sh
@@ -83,7 +83,7 @@ for entry in "${NODES[@]}"; do
       echo "# oid:    ${oid}"
       echo "# walker fed: see comments in capture.sh"
       echo
-      snmpwalk -v2c -c "${COMMUNITY}" -On -Oe -Ovq=0 "${host}" "${oid}" 2>&1
+      snmpwalk -v2c -c "${COMMUNITY}" -On -Oe "${host}" "${oid}" 2>&1
     } > "${out}"
     if grep -q "No Such Object\|No Such Instance\|Timeout\|No Response" "${out}"; then
       echo "  ${oid} → empty/error (see ${out#$(dirname "$0")/})"

--- a/lab/cisco-iol-bgp/capture.sh
+++ b/lab/cisco-iol-bgp/capture.sh
@@ -83,7 +83,7 @@ for entry in "${NODES[@]}"; do
       echo "# oid:    ${oid}"
       echo "# walker fed: see comments in capture.sh"
       echo
-      snmpwalk -v2c -c "${COMMUNITY}" -On -Oe -Ovq=0 "${host}" "${oid}" 2>&1
+      snmpwalk -v2c -c "${COMMUNITY}" -On -Oe "${host}" "${oid}" 2>&1
     } > "${out}"
     if grep -q "No Such Object\|No Such Instance\|Timeout\|No Response" "${out}"; then
       echo "  ${oid} → empty/error (see ${out#$(dirname "$0")/})"


### PR DESCRIPTION
## Summary
- Drop `-Ovq=0` (invalid net-snmp output option) from `lab/cisco-iol-bgp/capture.sh:86` and `lab/arista-ceos-bgp/capture.sh:86`.
- Without this fix, every capture file produced by these scripts contains the snmpwalk usage banner instead of OID data, while the script reports "N lines captured" (the grep filter never matches the banner text).
- Closes #48.

## Why this was silent
- `snmpwalk -Ovq=0` writes `Unknown output option passed to -O: =.` + USAGE to stdout (verified live).
- Scripts redirect `2>&1` into `${out}`, then their grep checks for `No Such Object | No Such Instance | Timeout | No Response` — none match the banner.

## Scope
- Two pre-existing tracked scripts touched here.
- Third occurrence in `lab/cisco-iosxe-bgp/capture.sh` is part of an untracked scaffold; it's introduced in its already-fixed state via the PR for #49.
- Existing committed captures under `lab/*/captures/` were generated by a different path (distinct filename pattern) and are unaffected — no regeneration needed.

## Solution triple-pass
- **Correctness**: `-On -Oe` produces the `.OID = TYPE: value` format with numeric OIDs and numeric enums that existing committed captures use and that fixture conversion expects.
- **Efficiency**: flag change only, zero perf impact.
- **Regression risk**: no Go code parses `.txt` capture files; only README docs reference the `-On -Oe` format, which is unchanged.

## Adjacent (not fixed here, follow-up worthy)
- The grep filter misses other net-snmp failure banners (`Unknown output option`, `USAGE:`, `Cannot find module`, `Reason:`, etc.). If a future flag typo regresses this, the silent-success failure mode returns. Worth a follow-up to add `^USAGE:|^Unknown.*option` to the pattern.

## Test plan
- [ ] Manual smoke against a reachable SNMP target: `./capture.sh <host>` produces a file containing `.1.3.6.1.4.1.* = TYPE: value` lines, not a USAGE banner.
- [ ] Confirm existing captures under `lab/cisco-iol-bgp/captures/` are byte-identical (they don't come from these scripts).