### PR TITLE
Remove deprecated config keys for v1.5.0 (#60, #61, #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ the README. The lab-fixture-capture work previously slotted for
 v1.3.1 lands under this milestone instead, renamed to
 [v1.4.0-rc.1 — Lab Fixture Capture](https://github.com/colinedwardwood/network-topology-exporter/milestones).
 
+### Configuration (breaking)
+
+- **#60 (breaking — config schema)** — `modules.bgp.use_v2_mib` removed. The key was deprecated in v1.4.0 and carried with a startup warning for one release. Configs that set `use_v2_mib` now fail to load with a parse error. Use `modules.bgp.disable_v2_mib` (default `false` = v2 walkers enabled; set `true` to fall back to RFC 4273-only behaviour). Closes #60.
+- **#61 (breaking — config schema)** — `federation.hub.strict_device_name_matching` removed. The key was deprecated in v1.4.0 and carried with a startup warning for one release. Configs that set `strict_device_name_matching` now fail to load with a parse error. Use `federation.hub.loose_device_name_matching` (default `false` = strict matching; set `true` to enable domain-suffix stripping for single-site mixed short/FQDN deployments). Closes #61.
+- **#62 (breaking — config schema)** — `listen.tls_cert_file` and `listen.tls_key_file` removed. The keys were deprecated in v1.4.0 (replaced by `listen.web_config_file`) and carried with a startup warning for one release. Configs that set either key now fail to load with a parse error. Migrate to `listen.web_config_file` pointing at a Prometheus exporter-toolkit web-config YAML (set `tls_server_config.cert_file` / `key_file` to the same paths); the toolkit adds basic_auth and mTLS support beyond what the legacy fields offered. The `srv.ListenAndServeTLS` code path is also removed from the application — all TLS is now handled by `web.ListenAndServe`. Closes #62.
+
 ### Licensing
 
 - **Relicensed from Apache-2.0 to AGPL-3.0.** The project is now distributed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,13 +66,13 @@ Unreleased section.
 
 ### `v1.5.0` — Config schema freeze
 
-Remove the deprecated keys carried for one minor release of overlap:
+Remove the deprecated keys carried for one minor release of overlap (done):
 
-- `modules.bgp.use_v2_mib` (replaced by `disable_v2_mib` in v1.3.0)
+- `modules.bgp.use_v2_mib` (replaced by `disable_v2_mib` in v1.3.0) — removed
 - `federation.hub.strict_device_name_matching` (replaced by
-  `loose_device_name_matching` in v1.3.0)
+  `loose_device_name_matching` in v1.3.0) — removed
 - `listen.tls_cert_file` / `listen.tls_key_file` (replaced by
-  `listen.web_config_file` in v1.3.0)
+  `listen.web_config_file` in v1.3.0) — removed
 
 Audit `config/example.yaml` against `internal/config/config.go` so the
 example file is the authoritative schema document. Declare the config schema

--- a/cmd/topology-exporter/main_test.go
+++ b/cmd/topology-exporter/main_test.go
@@ -2254,20 +2254,13 @@ func TestGraphSizeAdmissionControl(t *testing.T) {
 	}
 }
 
