### PR TITLE
v1.6.0 operator-readiness docs (SECURITY.md, issue templates, matrices, stability)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,129 @@
+name: Bug report
+description: Report a defect in discovery, metrics emission, federation, or any other area.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more detail you provide, the faster we can triage it.
+
+        **Security issue?** Do not use this form — see [SECURITY.md](../../SECURITY.md) for private reporting.
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Exporter version
+      description: Run `./topology-exporter --version` or check the OCI image tag.
+      options:
+        - v1.4.0-rc.1
+        - v1.3.1-rc1
+        - v1.3.0
+        - v1.2.0
+        - v1.1.0
+        - v1.0.0
+        - Other (specify in description)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deploy-mode
+    attributes:
+      label: Deploy mode
+      description: How is the exporter running?
+      options:
+        - standalone (single instance, no federation)
+        - spoke (pushes to a hub)
+        - hub (receives spoke pushes, no local SNMP)
+        - uncoordinated (boundary metrics only)
+    validations:
+      required: true
+
+  - type: textarea
+    id: config-snippet
+    attributes:
+      label: Relevant config snippet
+      description: >
+        Paste the section of `config.yaml` that is relevant to the bug.
+        Redact all credential values — leave only the profile structure and key names.
+        Do not paste community strings, auth keys, or priv keys.
+      placeholder: |
+        modules:
+          bgp:
+            enabled: true
+            disable_v2_mib: false
+        credentials:
+          profiles:
+            - name: core-v3
+              type: snmp_v3
+              # (credential values omitted)
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: What actually happens — metric values, log output, error messages.
+      placeholder: |
+        network_topology_bgp_walker_outcome_total{walker="vendor_cisco",outcome="walker_drift"} 14
+
+        Log line (redact IPs if needed):
+        {"time":"...","level":"ERROR","msg":"bgp vendor walk","walker":"vendor_cisco","outcome":"walker_drift","device":"core-rtr-01"}
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log lines or metric values
+      description: >
+        Paste structured JSON log lines from stderr, or the output of
+        `curl -s http://localhost:9100/metrics | grep network_topology`.
+        Redact IP addresses to RFC 5737 documentation ranges (198.51.100.x) if needed.
+      render: text
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce the behaviour.
+      placeholder: |
+        1. Deploy with the config snippet above.
+        2. Wait for one full discovery cycle (check `network_topology_discovery_cycle_duration_seconds`).
+        3. Observe `network_topology_bgp_walker_outcome_total` — `walker_drift` count rises each cycle.
+    validations:
+      required: true
+
+  - type: textarea
+    id: vendor-context
+    attributes:
+      label: Vendor / platform context (if relevant)
+      description: >
+        If the bug is in a specific discovery module, include the vendor and platform.
+        See the supported-platforms matrix at `docs/supported-platforms.md`.
+      placeholder: |
+        Vendor: Cisco
+        Platform family: IOS-XE
+        OS version: 17.09.03a
+        Module affected: BGP (vendor_cisco walker)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I confirmed this is not a security vulnerability (which would go to SECURITY.md).
+          required: true
+        - label: Credential values have been removed from the config snippet and logs above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/colinedwardwood/network-topology-exporter/security/advisories/new
+    about: >
+      Do not file public issues for security vulnerabilities.
+      Use the private Security Advisory form instead — see SECURITY.md for the full policy.
+  - name: Ask a question / discuss usage
+    url: https://github.com/colinedwardwood/network-topology-exporter/discussions
+    about: General usage questions, configuration help, and deployment discussions.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,76 @@
+name: Feature request
+description: Propose a new capability or a change to existing behaviour.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check [ROADMAP.md](../../ROADMAP.md) — the feature may already be planned or
+        intentionally out of scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: >
+        What operational problem does this solve? Be specific about the gap:
+        what can you not do today, or what do you have to do that is more painful than it should be?
+      placeholder: |
+        When running 3 spoke instances across separate CIDRs, I can't tell from a single Grafana
+        dashboard which spoke is responsible for a given edge — the `discovery_proto` label doesn't
+        include the spoke ID, so I have to cross-reference the hub's per-spoke metrics manually.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe what you want the exporter to do. Be specific about the user-facing surface:
+        new config keys, new metric labels, new CLI flags, new API behaviour.
+      placeholder: |
+        Add an optional `spoke_id` label to `network_topology_edge_info` and `network_topology_device_info`
+        when the exporter is running in spoke mode (`federation.role: spoke`). The label would be empty
+        in standalone mode. This would let operators filter the hub's combined `/metrics` by originating
+        spoke without a separate lookup.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        What workarounds or alternative designs did you consider?
+        Why are they not sufficient?
+      placeholder: |
+        I considered adding a static label via `targets[].labels`, but that label would only appear on
+        device metrics (via `network_topology_device_info`), not on edge metrics. The edge label set
+        is fixed by the reconciler and doesn't pick up per-target enrichment.
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: >
+        How would you verify the feature is correctly implemented?
+        List the observable outcomes you would check.
+      placeholder: |
+        - `network_topology_edge_info{spoke_id="dc-a"}` is present in hub `/metrics` for all edges
+          originating from the dc-a spoke.
+        - `network_topology_edge_info{spoke_id=""}` is absent — the label is not emitted in standalone
+          mode at all (not emitted as empty string, to avoid cardinality inflation).
+        - A new `federation.spoke.label_edges_with_spoke_id: true` config key gates the behaviour
+          (default false, to preserve the current metric shape for existing deployments).
+        - `docs/metrics.md` is updated to describe the new label and its conditions.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I read ROADMAP.md and the feature is not already planned or out of scope.
+          required: true
+        - label: I searched existing issues and did not find a duplicate request.
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,18 @@ v1.3.1 lands under this milestone instead, renamed to
   the Getting Started dashboard to stop confusing first-time testers
   with a path the harness doesn't actually exercise.
 
