### PR TITLE
fix(scripts): bash-5 portability across colleague-capture lib

### DIFF
--- a/scripts/colleague-capture-lib/lib_banner.sh
+++ b/scripts/colleague-capture-lib/lib_banner.sh
@@ -2,11 +2,11 @@
 # Render the verdict-aware end-of-run banner.
 
 _color_enabled() { [ -t 1 ]; }
-_g() { _color_enabled && printf '\033[32m' || true; }
-_y() { _color_enabled && printf '\033[33m' || true; }
-_r() { _color_enabled && printf '\033[31m' || true; }
-_b() { _color_enabled && printf '\033[1m' || true; }
-_n() { _color_enabled && printf '\033[0m' || true; }
+_g() { if _color_enabled; then printf '\033[32m'; fi; }
+_y() { if _color_enabled; then printf '\033[33m'; fi; }
+_r() { if _color_enabled; then printf '\033[31m'; fi; }
+_b() { if _color_enabled; then printf '\033[1m'; fi; }
+_n() { if _color_enabled; then printf '\033[0m'; fi; }
 
 # print_banner VERDICT TARBALL SHA256 RECIPIENT VENDOR_DISPLAY SYSDESCR FIX_COMMAND
 print_banner() {

--- a/scripts/colleague-capture-lib/lib_diagnostics.sh
+++ b/scripts/colleague-capture-lib/lib_diagnostics.sh
@@ -57,7 +57,7 @@ emit_diagnostics() {
     echo '  ],'
 
     echo '  "aggregate": {'
-    printf '    "hosts_total": %s,\n' "${#HOSTS[@]:-0}"
+    printf '    "hosts_total": %s,\n' "$([ -n "${HOSTS+x}" ] && echo "${#HOSTS[@]}" || echo 0)"
     printf '    "hosts_preflight_ok": %s,\n' "${HOSTS_PREFLIGHT_OK:-0}"
     printf '    "hosts_with_vendor_table_rows": %s,\n' "${HOSTS_WITH_VENDOR_ROWS:-0}"
     printf '    "any_walk_timed_out": %s,\n' "$(json_bool "${ANY_WALK_TIMED_OUT:-0}")"

--- a/scripts/colleague-capture-lib/lib_vendor_match.sh
+++ b/scripts/colleague-capture-lib/lib_vendor_match.sh
@@ -13,8 +13,11 @@ vendor_match() {
     esac
   fi
 
-  # 2. SYSDESCR_KEYWORDS substring, case-insensitive
-  if [ "${#SYSDESCR_KEYWORDS[@]:-0}" -gt 0 ]; then
+  # 2. SYSDESCR_KEYWORDS substring, case-insensitive.
+  # The +x form is the portable way to check array existence under bash 5
+  # (which rejects ${#arr[@]:-0} as bad substitution) while still being
+  # safe under set -u. Bash 3.2 silently accepts ${#arr[@]:-0}; bash 5 does not.
+  if [ -n "${SYSDESCR_KEYWORDS+x}" ] && [ "${#SYSDESCR_KEYWORDS[@]}" -gt 0 ]; then
     local descr_lc
     descr_lc="$(echo "$sysdescr" | tr '[:upper:]' '[:lower:]')"
     local kw kw_lc


### PR DESCRIPTION
## Summary

Fixes two classes of bug in the colleague-capture toolkit that have been on `main` since the toolkit landed, but which only surfaced now because the `scripts lint + tests` CI workflow was never gating direct main pushes — the toolkit's commits landed straight through without that workflow ever running on `main`. The recent push of `1d25a77` was the first main push that triggered it, and it failed.

Surfaced when the parent PR #85 (`docs(bgp): record IOS-XE cross-confirmation, close #58`) inherited a red CI. Splitting the fixes out here so #85 can rebase onto clean `main` and merge cleanly.

## Bugs fixed

### 1. `lib_banner.sh` — shellcheck SC2015 (5 instances)

The five color helpers (`_g`, `_y`, `_r`, `_b`, `_n`) used the `A && B || C` pattern:

```bash
_g() { _color_enabled && printf '\033[32m' || true; }
```

Shellcheck flags this because if `printf` ever fails, the `|| true` fallback runs silently — `A && B || C` is not equivalent to `if A then B else C`. Refactored to plain `if/then/fi`:

```bash
_g() { if _color_enabled; then printf '\033[32m'; fi; }
```

Same observable behaviour, no fallback ambiguity, lint clean.

### 2. `lib_vendor_match.sh:17` and `lib_diagnostics.sh:60` — bash 5 "bad substitution"

Both used `${#arr[@]:-0}` to read array length with a default-to-zero fallback for unset arrays. This is **not valid bash** — you can't combine the `${#var}` (length) operator with `${var:-default}` in one substitution.

| Bash version | Behaviour |
|---|---|
| 3.2 (macOS system default) | silently accepts, returns the count |
| 5.x (Ubuntu CI, Homebrew bash on macOS) | rejects: `${#arr[@]:-0}: bad substitution` |

CI runs on Ubuntu bash 5; macOS-default bats runs bash 3.2 — so the bug was invisible to anyone who only ran `bats` locally and only surfaced when CI first executed.

The `lib_vendor_match.sh` path was the more concerning one: `vendor_match` runs the `SYSDESCR_KEYWORDS` branch when the sysObjectID prefix didn't already match, which is exactly the stock-net-snmp case (`1.3.6.1.4.1.8072.*`). The wrapper claims to disambiguate "is this device the wrong vendor or right vendor with a view restriction?" — but `vendor_match` was crashing on that path on any modern bash.

Replaced with the portable `+x` existence-check form:

```bash
if [ -n "${SYSDESCR_KEYWORDS+x}" ] && [ "${#SYSDESCR_KEYWORDS[@]}" -gt 0 ]; then
```

Safe under `set -u`, works on both bash 3.2 and bash 5.

## Verified locally

- `bats tests/scripts/test_lib_*.bats` — all 59 tests pass under `/opt/homebrew/bin/bash` (5.3.9), matching the CI Ubuntu bash version
- `shellcheck 0.11` — clean across the linted file set (`scripts/colleague-capture.sh`, `scripts/colleague-capture-lib/*.sh`, `lab/*/colleague-capture.sh`)

CI on this PR will verify against `shellcheck 0.9` (the CI-pinned version) and the Ubuntu bash 5 environment, which is what actually matters.

## Why this is a separate PR from #85

#85 is documentation + dead-code removal for the BGP IOS-XE cross-confirmation work — it has no relationship to the colleague-capture toolkit beyond inheriting the broken CI. Bundling unrelated lint/portability fixes into a docs PR would have made the substantive change harder to review and the history harder to read. After this lands, #85 will rebase onto clean main and merge.

## Test plan

- [x] All bats tests pass locally under bash 5
- [x] shellcheck 0.11 reports clean
- [ ] CI confirms shellcheck 0.9 also clean and bats under Ubuntu bash 5 passes