-// TestRunTLSMetrics verifies that when listen.tls_cert_file and
-// listen.tls_key_file are configured, the /metrics endpoint is reachable over
-// HTTPS and returns HTTP 200.
-func TestRunTLSMetrics(t *testing.T) {
+// TestRunTLSMetricsRemovedKeys verifies that a config using the removed
+// listen.tls_cert_file / listen.tls_key_file keys causes the process to exit
+// non-zero (config load fails at startup). Removed in v1.5.0; use
+// listen.web_config_file instead.
+func TestRunTLSMetricsRemovedKeys(t *testing.T) {
 	dir := t.TempDir()
 	certFile, keyFile := generateSelfSignedCert(t, dir)
-
-	// Pick a random free port for the TLS listener.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	listenAddr := ln.Addr().String()
-	_ = ln.Close()
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfgContent := fmt.Sprintf(`
@@ -2281,56 +2274,28 @@ modules:
 snapshot:
   path: %s/snapshot.json
 listen:
-  addr: %s
+  addr: 127.0.0.1:0
   tls_cert_file: %s
   tls_key_file: %s
-`, dir, listenAddr, certFile, keyFile)
+`, dir, certFile, keyFile)
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan int, 1)
 	go func() {
 		done <- app.Run(ctx, []string{"--config.file=" + cfgPath})
 	}()
 
-	// Wait for the TLS server to become ready.
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		},
-		Timeout: 5 * time.Second,
-	}
-	url := "https://" + listenAddr + "/metrics"
-	deadline := time.Now().Add(10 * time.Second)
-	var resp *http.Response
-	for time.Now().Before(deadline) {
-		resp, err = client.Get(url) //nolint:noctx
-		if err == nil {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if err != nil {
-		cancel()
-		t.Fatalf("TLS /metrics not reachable within deadline: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	cancel()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("GET /metrics over TLS: status = %d, want 200", resp.StatusCode)
-	}
-
 	select {
 	case code := <-done:
-		if code != 0 {
-			t.Errorf("run() exit code = %d, want 0", code)
+		if code == 0 {
+			t.Error("run() exit code = 0; expected non-zero (config with removed tls_cert_file/tls_key_file should fail)")
 		}
 	case <-time.After(10 * time.Second):
-		t.Fatal("run() did not return within 10s after cancel")
+		t.Fatal("run() did not return within 10s; expected immediate failure on bad config")
 	}
 }
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -68,8 +68,7 @@ modules:
     #                          # failure modes via network_topology_bgp_walker_outcome_total
     #                          # (labels walker_drift / malformed_index / mib_unimplemented),
     #                          # so silent zero-edge dropouts are alertable.
-    #                          # Replaces the v1.3.0 `use_v2_mib` key (still accepted with a
-    #                          # deprecation warning; removed in v1.5.0).
+    #                          # Replaces the removed v1.3.0 `use_v2_mib` key (removed in v1.5.0).
   ospf:
     enabled: false             # RFC 4750 OSPF-MIB
   fdb:
@@ -151,8 +150,7 @@ snapshot:
 #     # true ONLY for single-site deployments where mixed short/FQDN forms of
 #     # the same device must reconcile (e.g. one spoke reports "core-01" while
 #     # another reports "core-01.internal.corp" for the same physical device).
-#     # Replaces the v1.3.0 `strict_device_name_matching` key (still accepted
-#     # with a deprecation warning; removed in v1.5.0).
+#     # Replaces the removed v1.3.0 `strict_device_name_matching` key (removed in v1.5.0).
 #     # loose_device_name_matching: false
 #
 #     # Graph size admission control for the hub's combined graph.

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -94,7 +94,7 @@ tls_server_config:
 
 `client_allowed_sans` pins which scraper identities are accepted — a leaked cert with an unexpected SAN is rejected at the TLS layer before the request body is parsed. The Prometheus exporter-toolkit handles cert reload-on-change automatically, so SAN rotation does not require an exporter restart.
 
-The legacy `listen.tls_cert_file` and `listen.tls_key_file` fields remain accepted but emit a startup deprecation warning. They configure server-side TLS only — no client authentication — and will be removed in v1.5.0. Migrate to `listen.web_config_file` (set `tls_server_config.cert_file` / `key_file` to the same paths) and the deprecation warning goes away.
+The `listen.tls_cert_file` and `listen.tls_key_file` fields were removed in v1.5.0. Migrate to `listen.web_config_file` (set `tls_server_config.cert_file` / `key_file` to the same paths). Configs using the removed keys will fail to load with a parse error.
 
 ## Verifying release artefact provenance
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -238,13 +238,6 @@ func Run(ctx context.Context, args []string) int {
 				WebConfigFile:      &cfg.Listen.WebConfigFile,
 			}
 			serveErr = web.ListenAndServe(srv, webFlags, logger)
-		case cfg.Listen.TLSCertFile != "": //nolint:staticcheck // intentional: deprecated legacy TLS path supported through v1.5.0 per cfg.EmitDeprecationWarnings
-			// Deprecated path — server-side TLS only, no client auth. Operators
-			// using this path saw a startup deprecation warning from
-			// EmitDeprecationWarnings; the path stays functional until v1.5.0
-			// removes the legacy fields.
-			logger.Info("metrics TLS server listening (deprecated tls_cert_file/tls_key_file)", "addr", effectiveAddr)
-			serveErr = srv.ListenAndServeTLS(cfg.Listen.TLSCertFile, cfg.Listen.TLSKeyFile) //nolint:staticcheck // intentional: deprecated legacy TLS path supported through v1.5.0 per cfg.EmitDeprecationWarnings
 		default:
 			logger.Info("metrics server listening", "addr", effectiveAddr)
 			serveErr = srv.ListenAndServe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,28 +30,17 @@ type Config struct {
 }
 
 // ListenConfig holds the HTTP/HTTPS listen address and optional auth config.
-// The recommended way to enable TLS and/or authentication is WebConfigFile,
-// which points at a Prometheus exporter-toolkit web-config YAML — the same
-// schema operators know from snmp_exporter, node_exporter, blackbox_exporter,
-// etc. (see https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
+// WebConfigFile points at a Prometheus exporter-toolkit web-config YAML — the
+// same schema operators know from snmp_exporter, node_exporter,
+// blackbox_exporter, etc. (see
+// https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
 // The toolkit handles basic_auth, server TLS, and full mTLS in one file.
 //
-// TLSCertFile / TLSKeyFile remain accepted for one minor release as a
-// transitional path; they configure server-side TLS only (no client auth)
-// and are equivalent to a web-config with just tls_server_config.cert_file
-// and key_file set. Operators using these fields receive a startup
-// deprecation warning. New deployments should use WebConfigFile.
-//
-// When all three are empty the server uses plain HTTP — the default and the
+// When both fields are empty the server uses plain HTTP — the default and the
 // canonical Prometheus convention of "scrape from a private network".
 type ListenConfig struct {
 	Addr          string `yaml:"addr"`            // default ":9100"
-	WebConfigFile string `yaml:"web_config_file"` // exporter-toolkit web-config YAML; recommended
-
-	// Deprecated: use WebConfigFile.
-	TLSCertFile string `yaml:"tls_cert_file"`
-	// Deprecated: use WebConfigFile.
-	TLSKeyFile string `yaml:"tls_key_file"`
+	WebConfigFile string `yaml:"web_config_file"` // exporter-toolkit web-config YAML
 }
 
 // OutputConfig holds optional push-mode output paths.
@@ -114,10 +103,6 @@ type FederationHubConfig struct {
 	// distinct. Set to true to restore the pre-v1.3.0 behaviour for single-site
 	// deployments where short and FQDN forms of the same device must reconcile
 	// to one node — both forms normalise to "core-sw".
-	//
-	// Replaces the v1.3.0 `strict_device_name_matching` (*bool) field. The old
-	// YAML key is still accepted for one minor release with a deprecation
-	// warning; see UnmarshalYAML below.
 	LooseDeviceNameMatching bool `yaml:"loose_device_name_matching"`
 	// MinPushInterval rejects per-spoke pushes received sooner than this
 	// duration after the previous accepted push from the same spoke_id, with
@@ -127,41 +112,6 @@ type FederationHubConfig struct {
 	// check; set to roughly half the spoke's discovery_interval for a sane
 	// floor. Must be strictly less than spoke_timeout.
 	MinPushInterval time.Duration `yaml:"min_push_interval"`
-
-	// strictDeviceNameMatchingDeprecated records whether the operator set the
-	// legacy `strict_device_name_matching` YAML key. Set by UnmarshalYAML, read
-	// by EmitDeprecationWarnings on startup. Remove in v1.5.0 along with the
-	// transitional unmarshal path.
-	strictDeviceNameMatchingDeprecated *bool `yaml:"-"`
-}
-
-// UnmarshalYAML accepts the legacy `strict_device_name_matching` key for one
-// minor release after the v1.3.0 rename to `loose_device_name_matching`.
-// Translation: an explicit `strict_device_name_matching: false` sets
-// `LooseDeviceNameMatching = true`; an explicit `true` (or omission) leaves
-// `LooseDeviceNameMatching` at its zero-value default (false = strict).
-// EmitDeprecationWarnings logs a warning if the deprecated key was used.
-//
-// Remove this UnmarshalYAML, the deprecated alias field, and the
-// strictDeviceNameMatchingDeprecated tracking field in v1.5.0.
-func (c *FederationHubConfig) UnmarshalYAML(value *yaml.Node) error {
-	type alias FederationHubConfig // break recursion
-	aux := struct {
-		*alias           `yaml:",inline"`
-		StrictDeprecated *bool `yaml:"strict_device_name_matching"`
-	}{alias: (*alias)(c)}
-	if err := value.Decode(&aux); err != nil {
-		return err
-	}
-	if aux.StrictDeprecated != nil {
-		// Operator set the old key. Translate: old=false means loose, so flip
-		// LooseDeviceNameMatching on (unless the new key already set it).
-		if !*aux.StrictDeprecated && !c.LooseDeviceNameMatching {
-			c.LooseDeviceNameMatching = true
-		}
-		c.strictDeviceNameMatchingDeprecated = aux.StrictDeprecated
-	}
-	return nil
 }
 
 // FederationSpokeConfig holds the spoke's settings.
@@ -244,47 +194,9 @@ type FDBConfig struct {
 // BGP adjacencies; RFC 4273 BGP4-MIB is IPv4-only. The zero value (false) is
 // the safe default since v1.3.0: v2 walkers run. Set to true to fall back to
 // RFC 4273-only behaviour if a vendor regression appears.
-//
-// Replaces the v1.3.0 `UseV2MIB` (*bool) field. The old YAML key
-// `use_v2_mib` is still accepted for one minor release with a deprecation
-// warning; see UnmarshalYAML below.
 type BGPConfig struct {
 	Enabled      bool `yaml:"enabled"`
 	DisableV2MIB bool `yaml:"disable_v2_mib"`
-
-	// useV2MIBDeprecated records whether the operator set the legacy
-	// `use_v2_mib` YAML key. Set by UnmarshalYAML, read by
-	// EmitDeprecationWarnings on startup. Remove in v1.5.0.
-	useV2MIBDeprecated *bool `yaml:"-"`
-}
-
-// UnmarshalYAML accepts the legacy `use_v2_mib` key for one minor release
-// after the v1.3.0 rename to `disable_v2_mib`. Translation: an explicit
-// `use_v2_mib: false` sets `DisableV2MIB = true`; an explicit `true` (or
-// omission) leaves `DisableV2MIB` at its zero-value default (false = v2
-// enabled). EmitDeprecationWarnings logs a warning if the deprecated key was
-// used.
-//
-// Remove this UnmarshalYAML, the deprecated alias field, and the
-// useV2MIBDeprecated tracking field in v1.5.0.
-func (c *BGPConfig) UnmarshalYAML(value *yaml.Node) error {
-	type alias BGPConfig // break recursion
-	aux := struct {
-		*alias             `yaml:",inline"`
-		UseV2MIBDeprecated *bool `yaml:"use_v2_mib"`
-	}{alias: (*alias)(c)}
-	if err := value.Decode(&aux); err != nil {
-		return err
-	}
-	if aux.UseV2MIBDeprecated != nil {
-		// Operator set the old key. Translate: old=false means "disable v2",
-		// so flip DisableV2MIB on (unless the new key already set it).
-		if !*aux.UseV2MIBDeprecated && !c.DisableV2MIB {
-			c.DisableV2MIB = true
-		}
-		c.useV2MIBDeprecated = aux.UseV2MIBDeprecated
-	}
-	return nil
 }
 
 // ModulesConfig toggles individual discovery modules. Each module's spec
@@ -386,13 +298,18 @@ type TargetConfig struct {
 }
 
 // Load parses the configuration file at path and applies defaults.
+// Unknown YAML keys are rejected (KnownFields mode) so that removed
+// deprecated keys produce a clear parse error rather than being silently
+// ignored.
 func Load(path string) (*Config, error) {
 	b, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("read config %q: %w", path, err)
 	}
 	var c Config
-	if err := yaml.Unmarshal(b, &c); err != nil {
+	dec := yaml.NewDecoder(strings.NewReader(string(b)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parse config %q: %w", path, err)
 	}
 	c.applyDefaults()
@@ -461,28 +378,9 @@ func (c *Config) applyDefaults() {
 }
 
 func (c *Config) validateListen() error {
-	webCfgSet := c.Listen.WebConfigFile != ""
-	certSet := c.Listen.TLSCertFile != ""
-	keySet := c.Listen.TLSKeyFile != ""
-
-	if webCfgSet && (certSet || keySet) {
-		return errors.New("listen.web_config_file conflicts with deprecated listen.tls_cert_file/listen.tls_key_file — set web_config_file only")
-	}
-	if webCfgSet {
+	if c.Listen.WebConfigFile != "" {
 		if _, err := os.Stat(c.Listen.WebConfigFile); err != nil {
 			return fmt.Errorf("listen.web_config_file %q: %w", c.Listen.WebConfigFile, err)
-		}
-		return nil
-	}
-	if certSet != keySet {
-		return errors.New("listen.tls_cert_file and listen.tls_key_file must both be set or both be empty")
-	}
-	if certSet {
-		if _, err := os.Stat(c.Listen.TLSCertFile); err != nil {
-			return fmt.Errorf("listen.tls_cert_file %q: %w", c.Listen.TLSCertFile, err)
-		}
-		if _, err := os.Stat(c.Listen.TLSKeyFile); err != nil {
-			return fmt.Errorf("listen.tls_key_file %q: %w", c.Listen.TLSKeyFile, err)
 		}
 	}
 	return nil
@@ -847,61 +745,13 @@ func (c *Config) validateFDB() error {
 	return nil
 }
 
-// EmitDeprecationWarnings logs a slog.Warn for each legacy YAML key the
-// operator set during Load. Call once at startup after Load. Returns true if
-// any deprecation warning was emitted (handy for tests).
-//
-// Remove this function in v1.5.0 along with the transitional UnmarshalYAML
-// methods on FederationHubConfig and BGPConfig.
-func (c *Config) EmitDeprecationWarnings(logger *slog.Logger) bool {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	emitted := false
-	if c.Federation.Hub.strictDeviceNameMatchingDeprecated != nil {
-		logger.Warn("config: federation.hub.strict_device_name_matching is deprecated and will be removed in v1.5.0; use loose_device_name_matching (default false = strict; set to true to enable domain-suffix stripping)",
-			"deprecated_key", "strict_device_name_matching",
-			"replacement_key", "loose_device_name_matching",
-			"deprecated_value", *c.Federation.Hub.strictDeviceNameMatchingDeprecated,
-			"effective_loose_device_name_matching", c.Federation.Hub.LooseDeviceNameMatching,
-		)
-		emitted = true
-	}
-	if c.Modules.BGP.useV2MIBDeprecated != nil {
-		logger.Warn("config: modules.bgp.use_v2_mib is deprecated and will be removed in v1.5.0; use disable_v2_mib (default false = v2 enabled; set to true to disable v2 walkers)",
-			"deprecated_key", "use_v2_mib",
-			"replacement_key", "disable_v2_mib",
-			"deprecated_value", *c.Modules.BGP.useV2MIBDeprecated,
-			"effective_disable_v2_mib", c.Modules.BGP.DisableV2MIB,
-		)
-		emitted = true
-	}
-	if c.Listen.TLSCertFile != "" || c.Listen.TLSKeyFile != "" {
-		logger.Warn("config: listen.tls_cert_file / listen.tls_key_file are deprecated and will be removed in v1.5.0; migrate to listen.web_config_file (Prometheus exporter-toolkit web-config YAML) which adds basic_auth and mTLS support — see docs/operator/security.md",
-			"deprecated_keys", "tls_cert_file,tls_key_file",
-			"replacement_key", "web_config_file",
-		)
-		emitted = true
-	}
-	return emitted
-}
-
-// HasDeprecatedListenTLS reports whether the operator set the legacy
-// `listen.tls_cert_file` or `listen.tls_key_file` keys. Test helper.
-func (c *Config) HasDeprecatedListenTLS() bool {
-	return c.Listen.TLSCertFile != "" || c.Listen.TLSKeyFile != ""
-}
-
-// HasDeprecatedFederationHubStrict reports whether the operator set the
-// legacy `strict_device_name_matching` YAML key. Test helper.
-func (c *Config) HasDeprecatedFederationHubStrict() bool {
-	return c.Federation.Hub.strictDeviceNameMatchingDeprecated != nil
-}
-
-// HasDeprecatedBGPUseV2MIB reports whether the operator set the legacy
-// `use_v2_mib` YAML key. Test helper.
-func (c *Config) HasDeprecatedBGPUseV2MIB() bool {
-	return c.Modules.BGP.useV2MIBDeprecated != nil
+// EmitDeprecationWarnings is a no-op stub retained so call-sites in main
+// continue to compile without modification. All three deprecated config keys
+// (use_v2_mib, strict_device_name_matching, tls_cert_file/tls_key_file) were
+// removed in v1.5.0; the YAML loader now rejects them with a parse error.
+// Returns false always.
+func (c *Config) EmitDeprecationWarnings(_ *slog.Logger) bool {
+	return false
 }
 
 func cidrContainsAny(nets []*net.IPNet, ip net.IP) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1492,9 +1491,9 @@ func TestListenAddrDefault(t *testing.T) {
 	}
 }
 
-// TestListenTLSCertWithoutKey verifies that setting tls_cert_file without
-// tls_key_file causes Load to return an error.
-func TestListenTLSCertWithoutKey(t *testing.T) {
+// TestListenTLSCertFileRemovedKey verifies that the removed tls_cert_file key
+// produces a parse error (removed in v1.5.0; use listen.web_config_file).
+func TestListenTLSCertFileRemovedKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	body := `
@@ -1506,13 +1505,13 @@ listen:
 	}
 	_, err := Load(path)
 	if err == nil {
-		t.Fatal("expected error when tls_cert_file set without tls_key_file, got nil")
+		t.Fatal("expected parse error for removed key tls_cert_file, got nil")
 	}
 }
 
