### PR TITLE
chore(gitignore): ignore TODOs.txt scratchpad at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ vendor/
 .claude/worktrees/
 /topology-exporter
 clab-nte-e2e/
+
+# Personal scratchpad — not a project artifact
+TODOs.txt


### PR DESCRIPTION
## Summary
- Adds `TODOs.txt` to `.gitignore`. The file is a personal task list at the repo root that should not be tracked — the repo uses GitHub issues + `plans/` as its system of record.
- No code or behaviour change.

## Test plan
- [x] `git check-ignore -v TODOs.txt` matches the new pattern.
- [x] `git status` no longer lists `TODOs.txt`.