### PR TITLE
chore: signal pre-1.0 stability conventions despite v1.x tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## Unreleased — planned as v1.4.0-rc.1
+
+Upcoming releases adopt `-rc.N` suffixes to signal that the public
+surface is intentionally not frozen — see the pre-release notice in
+the README. The lab-fixture-capture work previously slotted for
+v1.3.1 lands under this milestone instead, renamed to
+[v1.4.0-rc.1 — Lab Fixture Capture](https://github.com/colinedwardwood/network-topology-exporter/milestones).
 
 ### Features
 
@@ -31,12 +37,13 @@
 - README now lists both test environments (`deploy/test-harness/` and
   `deploy/long-running-test/`).
 - **Test-harness onboarding now uses the published GHCR image.**
-  `deploy/test-harness/docker-compose.yml` references
-  `ghcr.io/colinedwardwood/network-topology-exporter:latest`, and the
-  "00. Getting Started" dashboard plus `deploy/test-harness/README.md`
-  now instruct testers to `docker compose pull` instead of running a
-  local `docker build`. Cuts cold-start time from minutes (Go toolchain
-  + multi-arch build) to seconds (image pull).
+  `deploy/test-harness/docker-compose.yml` pins
+  `ghcr.io/colinedwardwood/network-topology-exporter:1.3.1-rc1` so every
+  tester runs the same build, and the "00. Getting Started" dashboard
+  plus `deploy/test-harness/README.md` now instruct testers to
+  `docker compose pull` instead of running a local `docker build`.
+  Cuts cold-start time from minutes (Go toolchain + multi-arch build)
+  to seconds (image pull).
 - **Removed OTLP/Tempo references from tester onboarding.** The default
   harness ships metrics + logs only; the trace-related access-policy
   scope, Tempo username, and OTLP push endpoint have been dropped from
@@ -57,7 +64,6 @@ First release candidate for the 1.3.1 milestone. Includes the new tester-onboard
 - **D52 (Static Analysis)** — Resolved 16 `SA5011` possible-nil-dereference warnings across the test suite by ensuring test termination after fatal failures.
 - **D53 (E2E Stability)** — Fixed `permission denied` errors in E2E tests by explicitly configuring local snapshot paths for test binaries.
 - **D54 (Scope Guard)** — LLDP and CDP modules now support catch-all CIDRs (`0.0.0.0/0`) in the `cidr_allow_list`, allowing discovery of non-IP neighbors (like MAC-only containerlab nodes) when explicitly permitted by the operator.
-
 ## v1.3.0 — 2026-05-17
 
 Post-audit hardening. 25 numbered changes (D22–D46) covering 28 closed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # network-topology-exporter
 
+> [!WARNING]
+> **This is a test release, not a stable v1.x.** Despite the existing
+> `v1.0.0`–`v1.3.0` tags, the project follows pre-1.0 stability
+> conventions: the public surface (config schema, metric names, CLI
+> flags, on-disk snapshot format, federation API) can break between
+> minor releases. Upcoming releases will use `-rc.N` suffixes —
+> next: `v1.4.0-rc.1`. Pin exact versions in anything you care about,
+> and please file issues for anything you can break.
+
 A standalone, Apache 2.0 Go exporter that discovers network topology over SNMP, LLDP, CDP, BGP, OSPF, FDB, IS-IS, and MPLS-TE, and emits four signals:
 
 - **Prometheus metrics** for device inventory and topology edges, scraped via `/metrics`.
@@ -15,7 +24,7 @@ The Prometheus / Grafana stack already covers storage, query, alerting, and visu
 
 ## Status
 
-**Release candidate.** SNMP / LLDP / CDP / BGP / OSPF / FDB / IS-IS / MPLS-TE discovery, graph reconciliation, credential management, snapshot persistence, multi-instance federation, and optional OTLP push are all implemented and covered by unit, integration, and end-to-end tests.
+**Functionally complete, public surface intentionally unstable.** SNMP / LLDP / CDP / BGP / OSPF / FDB / IS-IS / MPLS-TE discovery, graph reconciliation, credential management, snapshot persistence, multi-instance federation, and optional OTLP push are all implemented and covered by unit, integration, and end-to-end tests. The project ships against test deployments and welcomes adversarial feedback — see the pre-release notice at the top of this README.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- Add a `[!WARNING]` banner at the top of README naming the surfaces (config schema, metric names, CLI flags, snapshot format, federation API) that can still break between minor releases.
- Reframe `## Status` from "Release candidate" → "Functionally complete, public surface intentionally unstable" with a pointer back to the banner.
- CHANGELOG `Unreleased` header retargeted from `planned as v1.3.1` → `planned as v1.4.0-rc.1`. Adopting `-rc.N` suffixes from this release forward.
- Renamed GitHub milestone `v1.3.1 — Lab Fixture Capture` → `v1.4.0-rc.1 — Lab Fixture Capture` (preserves attached issue #1 and tracker history).

## Why not just bump to v0.9?
Tag immutability + Go module proxy semver ordering. `v1.0.0`–`v1.3.0` are public; `go get @v1.3.0` will always resolve to the v1.3.0 commit regardless of what we tag going forward, and a `v0.9` tag would silently sort *below* anything anyone has pinned to. A README banner + `-rc.N` tag convention achieves the same "this is a test release" signal without breaking semver.

## What's NOT in this PR
- Existing `v1.0.0`–`v1.3.0` GitHub Releases are unchanged — operators who pinned to v1.3.0 keep what they had.
- No code changes. No deprecations.

## Test plan
- [x] README banner renders correctly (GitHub flavored `> [!WARNING]` callout syntax).
- [x] CHANGELOG link still resolves (points at `/milestones` listing, not a numbered URL).
- [x] Milestone renamed in-place — same number, new title; issue #1 attachment preserved.

## Follow-ups (not in this PR; surface if you want them)
- Mark existing `v1.0.0`–`v1.3.0` releases as "pre-release" in the GitHub Releases UI (cosmetic-only, doesn't change tag resolution).
- Add a short "Versioning" section in the README explaining the `-rc.N` convention in more depth.
- Decide if `v1.3.1` should be skipped entirely or fall back into a hotfix slot if a real patch ships before the next minor.