-// TestListenTLSKeyWithoutCert verifies that setting tls_key_file without
-// tls_cert_file causes Load to return an error.
-func TestListenTLSKeyWithoutCert(t *testing.T) {
+// TestListenTLSKeyFileRemovedKey verifies that the removed tls_key_file key
+// produces a parse error (removed in v1.5.0; use listen.web_config_file).
+func TestListenTLSKeyFileRemovedKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	body := `
@@ -1524,13 +1523,13 @@ listen:
 	}
 	_, err := Load(path)
 	if err == nil {
-		t.Fatal("expected error when tls_key_file set without tls_cert_file, got nil")
+		t.Fatal("expected parse error for removed key tls_key_file, got nil")
 	}
 }
 
-// TestListenTLSBothSetButMissing verifies that providing non-existent TLS
-// file paths causes Load to return an error.
-func TestListenTLSBothSetButMissing(t *testing.T) {
+// TestListenTLSBothRemovedKeys verifies that using both removed tls_cert_file
+// and tls_key_file keys produces a parse error (removed in v1.5.0).
+func TestListenTLSBothRemovedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	body := `
@@ -1543,34 +1542,7 @@ listen:
 	}
 	_, err := Load(path)
 	if err == nil {
-		t.Fatal("expected error for non-existent TLS files, got nil")
-	}
-}
-
-// TestListenTLSBothSetAndExist verifies that providing existing (dummy) TLS
-// files passes validation.
-func TestListenTLSBothSetAndExist(t *testing.T) {
-	dir := t.TempDir()
-	certPath := filepath.Join(dir, "cert.pem")
-	keyPath := filepath.Join(dir, "key.pem")
-	if err := os.WriteFile(certPath, []byte("dummy cert"), 0o600); err != nil {
-		t.Fatalf("write cert: %v", err)
-	}
-	if err := os.WriteFile(keyPath, []byte("dummy key"), 0o600); err != nil {
-		t.Fatalf("write key: %v", err)
-	}
-
-	cfgPath := filepath.Join(dir, "config.yaml")
-	body := "listen:\n  tls_cert_file: " + certPath + "\n  tls_key_file: " + keyPath + "\n"
-	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("expected valid config with existing TLS files, got: %v", err)
-	}
-	if c.Listen.TLSCertFile != certPath {
-		t.Errorf("TLSCertFile = %q, want %q", c.Listen.TLSCertFile, certPath)
+		t.Fatal("expected parse error for removed keys tls_cert_file/tls_key_file, got nil")
 	}
 }
 
