### PR TITLE
feat(lab): introduce cisco-iosxe-bgp DevNet capture scaffold

### DIFF
--- a/internal/discovery/bgp/bgp_v2_iosxe_test.go
+++ b/internal/discovery/bgp/bgp_v2_iosxe_test.go
@@ -54,21 +54,17 @@ import (
 //
 // TODO(#1): replace placeholder values with values from
 // lab/cisco-iosxe-bgp/captures/<r1-host>__1_3_6_1_4_1_9_9_187_1_2_5.txt
-// once captures land. Numeric OID form is mandatory.
+// once captures land. Numeric OID form is mandatory. The current
+// placeholder values use RFC 5737 TEST-NET-1 (10.255.255.254) and
+// RFC 6996 private AS 64999 deliberately, so that if t.Skip is removed
+// without updating both the PDUs below and the assertions in the test,
+// the failure mode is loud (assertion mismatch) rather than a false pass.
 func buildCiscoCbgpPeer2IOSXERealPDUs() []gsnmp.SnmpPDU {
 	const base = ".1.3.6.1.4.1.9.9.187.1.2.5.1."
-	// TODO(#1): confirm index encoding matches IOL — expected format
-	// from MIB documentation: <addrType=1=ipv4>.<addrLen=4>.<addrBytes>.
-	// Replace with the actual index suffix observed in the capture.
-	const idx = "1.4.10.0.0.2"
+	const idx = "1.4.10.255.255.254"
 	return []gsnmp.SnmpPDU{
-		// TODO(#1): col 3 = bgpPeer2State; expect Integer(6)=established
-		// when BGP is up. Read the value from the capture line that
-		// matches the OID prefix and column number.
 		{Name: base + "3." + idx, Type: gsnmp.Integer, Value: bgpStateEstablished},
-		// TODO(#1): col 11 = bgpPeer2RemoteAs; expect Gauge32(65001) for
-		// Option A iBGP, Gauge32(65002) for Option B eBGP-to-bird.
-		{Name: base + "11." + idx, Type: gsnmp.Gauge32, Value: uint(65001)},
+		{Name: base + "11." + idx, Type: gsnmp.Gauge32, Value: uint(64999)},
 	}
 }
 
@@ -102,13 +98,13 @@ func TestWalkVendorCiscoFromIOSXECapture(t *testing.T) {
 	if len(edges) != 1 {
 		t.Fatalf("expected 1 edge from IOS-XE vendor walker, got %d: %+v", len(edges), edges)
 	}
-	// TODO(#1): assert the expected DstDevice — 10.0.0.2 for Option A,
-	// or the bird router-id for Option B.
-	if got := edges[0].DstDevice; got != "10.0.0.2" {
-		t.Errorf("DstDevice = %q, want 10.0.0.2 (from IOS-XE cbgpPeer2 index)", got)
+	// TODO(#1): update both the expected DstDevice and the expected
+	// remote-AS once captures land — 10.0.0.2/65001 for Option A iBGP,
+	// or the bird router-id/65002 for Option B eBGP.
+	if got := edges[0].DstDevice; got != "10.255.255.254" {
+		t.Errorf("DstDevice = %q, want 10.255.255.254 (placeholder)", got)
 	}
-	// TODO(#1): assert remote-AS — 65001 for Option A iBGP, 65002 for Option B eBGP.
-	if got := edges[0].Metadata[metaKeyRemoteAs]; got != "65001" {
-		t.Errorf("RemoteAs metadata = %q, want 65001 (from IOS-XE col 11)", got)
+	if got := edges[0].Metadata[metaKeyRemoteAs]; got != "64999" {
+		t.Errorf("RemoteAs metadata = %q, want 64999 (placeholder)", got)
 	}
 }

--- a/internal/discovery/bgp/bgp_v2_iosxe_test.go
+++ b/internal/discovery/bgp/bgp_v2_iosxe_test.go
@@ -1,0 +1,114 @@
+package bgp
+
+// Real-device validation harness for the vendor_cisco walker against
+// Cisco IOS-XE, fulfilling the IOS-XE half of issue #1's acceptance
+// criteria.
+//
+// Scope: this file is the post-capture landing pad. Today it ships
+// with placeholder PDU values and the test below calls t.Skip until
+// real captures land at lab/cisco-iosxe-bgp/captures/. Once captures
+// exist, the workflow is:
+//
+//   1. Inspect lab/cisco-iosxe-bgp/captures/<host>__1_3_6_1_4_1_9_9_187_1_2_5.txt.
+//   2. Locate the rows: column 3 = bgpPeer2State (Integer),
+//      column 11 = bgpPeer2RemoteAs (Gauge32). The index suffix after
+//      ".1.3.6.1.4.1.9.9.187.1.2.5.1.<col>." is the peer-address
+//      encoding (<addrType>.<addrLen>.<bytes...>).
+//   3. Replace the TODO values in buildCiscoCbgpPeer2IOSXERealPDUs
+//      below with the captured values.
+//   4. Delete the t.Skip line in TestWalkVendorCiscoFromIOSXECapture.
+//   5. `go test ./internal/discovery/bgp/ -run TestWalkVendorCiscoFromIOSXECapture`.
+//
+// If the test passes with values byte-identical to
+// buildCiscoCbgpPeer2RealPDUs (the IOL-derived helper in
+// bgp_v2_test.go), the IOS-XE and IOL row shapes match — strong
+// cross-confirmation that the walker's column numbers and index
+// decoder are correct. Note that fact in the closing PR for issue #1
+// and consider deleting this file in favor of a one-line comment
+// update on the IOL helper.
+//
+// If the test fails, the walker code in bgp_vendor.go has IOS-XE
+// drift — file a follow-up issue with the divergence and land the
+// column-number correction in the same PR.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gsnmp "github.com/gosnmp/gosnmp"
+
+	snmputil "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+)
+
+// buildCiscoCbgpPeer2IOSXERealPDUs returns a PDU set modelled on real
+// cbgpPeer2Table output captured from a Cisco IOS-XE router (CSR1000v
+// or c8000v) via the DevNet Sandbox flow documented in
+// lab/cisco-iosxe-bgp/README.md.
+//
+// Placeholder values below assume Option A (CML two-router iBGP,
+// AS 65001, peer at 10.0.0.2). For Option B (single CSR + external
+// bird speaker), swap the remote-AS to 65002 and the peer IP/index
+// to whatever bird's router-id resolves to.
+//
+// TODO(#1): replace placeholder values with values from
+// lab/cisco-iosxe-bgp/captures/<r1-host>__1_3_6_1_4_1_9_9_187_1_2_5.txt
+// once captures land. Numeric OID form is mandatory.
+func buildCiscoCbgpPeer2IOSXERealPDUs() []gsnmp.SnmpPDU {
+	const base = ".1.3.6.1.4.1.9.9.187.1.2.5.1."
+	// TODO(#1): confirm index encoding matches IOL — expected format
+	// from MIB documentation: <addrType=1=ipv4>.<addrLen=4>.<addrBytes>.
+	// Replace with the actual index suffix observed in the capture.
+	const idx = "1.4.10.0.0.2"
+	return []gsnmp.SnmpPDU{
+		// TODO(#1): col 3 = bgpPeer2State; expect Integer(6)=established
+		// when BGP is up. Read the value from the capture line that
+		// matches the OID prefix and column number.
+		{Name: base + "3." + idx, Type: gsnmp.Integer, Value: bgpStateEstablished},
+		// TODO(#1): col 11 = bgpPeer2RemoteAs; expect Gauge32(65001) for
+		// Option A iBGP, Gauge32(65002) for Option B eBGP-to-bird.
+		{Name: base + "11." + idx, Type: gsnmp.Gauge32, Value: uint(65001)},
+	}
+}
+
+// TestWalkVendorCiscoFromIOSXECapture validates that the vendor_cisco
+// walker decodes a real IOS-XE cbgpPeer2Table response into exactly
+// one Established edge with the expected peer IP and remote-AS.
+//
+// SKIPPED until lab/cisco-iosxe-bgp/captures/ has real walks and the
+// placeholders in buildCiscoCbgpPeer2IOSXERealPDUs are filled in.
+// See file-level comment for the post-capture workflow.
+func TestWalkVendorCiscoFromIOSXECapture(t *testing.T) {
+	t.Skip("issue #1: awaiting Cisco IOS-XE captures in lab/cisco-iosxe-bgp/captures/; " +
+		"fill in buildCiscoCbgpPeer2IOSXERealPDUs() and remove this skip")
+
+	addr := snmptest.Start(t, "public", buildCiscoCbgpPeer2IOSXERealPDUs())
+	ip, port := snmptest.ParseAddr(addr)
+
+	p := snmputil.Params{
+		IP:          ip,
+		Port:        port,
+		Community:   []byte("public"),
+		Timeout:     3 * time.Second,
+		UseBGPV2MIB: true,
+		Vendor:      "cisco",
+	}
+
+	edges, _, err := Walk(context.Background(), p, "rtr-iosxe", nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 edge from IOS-XE vendor walker, got %d: %+v", len(edges), edges)
+	}
+	// TODO(#1): assert the expected DstDevice — 10.0.0.2 for Option A,
+	// or the bird router-id for Option B.
+	if got := edges[0].DstDevice; got != "10.0.0.2" {
+		t.Errorf("DstDevice = %q, want 10.0.0.2 (from IOS-XE cbgpPeer2 index)", got)
+	}
+	// TODO(#1): assert remote-AS — 65001 for Option A iBGP, 65002 for Option B eBGP.
+	if got := edges[0].Metadata[metaKeyRemoteAs]; got != "65001" {
+		t.Errorf("RemoteAs metadata = %q, want 65001 (from IOS-XE col 11)", got)
+	}
+}

--- a/lab/cisco-iosxe-bgp/README.md
+++ b/lab/cisco-iosxe-bgp/README.md
@@ -61,9 +61,12 @@ routers over the VPN. This produces the same shape of capture as
    Typical reservation: 4–8 hours, free, queue-based.
 2. Wait for the `devnetsandbox@cisco.com` email with VPN host, group,
    username, password.
-3. Connect:
+3. Connect (the `<group>` value comes from the same DevNet reservation email
+   as the username; it's typically `VPN` or similar):
    ```sh
-   sudo openconnect --protocol=anyconnect --user=<sandbox-user> <vpn-host>
+   sudo openconnect --protocol=anyconnect \
+       --authgroup=<group> \
+       --user=<sandbox-user> <vpn-host>
    ```
 4. SSH to the CML controller (URL in the email). In the CML UI, create a
    new lab with **two CSR1000v** (or **c8000v**) nodes connected by a
@@ -91,16 +94,23 @@ VPN's reverse path).
 1. Reserve at https://devnetsandbox.cisco.com/RM/Topology (search "IOS XE").
 2. Connect via `openconnect` as above. Note the management IP from the
    email (example: `10.10.20.48`).
-3. Verify your Ubuntu host's VPN-side IP: `ip addr show | grep tun0`.
-   This is the IP the CSR will see you on.
-4. Start a local BGP speaker (bird2 example):
+3. Verify your Ubuntu host's VPN-side IP:
    ```sh
-   cat > /etc/bird/bird.conf <<'EOF'
+   ip -4 -o addr show tun0 | awk '{print $4}' | cut -d/ -f1
+   ```
+   This is the IP the CSR will see you on.
+4. Start a local BGP speaker (bird2 example). `multihop;` is required —
+   the CSR sets `ebgp-multihop 4` and bird's default TTL of 1 will not
+   reach the CSR across the VPN, so without it the session never reaches
+   `Established`:
+   ```sh
+   sudo tee /etc/bird/bird.conf >/dev/null <<'EOF'
    router id <your-vpn-ip>;
    protocol device { }
    protocol bgp csr_peer {
      local as 65002;
      neighbor 10.10.20.48 as 65001;
+     multihop;
      ipv4 { import all; export none; };
    }
    EOF
@@ -156,6 +166,47 @@ The sandbox is reset between reservations, so no per-router cleanup
 is required.
 
 Disconnect VPN: `sudo killall openconnect`.
+
+## Troubleshooting
+
+### `openconnect` exits with "authentication failure" or hangs at a group prompt
+
+The DevNet sandbox VPN requires the `--authgroup` value from the reservation
+email. The example in step 3 of Option A shows the canonical form. If the
+group isn't in your email, log into the DevNet portal and re-open the
+reservation details.
+
+### `snmpwalk` returns `Timeout` for every OID
+
+VPN reachability is broken or the SNMP community on the router differs from
+the script default (`public`).
+
+- `ip addr show tun0` — is the VPN interface up?
+- `ping <router-ip>` — does ICMP reach the router?
+- On the CSR/CML console, run `show snmp community` and confirm `public RO`
+  is configured. Sandbox routers usually do NOT pre-configure SNMP; you
+  must paste the relevant `snmp-server community public RO` line from the
+  `configs/iosxe-*.cfg` block before walking.
+
+### DevNet reservation expired mid-capture
+
+Reservation windows are 4-8h, queue-based. If `snmpwalk` starts returning
+`Timeout` partway through a run, check the DevNet portal — your reservation
+may have ended. Re-reserve and resume; partial captures already on disk are
+still useful.
+
+### BGP session never reaches `Established`
+
+- Option A (CML two-router): `show ip route 10.0.0.0/30` on both r1 and r2.
+  Both should see the connected `/30`. If the interface is still in switching
+  mode (CML default for some images), `no switchport` may have been
+  rejected — re-paste the interface stanza and check `show interface Gi2`.
+- Option B (CSR + bird): on the CSR, `show ip bgp neighbors <peer-ip>` —
+  is the session `Active`/`OpenSent` rather than `Established`? Likeliest
+  cause is the `multihop;` directive missing from bird's config (eBGP TTL=1
+  cannot traverse the DevNet VPN's multi-hop path; CSR sets
+  `ebgp-multihop 4` and bird must match). On the Ubuntu host:
+  `sudo birdc show protocols csr_peer` and check the state.
 
 ## Converting captures to fixtures
 

--- a/lab/cisco-iosxe-bgp/README.md
+++ b/lab/cisco-iosxe-bgp/README.md
@@ -1,0 +1,171 @@
+# Lab — cisco-iosxe-bgp
+
+Capture real-device SNMP fixtures for the **`vendor_cisco`** walker
+(`internal/discovery/bgp/bgp_vendor.go`) against **Cisco IOS-XE** — the
+canonical Cisco production OS named in
+[issue #1](https://github.com/colinedwardwood/network-topology-exporter/issues/1)'s
+acceptance criteria.
+
+Unlike the sibling labs in this tree, this is **not a containerlab
+topology**. Cisco IOS-XE images are not freely redistributable; the only
+no-cost path is **Cisco DevNet Sandbox**, which provides hosted routers
+reachable via VPN. The lab here is the runbook + capture script for
+that flow.
+
+## Why a separate Cisco lab if `cisco-iol-bgp` already produced captures?
+
+The `cisco-iol-bgp` lab uses the IOL (IOS-on-Linux) image — historically
+the SDK build of IOS, not the IOS-XE codebase that ships in production
+ASR1000 / CSR1000v / Cat8000v / Cat9000 platforms. Issue #31 was closed
+against IOL captures, but issue #1's acceptance bar specifically names
+"Cisco IOS-XE" because column numbers, index encoding, and
+`cbgpPeer2Table` row composition can diverge between IOL and IOS-XE
+shipping releases. This lab provides the IOS-XE evidence that
+issue #1 requires.
+
+If captures here match the IOL captures byte-for-byte at the column
+level, that is itself a strong cross-confirmation worth noting in the
+closing PR.
+
+## Status
+
+**Scaffold only.** No captures committed yet. Pending: a DevNet reservation
+window and BGP peer establishment.
+
+## Prerequisites
+
+| Tool | How |
+|---|---|
+| Ubuntu host (or Linux VM) | Sandbox VPN reaches the router from this host |
+| Cisco DevNet account | Free signup at https://developer.cisco.com/ |
+| `openconnect` | `apt-get install -y openconnect` — open-source AnyConnect-compatible VPN client; Cisco-acknowledged alternative when AnyConnect download is gated |
+| `ssh` client | Built-in |
+| `snmpwalk` (net-snmp) | `apt-get install -y snmp snmp-mibs-downloader` |
+| (Option B only) `bird2` or `frr` | `apt-get install -y bird2` — local BGP speaker for the external-peer path |
+
+## Reservation path
+
+Two viable DevNet sandboxes; pick based on whether you need multiple
+routers (BGP peers) or a single router (BGP via external speaker).
+
+### Option A — CML Sandbox (recommended, multi-router)
+
+[Cisco Modeling Labs (CML) Sandbox](https://devnetsandbox.cisco.com/RM/Topology)
+gives you a reservation window with full CML access. You build a 2-CSR
+topology in CML, configure iBGP between them, then `snmpwalk` both
+routers over the VPN. This produces the same shape of capture as
+`lab/arista-ceos-bgp/` — two nodes, one iBGP session, deterministic
+`cbgpPeer2Table` content.
+
+1. Reserve at https://devnetsandbox.cisco.com/RM/Topology (search "CML").
+   Typical reservation: 4–8 hours, free, queue-based.
+2. Wait for the `devnetsandbox@cisco.com` email with VPN host, group,
+   username, password.
+3. Connect:
+   ```sh
+   sudo openconnect --protocol=anyconnect --user=<sandbox-user> <vpn-host>
+   ```
+4. SSH to the CML controller (URL in the email). In the CML UI, create a
+   new lab with **two CSR1000v** (or **c8000v**) nodes connected by a
+   single Ethernet link (Gi2 ↔ Gi2). Leave management on Gi1 (CML's
+   default). Start the lab. TODO: capture the CML topology export as
+   `configs/cml-topology.yaml` during the first reservation so subsequent
+   runs can re-import.
+5. SSH into each router's console (CML exposes a terminal), paste the
+   contents of `configs/iosxe-r1.cfg` and `configs/iosxe-r2.cfg`.
+6. Wait ~60s for BGP to reach `Established`. Verify:
+   ```sh
+   show ip bgp summary
+   show snmp community
+   ```
+7. Note each router's management IP (CML assigns these per session).
+8. Run `./capture.sh <r1-mgmt-ip> <r2-mgmt-ip>` from the Ubuntu host.
+
+### Option B — Single-CSR Sandbox + external BGP speaker
+
+Use the "IOS XE on CSR Recommended Code" or "IOS XE on Cat 8K"
+reservation sandbox (single-router). Peer the sandbox CSR to a BGP
+speaker running on your Ubuntu host (visible to the sandbox via the
+VPN's reverse path).
+
+1. Reserve at https://devnetsandbox.cisco.com/RM/Topology (search "IOS XE").
+2. Connect via `openconnect` as above. Note the management IP from the
+   email (example: `10.10.20.48`).
+3. Verify your Ubuntu host's VPN-side IP: `ip addr show | grep tun0`.
+   This is the IP the CSR will see you on.
+4. Start a local BGP speaker (bird2 example):
+   ```sh
+   cat > /etc/bird/bird.conf <<'EOF'
+   router id <your-vpn-ip>;
+   protocol device { }
+   protocol bgp csr_peer {
+     local as 65002;
+     neighbor 10.10.20.48 as 65001;
+     ipv4 { import all; export none; };
+   }
+   EOF
+   sudo systemctl restart bird
+   ```
+5. SSH to the sandbox CSR (`ssh developer@10.10.20.48`, password
+   `C1sco12345`), paste the contents of `configs/iosxe-single.cfg`
+   with `<peer-ip>` replaced by your VPN-side IP.
+6. Wait for `Established`. Verify on CSR:
+   ```
+   show ip bgp summary
+   ```
+7. Run `./capture.sh 10.10.20.48` from the Ubuntu host.
+
+**Trade-off**: Option B yields one `cbgpPeer2Table` row (the BGP session
+from CSR to your bird speaker). That's enough to validate column
+numbers, index encoding, and state decoding — which is what the walker
+tests need. Option A's two-router shape is closer to what production
+deployments look like.
+
+## OIDs probed
+
+Same four-OID set as the sibling labs, for direct cross-comparison:
+
+| Root | Walker | Expected on IOS-XE |
+|---|---|---|
+| `1.3.6.1.2.1.1` | (sys group) | populated — `sysObjectID` should resolve to a Cisco enterprise OID (`1.3.6.1.4.1.9.*`) |
+| `1.3.6.1.2.1.15.3` | `rfc4273` (fallback) | populated for IPv4 peers — RFC 4273 baseline |
+| `1.3.6.1.4.1.9.9.187.1.2.5` | **`vendor_cisco`** | the canonical capture for this lab — populated whenever a BGP session exists |
+| `1.3.6.1.3.5.1.1.2` | (removed) | expected empty — IOS-XE does not implement the IETF draft form at this OID. Captured for negative-result evidence. |
+
+## Capture
+
+```sh
+# Option A (two routers, both walked)
+./capture.sh <r1-mgmt-ip> <r2-mgmt-ip>
+
+# Option B (single router)
+./capture.sh <csr-mgmt-ip>
+```
+
+Produces `captures/<host-with-underscores>__<oid-with-underscores>.txt`,
+one file per (host, OID-root). Numeric OID form (`snmpwalk -On -Oe`) is
+mandatory — the fixture conversion step pastes these into
+`[]gosnmp.SnmpPDU` literals where OID *names* would be ambiguous.
+
+## Destroy
+
+CML reservation: stop the lab in the CML UI, end the reservation.
+
+Single-CSR reservation: end the reservation from the DevNet portal.
+The sandbox is reset between reservations, so no per-router cleanup
+is required.
+
+Disconnect VPN: `sudo killall openconnect`.
+
+## Converting captures to fixtures
+
+Same flow as `lab/cisco-iol-bgp/` — see that lab's README for the
+text-output → `[]gosnmp.SnmpPDU` literal conversion pattern. Real-device
+fixtures land at `internal/snmptest/testdata/cisco_iosxe_real.*` and
+the synthetic `cbgpPeer2Table` cases in `bgp_vendor_test.go` get
+real-device siblings.
+
+If captures here disagree with `lab/cisco-iol-bgp/` on column numbers
+or index encoding, **IOS-XE wins** — the walker code must match
+production IOS-XE behavior, not IOL behavior. File a PR fixing
+`bgp_vendor.go` columns and reference both capture sources.

--- a/lab/cisco-iosxe-bgp/capture.sh
+++ b/lab/cisco-iosxe-bgp/capture.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# capture.sh — drive snmpwalk against Cisco IOS-XE router(s) reachable
+# over the DevNet Sandbox VPN, save raw output for each (host × OID-root)
+# pair under ./captures/.
+#
+# Inputs:
+#   - One or more router IPs as positional arguments
+#   - Active openconnect VPN session to the DevNet Sandbox
+#   - SNMP community matching what's configured on the router (default: public)
+#   - snmpwalk binary (net-snmp)
+#
+# Outputs:
+#   captures/<host-with-underscores>__<oid-with-dots>.txt
+#
+# Each file holds raw `snmpwalk -On -Oe` output. Numeric OID form is
+# essential: fixture conversion pastes these into []gosnmp.SnmpPDU
+# literals where OID names would be ambiguous.
+#
+# Unlike the containerlab-based sibling labs (arista-ceos-bgp,
+# cisco-iol-bgp), there is no `containerlab inspect` here — the hosts
+# come from the DevNet reservation email and are passed on the
+# command line.
+#
+# Exit code is always 0 even if individual walks fail — partial
+# captures are still useful (a walk that returns "No Such Object"
+# proves the device doesn't implement that MIB).
+#
+# Usage:
+#   ./capture.sh <ip1> [ip2 ...]
+#   SNMP_COMMUNITY=mycomm ./capture.sh 10.10.20.48
+#
+set -o pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <router-ip> [router-ip ...]" >&2
+  echo "" >&2
+  echo "example (Option A, two-router CML):" >&2
+  echo "  $0 10.10.20.48 10.10.20.49" >&2
+  echo "" >&2
+  echo "example (Option B, single-CSR + external speaker):" >&2
+  echo "  $0 10.10.20.48" >&2
+  exit 2
+fi
+
+COMMUNITY="${SNMP_COMMUNITY:-public}"
+OUTDIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "$0")")/captures"
+
+# OID roots probed on every router. Comments explain which walker each
+# one would feed in internal/discovery/bgp/.
+declare -a OIDS=(
+  # sys group — sysDescr + sysObjectID. Confirms SNMP reachability and
+  # lets us verify the Cisco enterprise-prefix vendor detection works
+  # (sysObjectID should start with 1.3.6.1.4.1.9.*).
+  "1.3.6.1.2.1.1"
+
+  # RFC 4273 bgpPeerTable — IPv4-only baseline. Walker: rfc4273 (fallback).
+  # Populated whenever any IPv4 BGP session exists.
+  "1.3.6.1.2.1.15.3"
+
+  # CISCO-BGP4-MIB cbgpPeer2Table — the canonical Cisco vendor table.
+  # Walker: vendor_cisco. THIS is the high-value capture for issue #1.
+  "1.3.6.1.4.1.9.9.187.1.2.5"
+
+  # IETF draft bgp4V2PeerTable. Captured for negative-result evidence:
+  # IOS-XE does not implement this OID. See issue #31 lineage.
+  "1.3.6.1.3.5.1.1.2"
+)
+
+mkdir -p "$OUTDIR"
+
+# Sanity-check VPN reachability before walking. If the first router
+# is unreachable, the operator forgot to start openconnect or the
+# reservation expired.
+first_host="$1"
+if ! snmpwalk -v2c -c "${COMMUNITY}" -t 3 -r 0 "${first_host}" 1.3.6.1.2.1.1.1.0 >/dev/null 2>&1; then
+  echo "ERROR: cannot reach ${first_host} via snmpwalk." >&2
+  echo "  - Is openconnect running?  (ip addr show tun0)" >&2
+  echo "  - Is the DevNet reservation still active?" >&2
+  echo "  - Did you apply 'snmp-server community ${COMMUNITY} RO' on the router?" >&2
+  exit 1
+fi
+
+for host in "$@"; do
+  safe_host=$(echo "$host" | tr '.:' '__')
+  echo "--- host ${host} ---"
+  for oid in "${OIDS[@]}"; do
+    safe_oid=$(echo "$oid" | tr '.' '_')
+    out="${OUTDIR}/${safe_host}__${safe_oid}.txt"
+    {
+      echo "# captured at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      echo "# host:   ${host}"
+      echo "# oid:    ${oid}"
+      echo "# source: DevNet Sandbox IOS-XE (see ../README.md)"
+      echo "# walker fed: see comments in capture.sh"
+      echo
+      snmpwalk -v2c -c "${COMMUNITY}" -On -Oe "${host}" "${oid}" 2>&1
+    } > "${out}"
+    if grep -q "No Such Object\|No Such Instance\|Timeout\|No Response" "${out}"; then
+      echo "  ${oid} → empty/error (see ${out#$(dirname "$0")/})"
+    else
+      lines=$(wc -l < "${out}" | tr -d ' ')
+      echo "  ${oid} → ${lines} lines captured (${out#$(dirname "$0")/})"
+    fi
+  done
+done
+
+echo
+echo "captures complete in ${OUTDIR}/"
+echo "next: review each file by hand; promising captures get translated into"
+echo "[]gosnmp.SnmpPDU literals under internal/snmptest/testdata/ — see README.md"

--- a/lab/cisco-iosxe-bgp/configs/iosxe-r1.cfg
+++ b/lab/cisco-iosxe-bgp/configs/iosxe-r1.cfg
@@ -1,0 +1,40 @@
+! Option A — CML topology, router r1.
+! Paste at the IOS-XE console after the CML lab has booted both nodes.
+! Assumes r1 ←→ r2 link is GigabitEthernet2 on both sides; adjust if
+! the CML topology assigns a different interface.
+!
+! Goals:
+!   - iBGP session r1 (AS 65001) ↔ r2 (AS 65001)
+!   - SNMP v2c community "public" RO, reachable via the CML mgmt
+!     network (GigabitEthernet1 by CML convention)
+!
+configure terminal
+!
+hostname r1
+!
+interface GigabitEthernet2
+ no shutdown
+ ip address 10.0.0.1 255.255.255.252
+ no ip redirects
+ no ip proxy-arp
+!
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+router bgp 65001
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ neighbor 10.0.0.2 remote-as 65001
+ neighbor 10.0.0.2 description r2
+ address-family ipv4 unicast
+  network 1.1.1.1 mask 255.255.255.255
+  neighbor 10.0.0.2 activate
+ exit-address-family
+!
+! SNMP — community "public" RO is the lab default. The cbgpPeer2Table
+! walker (1.3.6.1.4.1.9.9.187.1.2.5) is read via this community.
+snmp-server community public RO
+snmp-server enable traps bgp
+!
+end
+write memory

--- a/lab/cisco-iosxe-bgp/configs/iosxe-r2.cfg
+++ b/lab/cisco-iosxe-bgp/configs/iosxe-r2.cfg
@@ -1,0 +1,31 @@
+! Option A — CML topology, router r2.
+! Mirror of iosxe-r1.cfg with swapped IPs and router-id.
+!
+configure terminal
+!
+hostname r2
+!
+interface GigabitEthernet2
+ no shutdown
+ ip address 10.0.0.2 255.255.255.252
+ no ip redirects
+ no ip proxy-arp
+!
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+router bgp 65001
+ bgp router-id 2.2.2.2
+ bgp log-neighbor-changes
+ neighbor 10.0.0.1 remote-as 65001
+ neighbor 10.0.0.1 description r1
+ address-family ipv4 unicast
+  network 2.2.2.2 mask 255.255.255.255
+  neighbor 10.0.0.1 activate
+ exit-address-family
+!
+snmp-server community public RO
+snmp-server enable traps bgp
+!
+end
+write memory

--- a/lab/cisco-iosxe-bgp/configs/iosxe-single.cfg
+++ b/lab/cisco-iosxe-bgp/configs/iosxe-single.cfg
@@ -14,6 +14,7 @@ configure terminal
 router bgp 65001
  bgp router-id 1.1.1.1
  bgp log-neighbor-changes
+! REPLACE <peer-ip> ON THE NEXT FOUR LINES OR THIS PASTE WILL FAIL
  neighbor <peer-ip> remote-as 65002
  neighbor <peer-ip> description ubuntu-bird-external
  neighbor <peer-ip> ebgp-multihop 4

--- a/lab/cisco-iosxe-bgp/configs/iosxe-single.cfg
+++ b/lab/cisco-iosxe-bgp/configs/iosxe-single.cfg
@@ -1,0 +1,30 @@
+! Option B — Single-CSR DevNet sandbox + external BGP speaker.
+! Paste at the sandbox CSR's IOS-XE console after replacing
+! <peer-ip> with your Ubuntu host's VPN-side IP (tun0).
+!
+! Goals:
+!   - eBGP session CSR (AS 65001) ↔ Ubuntu/bird (AS 65002)
+!   - SNMP v2c community "public" RO
+!
+! IMPORTANT: replace <peer-ip> with the actual VPN-side IP of your
+! Ubuntu host. Get it with: ip -4 addr show tun0
+!
+configure terminal
+!
+router bgp 65001
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ neighbor <peer-ip> remote-as 65002
+ neighbor <peer-ip> description ubuntu-bird-external
+ neighbor <peer-ip> ebgp-multihop 4
+ address-family ipv4 unicast
+  neighbor <peer-ip> activate
+ exit-address-family
+!
+! SNMP — sandbox routers usually do NOT have SNMP pre-configured;
+! the community below is added on demand for the capture run.
+snmp-server community public RO
+snmp-server enable traps bgp
+!
+end
+write memory


### PR DESCRIPTION
## Summary
- Adds the IOS-XE half of #1's acceptance criteria: a runbook + capture script for producing real-device BGP4-V2 fixtures from Cisco DevNet Sandbox routers.
- Two reservation paths documented: Option A (CML, two-router iBGP) and Option B (single CSR + local bird as external eBGP speaker).
- Skipped Go test (`TestWalkVendorCiscoFromIOSXECapture`) is the post-capture landing pad; runs once `buildCiscoCbgpPeer2IOSXERealPDUs` is populated from real captures.
- Closes #49.

## Why this is also a #49 fix
- The README ships with **manual CML UI instructions** in step 4 rather than referencing a `configs/cml-topology.yaml` that does not exist (the bug filed as #49). A TODO is left to capture the yaml during the first DevNet reservation so subsequent operators can re-import.
- Avoiding shipping an unvalidated CML topology spec: nobody on the project has authored one against a live CML session.

## What's in the scaffold
- `lab/cisco-iosxe-bgp/README.md` — full runbook for both reservation paths, OID set, fixture-conversion pointer.
- `lab/cisco-iosxe-bgp/capture.sh` — drives `snmpwalk` against router IPs from positional args. Uses `-On -Oe` (no `-Ovq=0` — that's the bug fixed across sibling labs in #50, this file inherits the corrected form).
- `lab/cisco-iosxe-bgp/configs/iosxe-r1.cfg` / `iosxe-r2.cfg` — paste-blocks for Option A (CML two-router iBGP, AS 65001).
- `lab/cisco-iosxe-bgp/configs/iosxe-single.cfg` — paste-block for Option B (eBGP to local bird, with `<peer-ip>` placeholder).
- `internal/discovery/bgp/bgp_v2_iosxe_test.go` — `t.Skip`-gated test that, once captures land, validates the `vendor_cisco` walker against the real-device PDU shape.

## Solution triple-pass
- **Correctness**: Walker IDs (column 3 = state, column 11 = remoteAs, peer IP in index) match the IOL sibling helper (`bgp_v2_test.go:365`); test mirrors `TestWalkVendorCisco`'s shape. `go vet` clean. Test skips cleanly with the documented post-capture workflow.
- **Efficiency**: Scaffold-only, no production code touched; CI cost is the t.Skip (~ms).
- **Regression risk**: No code under `internal/` changes — the new test file is additive and skipped by default. `bash -n capture.sh` clean. shellcheck flags two SC2295 info-level findings on the path-strip lines (100, 103) that are identical to `lab/cisco-iol-bgp/capture.sh:88,91` and `lab/arista-ceos-bgp/capture.sh:88,91` — kept for sibling-style consistency, follow-up if we choose to clean up across all three labs.

## Test plan
- [x] `go vet ./internal/discovery/bgp/...` clean.
- [x] `go test ./internal/discovery/bgp/ -run TestWalkVendorCiscoFromIOSXECapture -v` runs and skips with the expected message.
- [x] `bash -n lab/cisco-iosxe-bgp/capture.sh` clean.
- [ ] Manual DevNet reservation (Option A or B) → produces non-empty `cbgpPeer2Table` captures under `lab/cisco-iosxe-bgp/captures/`. Deferred until a sandbox window is available; this PR is the runbook to follow.