+### Documentation
+
+- **SECURITY.md** (closes #76) — New top-level `SECURITY.md` with: supported-version matrix (current minor + previous minor best-effort), private reporting via GitHub Security Advisories, 72 h acknowledge / 7 day status-update SLA, and coordinated disclosure and credit policy. Cross-referenced from `README.md`, `docs/operator/security.md`, and `docs/operator/threat-model.md`. Note for maintainer: Private Vulnerability Reporting must be enabled in repo **Settings → Security → Code security and analysis** before the "Report a vulnerability" button is active.
+
+- **GitHub issue templates** (closes #77) — Three YAML-form templates in `.github/ISSUE_TEMPLATE/`: `bug.yml` (version dropdown, deploy-mode dropdown, config snippet, observed/expected, logs, repro steps), `feature.yml` (problem, proposed solution, alternatives, acceptance criteria), and `config.yml` (`blank_issues_enabled: false` + contact link to the Security Advisory form for vulnerability reports).
+
+- **Supported-platforms matrix** (closes #80) — New `docs/supported-platforms.md` recording per-vendor/OS real-device validation status for each discovery module. Covers Cisco IOS (IOL 17.12.1), Cisco IOS-XE (cross-confirmation via #58), Arista cEOS 4.36, Nokia SR Linux 24.7.2 (LLDP-via-SNMP not supported, #46 caveat documented), Nokia SR-OS (#57 pending), and Juniper (#56 pending). Experimental walkers are clearly marked. Cross-referenced from `README.md` and `docs/standards.md`.
+
+- **Vendor comparison matrix** (closes #81) — New `docs/comparisons/matrix.md` with rows per feature and columns for network-topology-exporter, LibreNMS, SuzieQ, Nautobot, OpenNMS, and SolarWinds NPM. Includes a note on what is needed alongside the exporter for a complete operational stack (NCM, IPSLA, alert correlation). The existing `docs/comparisons/librenms.md` deep bilateral read is linked from the matrix. Matrix linked from README "Why this exists" section.
+
+- **Stability matrix / GA criteria** (closes #66) — New `docs/operator/stability.md` enumerating the five frozen surfaces (config schema, metric names, CLI flags, snapshot format v3, federation API), the semver contract per surface, and measurable acceptance criteria for each structural v1.0 commitment (real-device walker validation, no silent failure modes, operator runbook sufficiency). Documents the deprecation policy (≥1 minor overlap, startup WARN, CHANGELOG note). Cross-referenced from `README.md`, `ROADMAP.md`, and `CONTRIBUTING.md`.
+
 ### Added
 
 - Vendor lab capture toolkit at `scripts/colleague-capture.sh` and `scripts/redact-snmp-capture.py` — lets a colleague with vendor hardware produce a self-diagnosing snmpwalk tarball in one command, then redact the result before fixture conversion. Lab dirs `lab/cisco-iosxe-bgp/` (#58), `lab/juniper-jnxbgp/` (#56), and `lab/nokia-srbgp/` (#57) all shipped with switch-side v2c + v3 prep and a thin shim into the shared wrapper.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ If a MIB you want to use isn't in this list, propose it in a PR description with
 
 Open an issue describing the change before sending a large PR. Branch from `main` with a `<type>/<short-description>` name (`feat/ospf-mib-discovery`). Commit messages follow conventional commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`). Run `make lint test` before pushing. Open the PR with a clear description of what changed and why, and reference the public specification source per the citation discipline above. CI must pass and one maintainer reviews before merge.
 
+Changes to config keys, metric names and label sets, CLI flags, the snapshot schema, or the federation API are **breaking changes** — see [`docs/operator/stability.md`](docs/operator/stability.md) for the full contract and deprecation policy. Breaking changes require a changelog entry labelled `(breaking)` and, at GA, a major-version bump.
+
 ## Code style
 
 `gofmt` / `goimports` and `golangci-lint` (config in `.golangci.yml`) are enforced in CI. Tests live next to the code they test as `internal/discovery/<module>/<module>_test.go`. Integration tests under `tests/integration/` use containerlab or simulated SNMP targets.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ By default there is no bespoke control-plane API and the exporter does not push 
 
 The Prometheus / Grafana stack already covers storage, query, alerting, and visualisation. What it doesn't cover is a network-discovery surface that produces topology data in formats that stack already understands. Think `snmp_exporter` for the topology problem: a Grafana panel renders the network graph by querying Mimir directly, with no bespoke graph endpoint sitting in front of the data.
 
+For a side-by-side feature comparison with LibreNMS, SuzieQ, Nautobot, OpenNMS, and SolarWinds NPM, see [`docs/comparisons/matrix.md`](docs/comparisons/matrix.md).
+
 ## Status
 
 **Functionally complete, public surface intentionally unstable.** SNMP / LLDP / CDP / BGP / OSPF / FDB / IS-IS / MPLS-TE discovery, graph reconciliation, credential management, snapshot persistence, multi-instance federation, and optional OTLP push are all implemented and covered by unit, integration, and end-to-end tests. The project ships against test deployments and welcomes adversarial feedback — see the pre-release notice at the top of this README.
@@ -291,6 +293,14 @@ Curated dashboards for both harnesses live in [`dashboards/test-harness/`](dashb
 ## Architecture
 
 See [`docs/architecture.md`](docs/architecture.md) for the module layout and discovery cycle. Clean-room development rules: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Stability and security
+
+Vendor platform support: [`docs/supported-platforms.md`](docs/supported-platforms.md).
+
+Stability promises and GA criteria: [`docs/operator/stability.md`](docs/operator/stability.md).
+
+To report a vulnerability privately: [`SECURITY.md`](SECURITY.md).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ without reading source:
 - **SLO guidance** (`docs/operator/slos.md`) — three SLIs an operator
   should track (cycle-duration headroom, snapshot-drop rate,
   federation-spoke-down rate); recommended burn-rate alerts.
-- **Stability matrix** — single-page authoritative restatement of the v1.0
+- **Stability matrix** (`docs/operator/stability.md`) — single-page authoritative restatement of the v1.0
   GA criteria above, with the actual frozen surfaces enumerated.
 - **Failure-mode coverage audit** — per walker, document what's hard-fail vs
   what surfaces via a `*_outcome_total` counter, and what the operator

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported versions
+
+The project has not yet reached a stable v1.0 GA (see the pre-release notice in [README.md](README.md)). Until the stability banner is removed, only the current minor release receives security fixes.
+
+| Version series | Supported |
+|---|---|
+| Current minor (latest `-rc.N` tag) | Yes — patches are applied and a new RC is cut |
+| Previous minor | Best-effort: critical-severity issues are backported if the fix is self-contained; lower severity is not |
+| Any version two or more minors behind | Not supported |
+
+When v1.0 GA ships, this table will be updated to: current minor = fully supported; previous minor = security fixes only.
+
+## Reporting a vulnerability
+
+**Do not file a public GitHub issue for unpatched vulnerabilities.** Public issues expose the vulnerability to all readers before a fix is available.
+
+Use the GitHub **Private Security Advisory** path:
+
+1. Open [https://github.com/colinedwardwood/network-topology-exporter/security/advisories/new](https://github.com/colinedwardwood/network-topology-exporter/security/advisories/new) — or navigate to the repository on GitHub, click **Security** → **Report a vulnerability**.
+2. Fill in the advisory form: affected versions, reproduction steps, and your assessment of severity (CVSSv3 vector is appreciated but not required).
+3. Submit. The advisory is private by default; only you and the maintainers can see it.
+
+> **Maintainer note:** Private Vulnerability Reporting must be enabled in the repository settings before the "Report a vulnerability" button appears. Navigate to **Settings → Security → Code security and analysis → Private vulnerability reporting** and enable it.
+
+Alternatively, send a PGP-encrypted report to **colin.wood@grafana.com** with the subject line `[SECURITY] network-topology-exporter — <brief description>`. A public key is available at the email address above; request it if needed.
+
+## Response SLA
+
+| Milestone | Target |
+|---|---|
+| Acknowledge receipt | ≤72 hours |
+| Status update (accepted / needs more info / not applicable) | ≤7 days of acknowledgement |
+| Patch + advisory published (for accepted reports) | Coordinated with reporter; target ≤30 days for critical, ≤90 days for moderate |
+
+If a deadline cannot be met, the maintainer will communicate the delay and reason before the window closes.
+
+## What is in scope
+
+The following surfaces are in scope for vulnerability reports:
+
+- **SNMP parsing.** The exporter processes device-controlled bytes in every discovery module. Crashes, panics, or memory corruption triggered by crafted SNMP responses are high priority.
+- **Federation hub/spoke channel.** Authentication bypass, payload injection, or denial-of-service on `/spoke/push`.
+- **`/metrics` authentication bypass.** When `listen.web_config_file` is configured with TLS or basic auth, bypassing that layer is in scope.
+- **Credential leakage.** Any path that exposes SNMP credential bytes outside the mitigations described in `docs/operator/security.md`.
+- **Snapshot tampering.** A crafted `snapshot.json` that causes the exporter to crash, execute arbitrary code, or emit false data on restart.
+- **Supply-chain integrity.** Tampering with release artefacts, CI workflows, or the cosign signing path.
+
+## What is out of scope
+
+- **General Prometheus exposition-format parsing quirks.** Downstream scrapers have their own security posture.
+- **Denial-of-service from the management network itself.** The exporter runs on a trusted management plane; SNMP-level flooding of managed devices is an operator network-design problem, not an exporter vulnerability.
+- **Vendor MIB data that is semantically false but syntactically valid.** A compromised router returning false topology is outside the exporter's trust model — see `docs/operator/threat-model.md`.
+
+## Credit and disclosure policy
+
+- **Credit.** Reporters who find valid security issues are credited in the Security Advisory and in the CHANGELOG entry for the fixing release, by name or handle as they prefer. Anonymous reports are honoured if the reporter requests it.
+- **Coordinated disclosure.** The default is 90 days from initial acknowledgement, after which the reporter may disclose regardless of patch status. Reporters who need more or less time should say so upfront — the maintainer will accommodate reasonable requests.
+- **CVE assignment.** GitHub Security Advisories can request a CVE from GitHub's CNA. The maintainer will request one for all accepted advisories that cross the CVE reporting threshold (broadly: exploitable by an external actor or leading to loss of confidentiality/integrity/availability).
+
+## Related documents
+
+- `docs/operator/security.md` — credential-handling threat model and hardening guidance
+- `docs/operator/threat-model.md` — STRIDE matrix for the full binary surface
+- `docs/operator/federation.md` — mTLS PKI setup and certificate rotation

--- a/docs/comparisons/matrix.md
+++ b/docs/comparisons/matrix.md
@@ -1,0 +1,84 @@
+# Vendor Comparison Matrix
+
+**Date:** 2026-06-03
+**Scope:** Topology discovery capabilities and Prometheus/Grafana-stack integration. This is not a general feature comparison — it compares only the surfaces relevant to an operator who already runs Prometheus/Mimir/Grafana and wants topology data as a signal.
+
+For a deep bilateral read on LibreNMS specifically, see [`librenms.md`](librenms.md).
+
+---
+
+## Capability matrix
+
+Legend: **✅ supported** / **⚠ partial** (see caveat) / **❌ not supported**
+
+| Feature | network-topology-exporter | LibreNMS | SuzieQ | Nautobot | OpenNMS | SolarWinds NPM |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Topology discovery (LLDP/CDP)** | ✅ | ✅ | ✅ | ⚠ (plugin) | ✅ | ✅ |
+| **Multi-vendor BGP4-V2 peers** | ✅ | ❌ | ⚠ (read from config, not MIB) | ❌ | ⚠ | ✅ |
+| **OSPF adjacency discovery** | ✅ | ⚠ (polled, not topology-first) | ⚠ | ❌ | ✅ | ✅ |
+| **IS-IS adjacency discovery** | ✅ | ⚠ (sensor-level only) | ⚠ | ❌ | ⚠ | ⚠ |
+| **FDB (Layer-2 bridging)** | ✅ | ✅ | ⚠ | ❌ | ✅ | ✅ |
+| **MPLS-TE tunnel topology** | ✅ | ❌ | ❌ | ❌ | ⚠ | ✅ |
+| **Prometheus-native metric emission** | ✅ | ❌ | ❌ | ❌ | ⚠ (plugin) | ❌ |
+| **OTLP push (metrics + logs)** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Multi-instance federation** | ✅ mTLS hub/spoke | ⚠ shared DB | ❌ | ✅ (via API) | ⚠ distributed pollers | ✅ (proprietary) |
+| **MIB clean-room policy** | ✅ | ❌ (GPL accumulation) | N/A (read-only) | N/A | ❌ | N/A (proprietary) |
+| **No bespoke database required** | ✅ | ❌ (MariaDB + Redis) | ❌ (SQLite/Postgres) | ❌ (Postgres) | ❌ (Postgres + Cassandra) | ❌ (proprietary DB) |
+| **Single-binary footprint** | ✅ ~18 MB | ❌ PHP stack | ⚠ Python + DB | ❌ Django stack | ❌ Java stack | ❌ Windows service stack |
+| **Real-time discovery (sub-60s cycle)** | ✅ (default 60s, configurable) | ❌ (6-hour default) | ❌ (poll-on-demand) | ❌ (scheduled) | ⚠ (configurable, but heavyweight) | ⚠ (configurable) |
+| **Multi-source conflict detection** | ✅ counter + log | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Structured change events** | ✅ JSON log lines | ❌ | ❌ | ✅ (webhook) | ⚠ | ✅ |
+| **AGPL / open-source** | ✅ AGPL-3.0 | ✅ GPL-3.0 | ✅ Apache-2.0 | ✅ Apache-2.0 | ✅ AGPL-3.0 | ❌ proprietary |
+| **Grafana-native (no extra UI)** | ✅ | ❌ (own UI) | ❌ (own TUI) | ❌ (own UI) | ❌ (own UI) | ❌ (own UI) |
+| **SNMPv3 with authPriv** | ✅ SHA-family + AES-family | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Credential zeroization** | ✅ `[]byte` + `Zeroize()` | ❌ PHP strings | N/A | N/A | ❌ | N/A |
+
+---
+
+## Notes on each tool
+
+### LibreNMS
+
+Full-stack network management system (inventory, polling, syslog, alerting, topology maps). Topology is one of ~50 modules. If you do not already run Prometheus/Grafana, LibreNMS gives you discovery + visualization in a single product; the trade-off is a PHP+MariaDB+Redis runtime and a 6-hour default discovery cadence.
+
+The bilateral comparison — code paths, data model, reconciliation, federation, and credential handling — is in [`librenms.md`](librenms.md).
+
+### SuzieQ
+
+Read-only network observability tool that connects via SSH/NETCONF/REST and normalises device state into a Parquet-backed data model. Excellent at querying current BGP/OSPF/LLDP state from a Python CLI; not an exporter, not a Prometheus-native emitter. No topology-change events. Complements this exporter if you want ad-hoc device-state queries alongside continuous metric emission.
+
+### Nautobot
+
+Network source-of-truth platform (successor to NetBox). Topology data lives in its model as an authoritative record, not as a discovery output. Plugin ecosystem can do LLDP/CDP discovery but the output is records, not metrics. The right tool for tracking intended topology; this exporter tracks observed topology. They compose: Nautobot holds ground-truth, the exporter surfaces deltas.
+
+### OpenNMS
+
+Java-based SNMP poller and network management system. Has Prometheus metric export via plugin but it's not native. OSPF/BGP discovery exists but is not structured as a first-class topology edge set. Federation is a distributed-poller model sharing state via a Postgres+Cassandra backend. AGPL-3.0 licensed. Heavier operationally than this exporter but broader in feature scope (syslog, flow, alarm correlation).
+
+### SolarWinds NPM
+
+Commercial, Windows-hosted, full-stack NMS. Strong topology discovery including MPLS, BGP, and OSPF. Proprietary data store and UI. Relevant for enterprises already committed to the SolarWinds ecosystem. **Not a replacement for this exporter in a Grafana/Prometheus stack** — NPM does not emit Prometheus metrics or OTLP.
+
+---
+
+## "Not trying to be SolarWinds"
+
+SolarWinds NPM is a full NMS: it combines topology discovery, IPSLA probe management, NCM config backup, alert correlation, and a GUI into one product. This exporter is deliberately narrower: discovery → metric emission, nothing else. An operator using this exporter alongside Grafana still needs:
+
+- **Network Configuration Management (NCM):** Rancid, Oxidized, Batfish, or the SolarWinds NCM module. The exporter does not read or diff device configs.
+- **IPSLA / synthetic probes:** SmokePing, Blackbox Exporter (ICMP/HTTP probes), or SolarWinds IPSLA. The exporter discovers the topology; probe health is a separate signal.
+- **Alert correlation / root-cause analysis:** Grafana Incident (ML correlation), or the classic SolarWinds "root-cause-analysis" engine which cross-correlates alerts with topology. The `network_topology_change_total` counter and change event log lines are the exporter's contribution to correlation — they tell you *what changed*, not *why an alert fired*.
+
+If you need NCM + IPSLA + full alert correlation in one product, SolarWinds NPM (or OpenNMS, or LibreNMS for some of it) is the right shape. If you need topology as a signal inside a stack that already handles those concerns separately, this exporter fills the gap.
+
+---
+
+## Sources
+
+Comparisons are based on public documentation and, where noted, open-source code:
+
+- LibreNMS: [docs.librenms.org](https://docs.librenms.org), source at [github.com/librenms/librenms](https://github.com/librenms/librenms) — see [`librenms.md`](librenms.md) for code-level detail
+- SuzieQ: [suzieq.readthedocs.io](https://suzieq.readthedocs.io), source at [github.com/netenglabs/suzieq](https://github.com/netenglabs/suzieq)
+- Nautobot: [docs.nautobot.com](https://docs.nautobot.com), source at [github.com/nautobot/nautobot](https://github.com/nautobot/nautobot)
+- OpenNMS: [docs.opennms.com](https://docs.opennms.com), source at [github.com/OpenNMS/opennms](https://github.com/OpenNMS/opennms)
+- SolarWinds NPM: [documentation.solarwinds.com/en/success_center/npm/](https://documentation.solarwinds.com/en/success_center/npm/) (proprietary; documentation only)

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -141,6 +141,7 @@ If either verification fails the artefact is not authentic — do not deploy it.
 
 ## References
 
+- [`SECURITY.md`](../../SECURITY.md) — vulnerability reporting policy, response SLA, credit/disclosure terms.
 - Issue #5 — the GitHub issue that motivated the SNMP zeroization work.
 - Issue #3 — the GitHub issue that motivated the `/metrics` authentication work.
 - `internal/discovery/snmp/zeroize.go` — the `Zeroize()` implementation and `zeroBytes` helper.

--- a/docs/operator/stability.md
+++ b/docs/operator/stability.md
@@ -1,0 +1,173 @@
+# Stability Matrix
+
+This document is the authoritative statement of which surfaces are frozen, the semver contract that applies to each, and the measurable criteria that define v1.0 GA. It is written for operators who need to decide whether to pin a version or upgrade freely, and for contributors who need to know what constitutes a breaking change.
+
+Cross-references:
+
+- Metric list: [`docs/metrics.md`](../metrics.md)
+- Config key reference: [`config/example.yaml`](../../config/example.yaml)
+- Roadmap and release plan: [`ROADMAP.md`](../../ROADMAP.md)
+- Contribution rules: [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+
+---
+
+## Pre-1.0 stability warning
+
+Despite the existing `v1.0.0`–`v1.3.0` tags, the project follows pre-1.0 stability conventions. The five surfaces below can break between minor releases until the v1.0 GA banner is flipped. Pin exact versions in anything you care about.
+
+The path to GA: `v1.4.0-rc.1` (lab fixture capture) → `v1.5.0` (config schema freeze) → `v1.6.0` (operator readiness) → `v1.7.0` (self-observability) → `v1.0.0` (retag, banner removed). See [ROADMAP.md](../../ROADMAP.md).
+
+---
+
+## The five frozen surfaces
+
+At v1.0 GA, a breaking change to any of these surfaces requires a **major version bump** (i.e. `v2.0.0`). Until GA, breaking changes in these surfaces will be signalled by a changelog entry labelled `(breaking)`.
+
+### 1. Config schema
+
+The frozen artefact is `config/example.yaml`. Every key documented there is part of the contract.
+
+| Key group | Representative keys |
+|---|---|
+| Discovery controls | `discovery.interval`, `discovery.timeout_per_device`, `discovery.parallelism`, `discovery.cycle_budget_fraction`, `discovery.scope.cidr_allow_list`, `discovery.unconfirmed_link_ttl_cycles` |
+| Module toggles | `modules.{lldp,cdp,bgp,ospf,fdb,arp,isis,mpls_te}.enabled` |
+| BGP walker | `modules.bgp.disable_v2_mib` |
+| Credentials | `credentials.profiles[].{name,type,community_env,username_env,auth_protocol,auth_key_env,priv_protocol,priv_key_env}`, `credentials.assignments`, `credentials.fallback_order`, `credentials.trial_rate_per_second` |
+| Snapshot | `snapshot.path` |
+| Federation | `federation.role`, `federation.spoke_timeout`, `federation.known_inter_domain_links`, `federation.hub.*`, `federation.spoke.*` |
+| Output | `output.otlp.{enabled,endpoint,timeout,heartbeat_cycles}` |
+| Listen | `listen.web_config_file`, `listen.tls_cert_file` (deprecated, removed in v1.5.0) |
+| Targets | `targets[].{host,port,site,labels}` |
+
+**Breaking change** means: a key is renamed, removed, or its accepted value set changes in a way that requires operator action before upgrade. Additive changes (new optional keys with sensible defaults) are not breaking.
+
+**Deprecated keys** in flight: `modules.bgp.use_v2_mib` (→ `disable_v2_mib`), `federation.hub.strict_device_name_matching` (→ `loose_device_name_matching`), `listen.tls_cert_file`/`listen.tls_key_file` (→ `listen.web_config_file`). All three are accepted with a startup deprecation warning through v1.4.x and will be removed in v1.5.0.
+
+### 2. Metric names and label sets
+
+The frozen artefact is the table in [`docs/metrics.md`](../metrics.md). Every metric name and label set documented there is part of the contract.
+
+Key metrics (summary — full details in `docs/metrics.md`):
+
+| Metric | Type | Frozen label set |
+|---|---|---|
+| `network_topology_device_info` | gauge | `device_id`, `vendor`, `model`, `os_version`, `site` |
+| `network_topology_device_uptime_seconds` | gauge | `device_id` |
+| `network_topology_edge_info` | gauge | `src_device`, `src_port`, `dst_device`, `dst_port`, `discovery_proto`, `link_kind`, `direction` |
+| `network_topology_change_total` | counter | `change_kind`, `discovery_proto` |
+| `network_topology_out_of_scope_neighbours_total` | gauge | (none) |
+| `network_topology_graph_stale` | gauge | (none) |
+| `network_topology_snapshot_last_written_timestamp_seconds` | gauge | (none) |
+| `network_topology_discovery_cycle_duration_seconds` | histogram | (none) |
+| `network_topology_discovery_module_duration_seconds` | histogram | `module` |
+| `network_topology_bgp_walker_outcome_total` | counter | `walker`, `outcome` |
+| `network_topology_federation_spoke_up` | gauge | `spoke_id` |
+| `network_topology_federation_spoke_push_failures_total` | counter | (none) |
+| `network_topology_otlp_push_total` | counter | `status`, `reason` |
+
+**Breaking change** means: a metric is renamed, removed, a label is renamed or its value set changes in an incompatible way, or a metric's type changes. Adding a new label (widening the series fingerprint) is breaking. Adding a new metric is not.
+
+Adding a `reason` label value within an existing closed enum (e.g. a new `network_topology_bgp_walker_outcome_total{outcome=...}` value) is treated as potentially breaking if existing alerts use a negation match — the CHANGELOG entry will note it.
+
+### 3. CLI flags
+
+The frozen artefact is `--help` output and the README quickstart. The four defined flags are:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--config.file` | `/etc/topology-exporter/config.yaml` | Path to the YAML configuration file |
+| `--web.listen-address` | `:9100` | Address on which to expose `/metrics`, `/healthz`, and `/readyz` |
+| `--log.level` | `info` | Log level: `debug \| info \| warn \| error` |
+| `--version` | — | Print version string and exit |
+
+**Breaking change** means: a flag is renamed or removed, or its semantics change in a way that requires operator action. Adding new flags with sensible defaults is not breaking.
+
+### 4. Snapshot format
+
+The frozen artefact is the JSON schema of `snapshot.json`. The current schema version is **3** (`internal/snapshot/snapshot.go: CurrentVersion = 3`).
+
+The schema version is written to every snapshot file as `"version": 3`. The loader rejects files with a version number it does not recognise; it does not attempt a silent migration. At v1.0 GA:
+
+- **Minor version bumps** may add optional fields to the schema. The loader handles unknown fields gracefully (Go's `encoding/json` ignores them by default). Version number remains `3` for additive changes.
+- **Schema version increments** (4, 5, …) indicate that reading the file with an older binary is not supported. A migration path (if one exists) is documented in the CHANGELOG entry for the release that bumps the version.
+- A downgrade from a binary that wrote version `N` to one that only understands version `N-1` will result in the older binary refusing to load the snapshot and cold-starting from zero. The CHANGELOG will call this out as a breaking change.
+
+**Breaking change** means: the schema version is incremented, or a previously required field is removed or changes meaning.
+
+### 5. Federation API
+
+The frozen artefact is the `SpokePayload` wire type (`internal/federation/payload.go`) and the HTTP contract for `POST /spoke/push` on the hub's mTLS listener.
+
+Current federation API shape:
+
+| Aspect | Value |
+|---|---|
+| Endpoint | `POST /spoke/push` on `federation.hub.listen_addr` (default `:9101`) |
+| Transport | mTLS — client cert required, verified against `federation.hub.tls_ca_cert` |
+| Payload | `SpokePayload` serialised as JSON |
+| Reject response | HTTP 400 with `{"reason": "...", "detail": {...}}` JSON body |
+| Accept response | HTTP 204 (no body) |
+| `SpokePayload` fields | `spoke_id` (string), `cycle_at` (RFC 3339), `devices` (array), `edges` (array), `out_of_scope` (array), `ages` (map) |
+
+There is no explicit federation API version number in the wire format today. This is a known gap — a `"federation_api_version"` field is planned before v1.0 GA to allow the hub to reject incompatible spoke payloads with a clear error rather than a validation failure. Until then, spoke and hub **must** run the same minor version.
+
+**Breaking change** means: a required field is added, removed, or its type changes; the HTTP status codes for accept/reject change; the mTLS contract changes (e.g. new required SAN validation).
+
+---
+
+## Structural commitments
+
+Three commitments from the ROADMAP that have measurable acceptance criteria:
+
+### Every discovery walker is real-device validated
+
+**What it means:** Synthetic-only test coverage (PDU streams hand-crafted from MIB documents) is insufficient for v1.0 GA. Each walker must have a `lab/` directory with captures from real hardware or a supported containerlab image.
+
+**Current status:**
+
+| Walker | Validation status |
+|---|---|
+| Cisco IOL / IOS-XE (cbgpPeer2Table) | Real-device validated (`lab/cisco-iol-bgp/`, `lab/cisco-iosxe-bgp/`) |
+| Arista cEOS (enterprise BGP4V2) | Real-device validated (`lab/arista-ceos-bgp/`) |
+| Nokia SR-OS (tBgpPeerTable) | **Experimental** — pending colleague-capture (#57) |
+| Juniper Junos (jnxBgpM2PeerTable) | **Experimental** — pending colleague-capture (#56) |
+| LLDP (IEEE 802.1AB) | Real-device validated via containerlab E2E (`make test-e2e`) |
+| CDP (CISCO-CDP-MIB) | Synthetic tests; real-device captures not yet landed |
+| OSPF, IS-IS, FDB, MPLS-TE | Synthetic tests; real-device captures not yet landed |
+
+**Acceptance criterion:** all walkers in the table above show "real-device validated" before the v1.0.0 banner is flipped.
+
+### No silent failure modes
+
+**What it means:** Every external dependency the exporter relies on (per-vendor MIB shape, per-protocol assumption) has either a hard-fail contract or a `network_topology_*_outcome_total` counter labelled with the specific failure shape. Operators can alert on degradation rather than discovering it through dashboard absence.
+
+**Acceptance criterion:** `docs/metrics.md` has an entry for every failure counter, and each entry names the alert expression an operator should use.
+
+### Operator runbook is sufficient for a new operator to deploy, alert, and troubleshoot
+
+**What it means:** An operator who has never read the source code should be able to deploy the exporter, configure basic alerts, and diagnose common problems using the documentation in `docs/operator/` and the referenced runbooks.
+
+**Acceptance criterion:** the v1.6.0 operator-readiness milestone closes with the upgrade runbook (`docs/operator/upgrades.md`), SLO guidance (`docs/operator/slos.md`), this stability matrix, and the failure-mode coverage audit all shipped and cross-referenced from the README.
+
+---
+
+## Deprecation policy
+
+The following policy applies at v1.0 GA. During the pre-1.0 period, breaking changes may occur without a full deprecation cycle; each is labelled `(breaking)` in the CHANGELOG.
+
+**At GA:**
+
+1. **Minimum overlap:** a deprecated config key, metric label value, or CLI flag must remain functional for at least **one full minor release** after the deprecation is announced.
+2. **Startup warning:** deprecated config keys emit a `WARN`-level structured log line on startup, naming the deprecated key, the replacement, and the release in which the deprecated form will be removed.
+3. **CHANGELOG note:** the release that introduces the deprecation has a `### Deprecated` section entry; the release that removes the deprecated form has a `### Removed` section entry.
+4. **No silent migration:** the exporter does not silently rewrite a deprecated config file. If a deprecated key is present and the exporter accepts it, it logs the deprecation warning and uses the deprecated behaviour unchanged. Operators migrate on their own schedule within the overlap window.
+
+---
+
+## Related documents
+
+- [`ROADMAP.md`](../../ROADMAP.md) — release plan and v1.0 GA criteria in full
+- [`docs/metrics.md`](../metrics.md) — full metric reference with recommended alerts
+- [`config/example.yaml`](../../config/example.yaml) — config schema reference
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — what constitutes a breaking change for contributors
+- [`docs/supported-platforms.md`](../supported-platforms.md) — per-vendor walker validation status

--- a/docs/operator/threat-model.md
+++ b/docs/operator/threat-model.md
@@ -75,7 +75,7 @@ Things this binary deliberately does *not* defend against — they belong to the
 
 ## Reporting vulnerabilities
 
-Until `SECURITY.md` ships, vulnerability reports should be sent privately via GitHub Security Advisories (`Security` → `Report a vulnerability` on the repo). Do not file public issues for unpatched vulnerabilities.
+To report a vulnerability privately, see [`SECURITY.md`](../../SECURITY.md) for the full policy, response SLA, and credit/disclosure terms. Use GitHub Security Advisories (`Security` → `Report a vulnerability` on the repo). Do not file public issues for unpatched vulnerabilities.
 
 ## Related documents
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,5 +1,7 @@
 # Standards Compliance Matrix
 
+For per-vendor real-device validation status (which walkers have been tested against which platforms), see [`docs/supported-platforms.md`](supported-platforms.md).
+
 ## Implemented Standards
 
 | Standard | Scope in this exporter | Notes |

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,0 +1,47 @@
+# Supported Platforms
+
+This matrix records which vendor platforms have been tested against the exporter's discovery modules and at what validation depth. "Real-device validated" means the walker was exercised against a live or containerlab-deployed device and real SNMP captures exist in `lab/`; "synthetic" means the walker was written from MIB documentation and tested against hand-constructed PDU streams only.
+
+Cross-reference:
+
+- Module details and MIB citations: `docs/standards.md`
+- Full metric reference: `docs/metrics.md`
+- BGP4-V2 vendor walker status: README § "Vendor walker coverage"
+
+---
+
+## Platform matrix
+
+| Vendor | Platform family | OS version tested | Modules verified | Capture path | Notes |
+|---|---|---|---|---|---|
+| Cisco | IOS (IOL) | 17.12.1 | SNMP system group, BGP4-V2 (`cbgpPeer2Table`) | `lab/cisco-iol-bgp/` containerlab | BGP walker validated against real `snmpwalk` captures 2026-05-16 (issue #1, #31). Column numbers (`state=3`, `remoteAs=11`) and index encoding confirmed byte-for-byte. RFC 4273 `bgpPeerTable` also validated. LLDP and CDP walkers exercised via synthetic tests; no IOL-specific LLDP captures exist yet. |
+| Cisco | IOS-XE | Hardware (colleague capture, 2026-05-30) | BGP4-V2 (`cbgpPeer2Table`) | `lab/cisco-iosxe-bgp/` colleague-capture flow | Cross-confirmation of the IOL-derived walker (issue #58). Four sessions (two IPv4, two IPv6, all Established), columns 3–29 of `cbgpPeer2Table`. Column numbers and index encoding matched IOL byte-for-byte — no walker drift between IOL emulator and real IOS-XE. No separate IOS-XE fixture committed; the IOL fixture provides CI regression coverage. |
+| Arista | EOS (cEOS) | 4.36.0F | SNMP system group, BGP4-V2 enterprise (`1.3.6.1.4.1.30065.4.1.1.2`) | `lab/arista-ceos-bgp/` containerlab | Walker validated against real cEOS 4.36 captures 2026-05-16 (issue #31). Arista does **not** implement the IETF draft `bgp4V2PeerTable` at `1.3.6.1.3.5.1.1.2` — the enterprise OID is the correct target. Column numbers (`state=13`, `remoteAs=10`) and index format confirmed from captures. LLDP not separately captured on cEOS; walker is IEEE 802.1AB-standard and expected to work on platforms that implement the MIB correctly. |
+| Nokia | SR Linux | 24.7.2 | SNMP system group only | E2E containerlab (`make test-e2e-srl`) | **LLDP via SNMP is not supported on SR Linux 24.x.** The standard IEEE 802.1AB LLDP MIB at `1.0.8802.1.1.2` returns `No Such Object` on every probe. LLDP data is only available via gNMI/JSON-RPC on SR Linux — a v2.0.0 work item. The SNMP system group (`sysDescr`, `sysName`, `sysUpTime`, `sysObjectID`) is exposed and works. The classic `TIMETRA-LLDP-MIB` at `1.3.6.1.4.1.6527.3.1.2.43` (used on SR-OS) is also absent on SR Linux. See issue #46. |
+| Nokia | SR-OS | Not yet lab-validated (colleague-capture pending) | BGP4-V2 (`tBgpPeerTable`, `1.3.6.1.4.1.6527.3.1.2.13.2`) — **Experimental** | `lab/nokia-srbgp/` colleague-capture flow | Walker columns transcribed from TIMETRA-BGP-MIB documentation but not yet validated against real hardware (issue #57). On SR-OS fleets, set `modules.bgp.disable_v2_mib: true` until the capture work closes. Walker surfaces failure modes via `network_topology_bgp_walker_outcome_total{walker="vendor_nokia",outcome=...}` — silent zero-edge dropout is alertable. Alcatel-Lucent pre-acquisition gear (7705 SAR, 7750 SR, 7250 IXR) implements the same MIB and should produce a valid capture. |
+| Juniper | Junos (vMX / physical) | Not yet lab-validated (colleague-capture pending) | BGP4-V2 (`jnxBgpM2PeerTable`, `1.3.6.1.4.1.2636.5.1.1.2.1.1`) — **Experimental** | `lab/juniper-jnxbgp/` colleague-capture flow | Walker columns transcribed from JUNIPER-BGP-MIB documentation but not yet validated against real hardware (issue #56). On Junos fleets, set `modules.bgp.disable_v2_mib: true` until the capture work closes. Same alertability caveat as Nokia above. |
+
+---
+
+## Notes on "modules verified"
+
+**SNMP system group** (always): `sysDescr`, `sysName`, `sysUpTime`, `sysObjectID`. Required by every mode; used for vendor detection (enterprise prefix from `sysObjectID`) and device identity. Validated against every platform listed above.
+
+**LLDP** (IEEE 802.1AB): Walker is specification-derived and has no per-vendor branching. Platforms that correctly implement the MIB at `1.0.8802.1.1.2` work without modification. Platforms confirmed to fail: SR Linux 24.x (gNMI only, #46). Platforms with E2E containerlab coverage via synthetic SNMP agents: all platforms in `make test-e2e`.
+
+**CDP** (CISCO-CDP-MIB): Cisco-only. Not expected on Arista, Nokia, or Juniper platforms.
+
+**BGP4-V2 vendor walkers**: See the table above and README § "Vendor walker coverage" for the definitive validation status of each walker. The RFC 4273 fallback (`bgpPeerTable`) provides IPv4-only BGP peer edges on any platform that implements the base MIB.
+
+**OSPF, IS-IS, FDB, MPLS-TE**: These walkers are implemented from their respective RFCs and tested against synthetic SNMP agents in `make test-integration`. No per-vendor real-device captures exist yet for these modules; they are expected to work on any conformant platform but have not been explicitly validated against the platforms in this matrix.
+
+---
+
+## Adding a new platform
+
+To add a platform to this matrix:
+
+1. Run the exporter against the platform (or a colleague-capture in `lab/<vendor>/`) and confirm that the target modules produce edges rather than `outcome=mib_unimplemented` or `outcome=walker_drift`.
+2. Land the `snmpwalk` captures in the appropriate `lab/` directory per the existing lab README conventions.
+3. Update this table row with the OS version tested and the module list verified.
+4. If a new vendor BGP4-V2 walker is needed, add a `vendorTableSpec` in `internal/discovery/bgp/bgp_vendor.go` per the existing pattern and cite the public vendor MIB source.


### PR DESCRIPTION
Adds the v1.6.0 operator-readiness documentation set. Docs/config only — no code changes.

- **#76** `SECURITY.md` — private-disclosure process (GitHub Security Advisory), supported-version matrix, response SLA, scope, credit/disclosure policy. Cross-referenced from README, `operator/security.md`, `operator/threat-model.md`.
- **#77** `.github/ISSUE_TEMPLATE/{bug,feature,config}.yml` — GitHub form-schema templates; blank issues disabled; security reports routed to the private advisory.
- **#80** `docs/supported-platforms.md` — per-vendor/OS validation matrix (verified against lab READMEs + code; experimental walkers flagged).
- **#81** `docs/comparisons/matrix.md` — six-tool feature comparison; links the LibreNMS deep read; linked from README.
- **#66** `docs/operator/stability.md` — five frozen surfaces with concrete artefacts (snapshot format v3, federation `POST /spoke/push`, CLI flags), deprecation policy, GA criteria.

**Maintainer action:** enable Settings → Security → Private vulnerability reporting so the "Report a vulnerability" button surfaces.
**Known gap (noted in stability.md):** the federation wire payload has no explicit version field yet — flagged as pre-GA work.

Closes #66, #76, #77, #80, #81.