@@ -1610,11 +1582,10 @@ func TestListenWebConfigFileMissingFails(t *testing.T) {
 	}
 }
 
-// TestListenWebConfigFileConflictsWithLegacyTLS verifies that setting BOTH
-// web_config_file AND the deprecated tls_cert_file/tls_key_file is rejected
-// at config load — there is one correct way to configure listener auth and
-// the operator must pick.
-func TestListenWebConfigFileConflictsWithLegacyTLS(t *testing.T) {
+// TestListenWebConfigFileWithLegacyTLSRejected verifies that setting
+// tls_cert_file/tls_key_file alongside web_config_file is rejected — these
+// keys were removed in v1.5.0 and produce a parse error regardless.
+func TestListenWebConfigFileWithLegacyTLSRejected(t *testing.T) {
 	dir := t.TempDir()
 	webCfgPath := filepath.Join(dir, "web-config.yml")
 	certPath := filepath.Join(dir, "cert.pem")
@@ -1630,23 +1601,23 @@ func TestListenWebConfigFileConflictsWithLegacyTLS(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 	if _, err := Load(cfgPath); err == nil {
-		t.Fatal("expected error when web_config_file is set alongside legacy tls fields, got nil")
+		t.Fatal("expected error when removed tls_cert_file/tls_key_file keys are present, got nil")
 	}
 }
 
-// TestListenDeprecatedTLSEmitsWarning verifies that EmitDeprecationWarnings
-// fires when the legacy tls_cert_file/tls_key_file fields are set.
-func TestListenDeprecatedTLSEmitsWarning(t *testing.T) {
+// TestListenTLSRemovedKeysEmitNoWarning verifies that EmitDeprecationWarnings
+// is a no-op now that all deprecated TLS keys have been removed in v1.5.0.
+func TestListenTLSRemovedKeysEmitNoWarning(t *testing.T) {
+	// Only web_config_file (the current API) is used here — the old
+	// tls_cert_file/tls_key_file keys would cause a parse error so we
+	// cannot construct a config that uses them and still calls Load.
 	dir := t.TempDir()
-	certPath := filepath.Join(dir, "cert.pem")
-	keyPath := filepath.Join(dir, "key.pem")
-	for _, p := range []string{certPath, keyPath} {
-		if err := os.WriteFile(p, []byte("dummy"), 0o600); err != nil {
-			t.Fatalf("write %s: %v", p, err)
-		}
+	webCfgPath := filepath.Join(dir, "web-config.yml")
+	if err := os.WriteFile(webCfgPath, []byte("# empty\n"), 0o600); err != nil {
+		t.Fatalf("write web-config: %v", err)
 	}
 	cfgPath := filepath.Join(dir, "config.yaml")
-	body := "listen:\n  tls_cert_file: " + certPath + "\n  tls_key_file: " + keyPath + "\n"
+	body := "listen:\n  web_config_file: " + webCfgPath + "\n"
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1654,16 +1625,8 @@ func TestListenDeprecatedTLSEmitsWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if !c.HasDeprecatedListenTLS() {
-		t.Fatal("HasDeprecatedListenTLS() = false, want true")
-	}
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	if !c.EmitDeprecationWarnings(logger) {
-		t.Error("EmitDeprecationWarnings returned false; expected a warning for the deprecated TLS keys")
-	}
-	if !strings.Contains(buf.String(), "tls_cert_file") {
-		t.Errorf("warning did not mention tls_cert_file; output: %s", buf.String())
+	if c.EmitDeprecationWarnings(nil) {
+		t.Error("EmitDeprecationWarnings returned true; expected false (no deprecated keys remain)")
 	}
 }
 
@@ -1680,10 +1643,10 @@ func TestListenTLSNeitherSet(t *testing.T) {
 	}
 }
 
-// TestListenTLSCertExistsKeyMissing verifies that when both tls_cert_file and
-// tls_key_file are provided but the key file does not exist on disk, Load
-// returns an error (covering the tls_key_file os.Stat branch).
-func TestListenTLSCertExistsKeyMissing(t *testing.T) {
+// TestListenTLSCertExistsKeyMissingRemovedKey verifies that using the removed
+// tls_cert_file/tls_key_file keys always produces a parse error (removed in
+// v1.5.0), regardless of whether the referenced files exist.
+func TestListenTLSCertExistsKeyMissingRemovedKey(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "cert.pem")
 	if err := os.WriteFile(certPath, []byte("dummy cert"), 0o600); err != nil {
@@ -1697,7 +1660,7 @@ func TestListenTLSCertExistsKeyMissing(t *testing.T) {
 	}
 	_, err := Load(cfgPath)
 	if err == nil {
-		t.Fatal("expected error when tls_key_file does not exist, got nil")
+		t.Fatal("expected parse error for removed keys tls_cert_file/tls_key_file, got nil")
 	}
 }
 
@@ -2110,9 +2073,6 @@ func TestLooseDeviceNameMatchingNewKey(t *testing.T) {
 	if !c.Federation.Hub.LooseDeviceNameMatching {
 		t.Errorf("LooseDeviceNameMatching = false, want true")
 	}
-	if c.HasDeprecatedFederationHubStrict() {
-		t.Errorf("HasDeprecatedFederationHubStrict = true, want false (new key was used)")
-	}
 }
 
 // TestLooseDeviceNameMatchingNewKeyDefault: omitting the key yields strict
@@ -2130,50 +2090,33 @@ func TestLooseDeviceNameMatchingNewKeyDefault(t *testing.T) {
 	if c.Federation.Hub.LooseDeviceNameMatching {
 		t.Errorf("LooseDeviceNameMatching = true, want false (default = strict)")
 	}
-	if c.HasDeprecatedFederationHubStrict() {
-		t.Errorf("HasDeprecatedFederationHubStrict = true, want false (no key was set)")
-	}
 }
 
-// TestStrictDeviceNameMatchingDeprecatedOldKeyTrue: the legacy key set to true
-// (i.e. operator asks for strict) leaves LooseDeviceNameMatching=false and
-// flags the deprecation.
-func TestStrictDeviceNameMatchingDeprecatedOldKeyTrue(t *testing.T) {
+// TestStrictDeviceNameMatchingRemovedKeyTrue: the removed key strict_device_name_matching=true
+// must produce a parse error (removed in v1.5.0; use loose_device_name_matching instead).
+func TestStrictDeviceNameMatchingRemovedKeyTrue(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("federation:\n  hub:\n    strict_device_name_matching: true\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if c.Federation.Hub.LooseDeviceNameMatching {
-		t.Errorf("LooseDeviceNameMatching = true, want false (old strict=true → new loose=false)")
-	}
-	if !c.HasDeprecatedFederationHubStrict() {
-		t.Errorf("HasDeprecatedFederationHubStrict = false, want true (deprecated key was set)")
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected parse error for removed key strict_device_name_matching, got nil")
 	}
 }
 
-// TestStrictDeviceNameMatchingDeprecatedOldKeyFalse: the legacy key set to
-// false (i.e. operator asks for loose) flips LooseDeviceNameMatching to true
-// and flags the deprecation.
-func TestStrictDeviceNameMatchingDeprecatedOldKeyFalse(t *testing.T) {
+// TestStrictDeviceNameMatchingRemovedKeyFalse: the removed key strict_device_name_matching=false
+// must produce a parse error (removed in v1.5.0; use loose_device_name_matching instead).
+func TestStrictDeviceNameMatchingRemovedKeyFalse(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("federation:\n  hub:\n    strict_device_name_matching: false\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if !c.Federation.Hub.LooseDeviceNameMatching {
-		t.Errorf("LooseDeviceNameMatching = false, want true (old strict=false → new loose=true)")
-	}
-	if !c.HasDeprecatedFederationHubStrict() {
-		t.Errorf("HasDeprecatedFederationHubStrict = false, want true (deprecated key was set)")
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected parse error for removed key strict_device_name_matching, got nil")
 	}
 }
 
@@ -2197,9 +2140,6 @@ func TestDisableV2MIBNewKey(t *testing.T) {
 	if !c.Modules.BGP.DisableV2MIB {
 		t.Errorf("DisableV2MIB = false, want true")
 	}
-	if c.HasDeprecatedBGPUseV2MIB() {
-		t.Errorf("HasDeprecatedBGPUseV2MIB = true, want false (new key was used)")
-	}
 }
 
 // TestDisableV2MIBNewKeyDefault: omitting the key yields v2 enabled (the safe
@@ -2217,90 +2157,70 @@ func TestDisableV2MIBNewKeyDefault(t *testing.T) {
 	if c.Modules.BGP.DisableV2MIB {
 		t.Errorf("DisableV2MIB = true, want false (default = v2 enabled)")
 	}
-	if c.HasDeprecatedBGPUseV2MIB() {
-		t.Errorf("HasDeprecatedBGPUseV2MIB = true, want false (no key was set)")
-	}
 }
 
-// TestUseV2MIBDeprecatedOldKeyTrue: the legacy key set to true (operator asks
-// for v2 enabled) leaves DisableV2MIB=false and flags the deprecation.
-func TestUseV2MIBDeprecatedOldKeyTrue(t *testing.T) {
+// TestUseV2MIBRemovedKeyTrue: the removed key use_v2_mib=true must produce a
+// parse error (removed in v1.5.0; use disable_v2_mib instead).
+func TestUseV2MIBRemovedKeyTrue(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("modules:\n  bgp:\n    use_v2_mib: true\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if c.Modules.BGP.DisableV2MIB {
-		t.Errorf("DisableV2MIB = true, want false (old use_v2_mib=true → new disable_v2_mib=false)")
-	}
-	if !c.HasDeprecatedBGPUseV2MIB() {
-		t.Errorf("HasDeprecatedBGPUseV2MIB = false, want true (deprecated key was set)")
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected parse error for removed key use_v2_mib, got nil")
 	}
 }
 
-// TestUseV2MIBDeprecatedOldKeyFalse: the legacy key set to false (operator
-// asks to disable v2) flips DisableV2MIB to true and flags the deprecation.
-func TestUseV2MIBDeprecatedOldKeyFalse(t *testing.T) {
+// TestUseV2MIBRemovedKeyFalse: the removed key use_v2_mib=false must produce
+// a parse error (removed in v1.5.0; use disable_v2_mib instead).
+func TestUseV2MIBRemovedKeyFalse(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte("modules:\n  bgp:\n    use_v2_mib: false\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if !c.Modules.BGP.DisableV2MIB {
-		t.Errorf("DisableV2MIB = false, want true (old use_v2_mib=false → new disable_v2_mib=true)")
-	}
-	if !c.HasDeprecatedBGPUseV2MIB() {
-		t.Errorf("HasDeprecatedBGPUseV2MIB = false, want true (deprecated key was set)")
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected parse error for removed key use_v2_mib, got nil")
 	}
 }
 
-// TestEmitDeprecationWarningsFiresForBothKeys verifies that
-// EmitDeprecationWarnings logs a warning for each deprecated key the
-// operator set during Load, and returns true when any warning was emitted.
-func TestEmitDeprecationWarningsFiresForBothKeys(t *testing.T) {
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	body := "" +
-		"federation:\n" +
-		"  hub:\n" +
-		"    strict_device_name_matching: false\n" +
-		"modules:\n" +
-		"  bgp:\n" +
-		"    use_v2_mib: false\n"
-	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
+// TestRemovedKeysProduceParseError verifies that configs using any of the three
+// removed deprecated keys (strict_device_name_matching, use_v2_mib,
+// tls_cert_file, tls_key_file) produce a parse error from Load (removed in
+// v1.5.0; the YAML loader uses KnownFields(true) to enforce this).
+func TestRemovedKeysProduceParseError(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "strict_device_name_matching with use_v2_mib",
+			yaml: "federation:\n  hub:\n    strict_device_name_matching: false\nmodules:\n  bgp:\n    use_v2_mib: false\n",
+		},
+		{
+			name: "strict_device_name_matching alone",
+			yaml: "federation:\n  hub:\n    strict_device_name_matching: true\n",
+		},
+		{
+			name: "use_v2_mib alone",
+			yaml: "modules:\n  bgp:\n    use_v2_mib: true\n",
+		},
 	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-
-	var buf strings.Builder
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	emitted := c.EmitDeprecationWarnings(logger)
-	if !emitted {
-		t.Fatal("EmitDeprecationWarnings returned false; expected true (two deprecated keys set)")
-	}
-	logged := buf.String()
-	if !strings.Contains(logged, "strict_device_name_matching") {
-		t.Errorf("expected log to mention strict_device_name_matching; got:\n%s", logged)
-	}
-	if !strings.Contains(logged, "loose_device_name_matching") {
-		t.Errorf("expected log to mention loose_device_name_matching; got:\n%s", logged)
-	}
-	if !strings.Contains(logged, "use_v2_mib") {
-		t.Errorf("expected log to mention use_v2_mib; got:\n%s", logged)
-	}
-	if !strings.Contains(logged, "disable_v2_mib") {
-		t.Errorf("expected log to mention disable_v2_mib; got:\n%s", logged)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			_, err := Load(cfgPath)
+			if err == nil {
+				t.Fatalf("expected parse error for removed deprecated key(s), got nil")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Removes the three config keys deprecated in v1.4.0 and promised for removal in v1.5.0. **Breaking** for any config still setting them.

- **#60** `modules.bgp.use_v2_mib` removed → use `modules.bgp.disable_v2_mib`.
- **#61** `federation.hub.strict_device_name_matching` removed → use `federation.hub.loose_device_name_matching`.
- **#62** `listen.tls_cert_file` / `listen.tls_key_file` removed → use `listen.web_config_file`; the direct `srv.ListenAndServeTLS` path is gone (all TLS via the exporter-toolkit `web.ListenAndServe`).

**Mechanism / broader effect:** config loading now decodes with `KnownFields(true)`, so the removed keys (and **any** unknown key) produce a clear parse error instead of being silently ignored. Verified that `config/example.yaml` and both `deploy/` configs still load.

Tests for the deprecated keys are flipped to assert parse errors. `EmitDeprecationWarnings` is retained as a no-op stub to avoid touching app startup. `go build ./...` and `go test ./...` pass.

Closes #60, #61, #62.