### PR TITLE
Admin endpoint: POST /admin/rediscover for forced out-of-cycle walks (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,27 @@ v1.3.1 lands under this milestone instead, renamed to
   cost without coverage. README BGP vendor-coverage table updated to
   describe what was validated where. Closes #58.
 
+### Operability
+
+- **Admin endpoint for forced out-of-cycle re-discovery.** New
+  `POST /admin/rediscover` on the existing listen port accepts a JSON body
+  `{"targets":["10.0.0.1","10.0.0.2"]}` and triggers an immediate SNMP walk
+  against the listed IPs, so an operator who has just fixed a device's SNMP
+  config (community, ACL, snmpd) can confirm the fix without waiting up to a
+  full `discovery.interval`. The response reports a per-target outcome
+  (`success` / `timeout` / `auth_failure` / `out_of_scope` / `error`) and the
+  resulting edge count. The endpoint is **privileged**: it is only exposed when
+  `listen.web_config_file` configures `basic_auth`/mTLS, and returns **403**
+  otherwise — unlike `/metrics`, the default no-auth ground state does not
+  expose it. Targets outside `discovery.scope.cidr_allow_list` are rejected
+  with HTTP 400 (no scope expansion via the admin call, LD-11). The forced
+  walk is serialised against the regular discovery cycle (shared cycle mutex)
+  so it cannot race or corrupt a running cycle; it reports results to the
+  caller but does not itself publish into the live graph — the corrected
+  device's edges land in `/metrics` on the next regular cycle. New audit metric
+  `network_topology_admin_rediscovery_total{outcome}`. See
+  `docs/operator/troubleshooting.md` § 4a. Closes #73.
+
 ### Documentation
 
 - **Threat model document** — New `docs/operator/threat-model.md` with a

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -86,6 +86,41 @@ See [cold-start-credentials.md](cold-start-credentials.md) for guidance on initi
 
 ---
 
+## 4a. I just fixed a device's SNMP config — how do I re-poll it without waiting?
+
+**Situation:** You corrected a community string, opened an ACL, or restarted snmpd on a device, and you want the exporter to re-walk that device *now* instead of waiting up to a full `discovery.interval` for the next regular cycle.
+
+Use the admin re-discovery endpoint:
+
+```
+curl -sS -u admin:secret -X POST http://localhost:9100/admin/rediscover \
+  -H 'Content-Type: application/json' \
+  -d '{"targets":["10.0.0.1","10.0.0.2"]}'
+```
+
+The endpoint triggers an out-of-cycle SNMP walk against each listed IP and returns a per-target outcome plus the resulting edge count:
+
+```json
+{
+  "results": [
+    {"target":"10.0.0.1","outcome":"success","edges":4},
+    {"target":"10.0.0.2","outcome":"auth_failure","error":"..."}
+  ]
+}
+```
+
+Outcomes are `success`, `timeout`, `auth_failure`, `out_of_scope`, or `error`. Every call also increments `network_topology_admin_rediscovery_total{outcome="..."}` for auditing.
+
+**Important behaviour:**
+
+- **Auth is mandatory.** The endpoint is privileged and is only exposed when `listen.web_config_file` configures `basic_auth` and/or mTLS (the same Prometheus exporter-toolkit web-config you use to protect `/metrics`). If no auth is configured the endpoint returns **403** and runs nothing — unlike `/metrics`, the default no-auth ground state does **not** expose this endpoint.
+- **No scope expansion.** A target outside `discovery.scope.cidr_allow_list` is rejected with HTTP 400 / outcome `out_of_scope`. The admin call cannot poll anything the regular cycle wouldn't (LD-11).
+- **It does not corrupt a running cycle.** The forced walk is serialised against the regular discovery cycle, so the two never poll devices concurrently. The forced walk only *reports* its result to you; it does **not** publish into the live graph. The corrected device's edges appear in `/metrics` on the next regular cycle (which now succeeds because you fixed the config). Use the endpoint to *confirm the fix works* and to *audit* it — the visible topology still updates on the normal cycle boundary.
+
+If the outcome is `auth_failure` or `timeout`, the fix did not take — re-check the device against [§4 Credential failures](#4-credential-failures) and [§3 SNMP timeouts and walk failures](#3-snmp-timeouts-and-walk-failures).
+
+---
+
 ## 5. Discovery cycle too slow
 
 **Symptom:** `network_topology_discovery_cycle_duration_seconds` P99 exceeds `discovery.interval`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/app/httpx"
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/federation"
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
@@ -201,6 +203,23 @@ func Run(ctx context.Context, args []string) int {
 			otlpSem = make(chan struct{}, MaxOTLPPushConcurrency)
 		}
 
+		// Issue #73: admin out-of-cycle re-discovery. cycleMu serialises forced
+		// walks against the regular cycle (shared with LoopConfig.CycleMu). The
+		// Rediscoverer carries its own credential resolver built from the same
+		// config; access to either resolver is serialised by cycleMu, so the
+		// two paths never hit a device concurrently. The endpoint is privileged:
+		// it only runs when listen.web_config_file configures basic_auth/mTLS,
+		// otherwise the handler returns 403.
+		var cycleMu sync.Mutex
+		adminResolver, err := credentials.New(cfg.Credentials)
+		if err != nil {
+			logger.Error("building admin rediscover credential resolver", "error", err)
+			return 1
+		}
+		allowedNets := snmpwalk.ParseCIDRs(cfg.Discovery.Scope.CIDRAllowList)
+		rediscoverer := NewRediscoverer(cfg, m, logger, adminResolver, allowedNets, &cycleMu, cfg.Listen.WebConfigFile != "")
+		mux.HandleFunc("/admin/rediscover", httpx.NewRediscoverHandler(rediscoverer))
+
 		workerDone.Add(1)
 		go func() {
 			defer workerDone.Done()
@@ -217,6 +236,7 @@ func Run(ctx context.Context, args []string) int {
 				OtlpExp:       otlpExp,
 				OtlpSem:       otlpSem,
 				OtlpWg:        &otlpWg,
+				CycleMu:       &cycleMu,
 			})
 		}()
 	}

--- a/internal/app/httpx/httpx.go
+++ b/internal/app/httpx/httpx.go
@@ -9,6 +9,8 @@ package httpx
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -17,6 +19,80 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// Rediscoverer is the admin-rediscover capability NewRediscoverHandler drives.
+// It is satisfied by *app.Rediscoverer; declared here as an interface so this
+// package does not import app (app already imports httpx).
+type Rediscoverer interface {
+	// AuthConfigured reports whether the listener is auth-gated. When false the
+	// handler fails closed with 403 — the endpoint is privileged and the
+	// default no-auth ground state must not expose it.
+	AuthConfigured() bool
+	// RediscoverResults runs forced out-of-cycle walks against the given target
+	// IPs and returns one result per target. The concrete element type is
+	// app.RediscoverResult; the handler only needs each element to be
+	// JSON-serialisable, so the interface returns []any to avoid an import edge
+	// (app already imports httpx).
+	RediscoverResults(ctx context.Context, targets []string) []any
+}
+
+// rediscoverRequest is the JSON body of POST /admin/rediscover.
+type rediscoverRequest struct {
+	Targets []string `json:"targets"`
+}
+
+// MaxRediscoverTargets caps the number of targets one admin request may force.
+// Keeps a single privileged call from monopolising the discovery mutex.
+const MaxRediscoverTargets = 256
+
+// NewRediscoverHandler returns the POST /admin/rediscover handler (issue #73).
+//
+// Auth model: the endpoint is privileged. When auth is configured
+// (listen.web_config_file set), the Prometheus exporter-toolkit has already
+// authenticated the request at the listener before it reaches this handler, so
+// reaching here means the caller is authorised. When NO auth is configured the
+// handler returns 403 — unlike /metrics, which is default-trust, this endpoint
+// refuses to run in an unauthenticated ground state so a forced SNMP walk can
+// never be triggered anonymously.
+func NewRediscoverHandler(rd Rediscoverer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed; use POST")
+			return
+		}
+		if !rd.AuthConfigured() {
+			writeJSONError(w, http.StatusForbidden,
+				"admin endpoint disabled: no auth configured. Set listen.web_config_file (basic_auth or mTLS) to enable /admin/rediscover.")
+			return
+		}
+		var req rediscoverRequest
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+		if len(req.Targets) == 0 {
+			writeJSONError(w, http.StatusBadRequest, `body must contain a non-empty "targets" array`)
+			return
+		}
+		if len(req.Targets) > MaxRediscoverTargets {
+			writeJSONError(w, http.StatusBadRequest,
+				fmt.Sprintf("too many targets: %d (max %d)", len(req.Targets), MaxRediscoverTargets))
+			return
+		}
+
+		results := rd.RediscoverResults(r.Context(), req.Targets)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
 
 // CycleStatus is the most recent discovery cycle's outcome surfaced by
 // /healthz. It is written by the discovery loop after each cycle and

--- a/internal/app/httpx/rediscover_test.go
+++ b/internal/app/httpx/rediscover_test.go
@@ -1,0 +1,114 @@
+package httpx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeRediscoverer is a test double for the httpx.Rediscoverer interface.
+type fakeRediscoverer struct {
+	authConfigured bool
+	gotTargets     []string
+	results        []any
+}
+
+func (f *fakeRediscoverer) AuthConfigured() bool { return f.authConfigured }
+
+func (f *fakeRediscoverer) RediscoverResults(_ context.Context, targets []string) []any {
+	f.gotTargets = targets
+	return f.results
+}
+
+func postJSON(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/admin/rediscover", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestRediscoverHandlerNoAuthReturns403 verifies the privileged-endpoint
+// contract: with no auth configured the handler must refuse (403) and never
+// touch the Rediscoverer. Unlike /metrics, the default no-auth ground state
+// does not expose this endpoint.
+func TestRediscoverHandlerNoAuthReturns403(t *testing.T) {
+	fake := &fakeRediscoverer{authConfigured: false}
+	h := NewRediscoverHandler(fake)
+
+	rec := postJSON(t, h, `{"targets":["10.0.0.1"]}`)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if fake.gotTargets != nil {
+		t.Errorf("Rediscover was called despite no auth configured: %v", fake.gotTargets)
+	}
+}
+
+// TestRediscoverHandlerHappyPath verifies that with auth configured a valid
+// POST reaches the Rediscoverer and the per-target results are echoed back.
+func TestRediscoverHandlerHappyPath(t *testing.T) {
+	fake := &fakeRediscoverer{
+		authConfigured: true,
+		results: []any{
+			map[string]any{"target": "10.0.0.1", "outcome": "success", "edges": 2},
+		},
+	}
+	h := NewRediscoverHandler(fake)
+
+	rec := postJSON(t, h, `{"targets":["10.0.0.1"]}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if len(fake.gotTargets) != 1 || fake.gotTargets[0] != "10.0.0.1" {
+		t.Errorf("targets passed to Rediscover = %v, want [10.0.0.1]", fake.gotTargets)
+	}
+	var resp struct {
+		Results []map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not valid JSON: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0]["outcome"] != "success" {
+		t.Errorf("results = %v, want one success", resp.Results)
+	}
+}
+
+// TestRediscoverHandlerRejectsGET verifies non-POST methods are refused.
+func TestRediscoverHandlerRejectsGET(t *testing.T) {
+	h := NewRediscoverHandler(&fakeRediscoverer{authConfigured: true})
+	req := httptest.NewRequest(http.MethodGet, "/admin/rediscover", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+// TestRediscoverHandlerEmptyAndBadBody verifies request-body validation: an
+// empty targets array and malformed JSON both yield 400 without invoking the
+// Rediscoverer.
+func TestRediscoverHandlerEmptyAndBadBody(t *testing.T) {
+	for name, body := range map[string]string{
+		"empty targets": `{"targets":[]}`,
+		"not json":      `{not json`,
+		"unknown field": `{"targets":["10.0.0.1"],"bogus":1}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeRediscoverer{authConfigured: true}
+			h := NewRediscoverHandler(fake)
+			rec := postJSON(t, h, body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if fake.gotTargets != nil {
+				t.Errorf("Rediscover called on bad request: %v", fake.gotTargets)
+			}
+		})
+	}
+}

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -59,6 +59,13 @@ type LoopConfig struct {
 	OtlpExp       *otlp.Exporter
 	OtlpSem       chan struct{}   // semaphore bounding concurrent OTLP pushes; nil when OTLP disabled
 	OtlpWg        *sync.WaitGroup // tracks in-flight OTLP push goroutines for clean shutdown
+	// CycleMu serialises each regular discovery cycle against forced
+	// out-of-cycle walks triggered via POST /admin/rediscover (issue #73).
+	// Held only for the duration of RunCycle's SNMP work; the Rediscoverer
+	// acquires the same mutex so the two paths never walk devices concurrently.
+	// May be nil (e.g. in unit tests that drive the loop without the admin
+	// endpoint); a nil mutex means "no serialisation needed".
+	CycleMu *sync.Mutex
 }
 
 // WarnSnapshot rate-limits chronic snapshot Warns via lc.WarnLimiter,
@@ -234,7 +241,16 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 		cycleNum++
 		lc.M.GoRoutines.Set(float64(runtime.NumGoroutine()))
 		start := time.Now()
+		// Serialise the cycle's SNMP work against forced out-of-cycle walks
+		// (issue #73): the Rediscoverer holds the same mutex, so a regular
+		// cycle and an admin rediscover never walk devices concurrently.
+		if lc.CycleMu != nil {
+			lc.CycleMu.Lock()
+		}
 		newGraph, newAges, conflicts, deviceErrors := RunCycle(ctx, lc.Logger, lc.Cfg, lc.M, lc.WalkerMetrics, lc.WarnLimiter, resolver, allowedNets, ages)
+		if lc.CycleMu != nil {
+			lc.CycleMu.Unlock()
+		}
 		if ctx.Err() != nil {
 			return
 		}

--- a/internal/app/rediscover.go
+++ b/internal/app/rediscover.go
@@ -1,0 +1,274 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/bgp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/cdp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/fdb"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/isis"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/lldp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/mpls"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/ospf"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// RediscoverOutcome is the per-target result of a forced out-of-cycle walk.
+// The underlying strings double as the `outcome` label on
+// network_topology_admin_rediscovery_total, so changing them is a metric
+// contract change.
+type RediscoverOutcome string
+
+// RediscoverOutcome values: one per terminal state a single target walk can
+// reach. out_of_scope is decided before any SNMP packet is sent.
+const (
+	RediscoverSuccess     RediscoverOutcome = "success"
+	RediscoverTimeout     RediscoverOutcome = "timeout"
+	RediscoverAuthFailure RediscoverOutcome = "auth_failure"
+	RediscoverOutOfScope  RediscoverOutcome = "out_of_scope"
+	RediscoverError       RediscoverOutcome = "error"
+)
+
+// RediscoverResult is the structured per-target outcome returned to the admin
+// caller (and serialised to JSON by the HTTP handler).
+type RediscoverResult struct {
+	Target  string            `json:"target"`
+	Outcome RediscoverOutcome `json:"outcome"`
+	Edges   int               `json:"edges"`
+	Error   string            `json:"error,omitempty"`
+}
+
+// Rediscoverer triggers out-of-cycle SNMP walks against individual in-scope
+// targets in response to the admin endpoint (issue #73). It is intentionally
+// read-only with respect to the published graph: a forced walk reports its
+// per-target edge count to the caller but does NOT mutate prevGraph, the
+// snapshot, or the unconfirmed-age counters owned by RunDiscoveryLoop. Those
+// remain the exclusive property of the regular cycle, so the out-of-cycle walk
+// cannot corrupt the published topology. The forced result becomes visible in
+// /metrics on the next regular cycle, which will re-walk the (now fixed)
+// device. See docs/operator/troubleshooting.md.
+//
+// Concurrency: every forced walk and every regular cycle acquire the same
+// CycleMu, so SNMP discovery is fully serialised across the two paths — they
+// never hit the credential resolver or the device concurrently, and there is
+// no data race on resolver cache state. The trade-off is that a forced walk
+// can block for up to one regular cycle (and vice versa); this is acceptable
+// for a rare, operator-initiated admin call and avoids the invasive work of
+// threading a priority queue through the parallelism pool.
+type Rediscoverer struct {
+	cfg         *config.Config
+	m           *metrics.Metrics
+	logger      *slog.Logger
+	resolver    *credentials.Resolver
+	allowedNets []*net.IPNet
+	// CycleMu serialises forced walks against the regular discovery cycle.
+	// Shared with RunDiscoveryLoop via LoopConfig.CycleMu.
+	cycleMu *sync.Mutex
+	// authConfigured is true when listen.web_config_file is set. The endpoint
+	// is privileged: with no auth configured the handler returns 403 and no
+	// walk runs. Default ground state (no auth) ⇒ no privileged endpoint.
+	authConfigured bool
+
+	// targetPortOverride maps an IP string to a non-default SNMP port for that
+	// IP. Populated only by tests pointing at an in-process agent on a random
+	// port; nil in production, where walkOne falls back to the configured
+	// target's port (or 161).
+	targetPortOverride map[string]uint16
+}
+
+// NewRediscoverer builds a Rediscoverer sharing cycleMu with the discovery
+// loop. resolver may be the same resolver the loop uses; access is serialised
+// by cycleMu. allowedNets is the parsed CIDR allow-list (LD-11).
+func NewRediscoverer(
+	cfg *config.Config,
+	m *metrics.Metrics,
+	logger *slog.Logger,
+	resolver *credentials.Resolver,
+	allowedNets []*net.IPNet,
+	cycleMu *sync.Mutex,
+	authConfigured bool,
+) *Rediscoverer {
+	return &Rediscoverer{
+		cfg:            cfg,
+		m:              m,
+		logger:         logger,
+		resolver:       resolver,
+		allowedNets:    allowedNets,
+		cycleMu:        cycleMu,
+		authConfigured: authConfigured,
+	}
+}
+
+// AuthConfigured reports whether the listener is auth-gated. The HTTP handler
+// uses this to fail closed (403) when no auth is configured.
+func (rd *Rediscoverer) AuthConfigured() bool { return rd.authConfigured }
+
+// Rediscover runs a forced out-of-cycle walk against each target IP and
+// returns one result per target in input order. Out-of-scope targets are
+// rejected before any SNMP traffic is sent. The whole batch runs under
+// CycleMu so it is serialised against the regular discovery cycle.
+func (rd *Rediscoverer) Rediscover(ctx context.Context, targets []string) []RediscoverResult {
+	results := make([]RediscoverResult, 0, len(targets))
+
+	// First pass: scope-check every target without holding the cycle mutex.
+	// Out-of-scope targets never reach SNMP, mirroring the LD-11 guard in
+	// RunCycle and the admin contract "no scope expansion via admin call".
+	type pending struct {
+		idx int
+		ip  net.IP
+	}
+	var toWalk []pending
+	for _, raw := range targets {
+		res := RediscoverResult{Target: raw}
+		ip := net.ParseIP(raw)
+		if ip == nil {
+			res.Outcome = RediscoverError
+			res.Error = "not a valid IP address"
+			rd.record(res.Outcome)
+			results = append(results, res)
+			continue
+		}
+		if len(rd.allowedNets) == 0 || !snmpwalk.IPInNets(ip, rd.allowedNets) {
+			res.Outcome = RediscoverOutOfScope
+			res.Error = "target is outside discovery.scope.cidr_allow_list (LD-11)"
+			rd.record(res.Outcome)
+			results = append(results, res)
+			continue
+		}
+		results = append(results, res) // outcome filled in after the walk
+		toWalk = append(toWalk, pending{idx: len(results) - 1, ip: ip})
+	}
+
+	if len(toWalk) == 0 {
+		return results
+	}
+
+	// Serialise the SNMP work against the regular cycle.
+	rd.cycleMu.Lock()
+	defer rd.cycleMu.Unlock()
+	for _, p := range toWalk {
+		select {
+		case <-ctx.Done():
+			results[p.idx].Outcome = RediscoverTimeout
+			results[p.idx].Error = ctx.Err().Error()
+			rd.record(RediscoverTimeout)
+			continue
+		default:
+		}
+		outcome, edges, err := rd.walkOne(ctx, p.ip)
+		results[p.idx].Outcome = outcome
+		results[p.idx].Edges = edges
+		if err != nil {
+			results[p.idx].Error = err.Error()
+		}
+		rd.record(outcome)
+	}
+	return results
+}
+
+// RediscoverResults adapts Rediscover to the httpx.Rediscoverer interface,
+// boxing each typed result so the httpx package need not import app. A
+// per-batch deadline (ResultsTimeout) bounds how long one admin request can
+// hold CycleMu even if the request context has no deadline of its own.
+func (rd *Rediscoverer) RediscoverResults(ctx context.Context, targets []string) []any {
+	ctx, cancel := context.WithTimeout(ctx, ResultsTimeout)
+	defer cancel()
+	typed := rd.Rediscover(ctx, targets)
+	out := make([]any, len(typed))
+	for i := range typed {
+		out[i] = typed[i]
+	}
+	return out
+}
+
+// walkOne probes a single in-scope IP with the configured credentials and the
+// enabled module set, returning the outcome and the number of raw edges the
+// walk produced. It mirrors the per-device probe in RunCycle but does not
+// publish anything into the graph.
+func (rd *Rediscoverer) walkOne(ctx context.Context, ip net.IP) (RediscoverOutcome, int, error) {
+	// Build the TargetConfig for this IP. If a configured target matches the IP
+	// exactly, reuse its port (and implicitly its credentials via the resolver);
+	// otherwise default the port to 161 (CredentialCandidates fills 0 → 161).
+	// The admin call addresses by IP, so no per-target site/label enrichment is
+	// attached — the forced walk only reports an outcome, it does not publish a
+	// Device record.
+	t := config.TargetConfig{Host: ip.String()}
+	for _, ct := range rd.cfg.Targets {
+		if ct.Host == ip.String() {
+			t.Port = ct.Port
+			break
+		}
+	}
+	if rd.targetPortOverride != nil {
+		if p, ok := rd.targetPortOverride[ip.String()]; ok {
+			t.Port = int(p)
+		}
+	}
+
+	dev, params, profileName, err := WalkSystemWithCredentials(ctx, rd.cfg, rd.resolver, ip, t, rd.logger)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return RediscoverTimeout, 0, err
+		}
+		return RediscoverAuthFailure, 0, err
+	}
+	defer params.Zeroize()
+	rd.resolver.RecordSuccess(ip.String(), profileName)
+
+	devCtx, cancel := context.WithTimeout(ctx, rd.cfg.Discovery.TimeoutPerDevice)
+	defer cancel()
+
+	params.MaxVlans = rd.cfg.Modules.FDB.MaxVlans
+	params.Vendor = dev.Vendor
+	params.UseBGPV2MIB = !rd.cfg.Modules.BGP.DisableV2MIB
+
+	mods := []Module{
+		{"lldp", rd.cfg.Modules.LLDP.Enabled, lldp.Walk},
+		{"cdp", rd.cfg.Modules.CDP.Enabled, cdp.Walk},
+		{"fdb", rd.cfg.Modules.FDB.Enabled, fdb.Walk},
+		{"ospf", rd.cfg.Modules.OSPF.Enabled, ospf.Walk},
+		{"bgp", rd.cfg.Modules.BGP.Enabled, bgp.Walk},
+		{"isis", rd.cfg.Modules.ISIS.Enabled, isis.Walk},
+		{"mpls_te", rd.cfg.Modules.MPLSTE.Enabled, mpls.Walk},
+	}
+
+	var edgeCount int
+	for _, mod := range mods {
+		if !mod.Enabled {
+			continue
+		}
+		modCtx := devCtx
+		var modCancel context.CancelFunc = func() {}
+		if rd.cfg.Discovery.TimeoutPerModule > 0 {
+			modCtx, modCancel = context.WithTimeout(devCtx, rd.cfg.Discovery.TimeoutPerModule)
+		}
+		edges, _, werr := mod.Walk(modCtx, params, dev.ID, rd.allowedNets)
+		modCancel()
+		if werr != nil {
+			rd.logger.Debug("rediscover module walk failed", "module", mod.Proto, "ip", ip, "error", werr)
+			continue
+		}
+		edgeCount += len(edges)
+	}
+	return RediscoverSuccess, edgeCount, nil
+}
+
+func (rd *Rediscoverer) record(outcome RediscoverOutcome) {
+	if rd.m == nil {
+		return
+	}
+	rd.m.AdminRediscoveryTotal.WithLabelValues(string(outcome)).Inc()
+}
+
+// ResultsTimeout is a defensive cap on a single admin rediscover request so a
+// large target list cannot hold CycleMu indefinitely. Each target still gets
+// its own per-device timeout via TimeoutPerDevice; this bounds the batch.
+const ResultsTimeout = 2 * time.Minute

--- a/internal/app/rediscover_app_test.go
+++ b/internal/app/rediscover_app_test.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	gsnmp "github.com/gosnmp/gosnmp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+)
+
+func slogDiscard() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// OID bases for building a minimal system-group + LLDP fixture.
+const (
+	oidSysDescr    = "1.3.6.1.2.1.1.1.0"
+	oidSysObjectID = "1.3.6.1.2.1.1.2.0"
+	oidSysUpTime   = "1.3.6.1.2.1.1.3.0"
+	oidSysName     = "1.3.6.1.2.1.1.5.0"
+
+	lldpLocBase = ".1.0.8802.1.1.2.1.3.7.1."
+	lldpRemBase = ".1.0.8802.1.1.2.1.4.1.1."
+)
+
+// systemAndLLDPPDUs returns a fixture that answers the system-group GET and
+// advertises one LLDP neighbour via a network-address (IPv4) chassis ID so the
+// edge survives active CIDR scope filtering (a MAC-chassis neighbour is dropped
+// at the module layer when scope filtering is on, and only re-resolved later by
+// the synthesis layer, which the single-device forced walk does not run).
+func systemAndLLDPPDUs(sysName string, remoteIP net.IP) []gsnmp.SnmpPDU {
+	const (
+		chassisSubtypeNetworkAddress = 5
+		portSubtypeIfName            = 5
+	)
+	remSuffix := "0.1.1" // timeMark=0, portNum=1, remIdx=1
+	v4 := remoteIP.To4()
+	chassisID := append([]byte{1}, v4...) // IANA family 1 (IPv4) + 4 octets
+	return []gsnmp.SnmpPDU{
+		{Name: "." + oidSysDescr, Type: gsnmp.OctetString, Value: []byte("Test OS 1.2.3")},
+		{Name: "." + oidSysObjectID, Type: gsnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.9.1.1"},
+		{Name: "." + oidSysUpTime, Type: gsnmp.TimeTicks, Value: uint32(123456)},
+		{Name: "." + oidSysName, Type: gsnmp.OctetString, Value: []byte(sysName)},
+
+		// lldpLocPortTable: port 1
+		{Name: lldpLocBase + "2.1", Type: gsnmp.Integer, Value: portSubtypeIfName},
+		{Name: lldpLocBase + "3.1", Type: gsnmp.OctetString, Value: []byte("Gi0/1")},
+		// lldpRemTable: one remote neighbour
+		{Name: lldpRemBase + "4." + remSuffix, Type: gsnmp.Integer, Value: chassisSubtypeNetworkAddress},
+		{Name: lldpRemBase + "5." + remSuffix, Type: gsnmp.OctetString, Value: chassisID},
+		{Name: lldpRemBase + "6." + remSuffix, Type: gsnmp.Integer, Value: portSubtypeIfName},
+		{Name: lldpRemBase + "7." + remSuffix, Type: gsnmp.OctetString, Value: []byte("Gi0/2")},
+		{Name: lldpRemBase + "9." + remSuffix, Type: gsnmp.OctetString, Value: []byte("sw-b")},
+	}
+}
+
+func testConfig(t *testing.T, communityEnv string) *config.Config {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Discovery.TimeoutPerDevice = 3 * time.Second
+	cfg.Discovery.Parallelism = 4
+	cfg.Modules.SNMP.CommunityEnv = communityEnv
+	cfg.Modules.LLDP.Enabled = true
+	cfg.Credentials.TrialRatePerSecond = 100
+	cfg.Modules.FDB.MaxVlans = 100
+	return cfg
+}
+
+func newTestRediscoverer(t *testing.T, cfg *config.Config, m *metrics.Metrics, allow []string, auth bool) *Rediscoverer {
+	t.Helper()
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	var mu sync.Mutex
+	return NewRediscoverer(cfg, m, slogDiscard(), resolver, snmpwalk.ParseCIDRs(allow), &mu, auth)
+}
+
+// TestRediscoverOutOfScopeRejected verifies an in-band target outside the
+// CIDR allow-list is rejected with out_of_scope and never walked — the admin
+// call cannot expand scope (issue #73).
+func TestRediscoverOutOfScopeRejected(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+	rd := newTestRediscoverer(t, cfg, m, []string{"10.0.0.0/24"}, true)
+
+	results := rd.Rediscover(context.Background(), []string{"10.99.0.1"})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Outcome != RediscoverOutOfScope {
+		t.Fatalf("outcome = %q, want out_of_scope", results[0].Outcome)
+	}
+	if got := testutil.ToFloat64(m.AdminRediscoveryTotal.WithLabelValues("out_of_scope")); got != 1 {
+		t.Errorf("out_of_scope metric = %v, want 1", got)
+	}
+}
+
+// TestRediscoverHappyPath walks a live in-process SNMP agent and asserts a
+// success outcome with the expected edge count and audit metric.
+func TestRediscoverHappyPath(t *testing.T) {
+	t.Setenv("TEST_COMM", "public")
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+
+	// The agent listens on 127.0.0.1 on a random port; the advertised neighbour
+	// is 127.0.0.2. Allow 127.0.0.0/8 so both are in scope, and override the
+	// SNMP port so walkOne reaches the agent rather than the default 161.
+	rd := newTestRediscoverer(t, cfg, m, []string{"127.0.0.0/8"}, true)
+	rd.targetPortOverride = map[string]uint16{ip.String(): port}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	results := rd.Rediscover(ctx, []string{ip.String()})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Outcome != RediscoverSuccess {
+		t.Fatalf("outcome = %q (err=%q), want success", results[0].Outcome, results[0].Error)
+	}
+	if results[0].Edges != 1 {
+		t.Errorf("edges = %d, want 1", results[0].Edges)
+	}
+	if got := testutil.ToFloat64(m.AdminRediscoveryTotal.WithLabelValues("success")); got != 1 {
+		t.Errorf("success metric = %v, want 1", got)
+	}
+}
+
+// TestRediscoverInvalidIPRejected verifies a non-IP target string is rejected
+// with the error outcome and never walked.
+func TestRediscoverInvalidIPRejected(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+	rd := newTestRediscoverer(t, cfg, m, []string{"10.0.0.0/24"}, true)
+
+	results := rd.Rediscover(context.Background(), []string{"not-an-ip"})
+	if len(results) != 1 || results[0].Outcome != RediscoverError {
+		t.Fatalf("results = %+v, want one error outcome", results)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -118,6 +118,14 @@ type Metrics struct {
 	// acquire the parallelism semaphore.
 	CycleBudgetSkipsTotal prometheus.Counter
 
+	// AdminRediscoveryTotal counts per-target outcomes of the admin
+	// out-of-cycle re-discovery endpoint (POST /admin/rediscover). Labelled by
+	// outcome ∈ {success, timeout, auth_failure, out_of_scope, error}. One
+	// increment per target per admin request; an audit trail of forced walks.
+	// Operators can alert on outcome="auth_failure" rate to spot a misconfigured
+	// rediscover client. Issue #73.
+	AdminRediscoveryTotal *prometheus.CounterVec
+
 	// BGPWalkerOutcomeTotal counts the outcome of each BGP walker pass.
 	// Labels:
 	//   walker  ∈ {vendor_cisco, vendor_arista, vendor_juniper, vendor_nokia, rfc4273}
@@ -277,6 +285,10 @@ func New(emitBoundaryObs bool) *Metrics {
 			Name: "network_topology_cycle_budget_skips_total",
 			Help: "Targets skipped in a discovery cycle because the cycle budget deadline expired before their goroutine could start.",
 		}),
+		AdminRediscoveryTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "network_topology_admin_rediscovery_total",
+			Help: "Per-target outcomes of forced out-of-cycle re-discovery via POST /admin/rediscover. outcome ∈ {success, timeout, auth_failure, out_of_scope, error}.",
+		}, []string{"outcome"}),
 		MetricsRenderDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name: "network_topology_metrics_render_duration_seconds",
 			Help: "Wall time to render one /metrics scrape response. Alert at p99 against the scraper's scrape_timeout.",
@@ -330,6 +342,7 @@ func New(emitBoundaryObs bool) *Metrics {
 		m.SnapshotQueueDepth,
 		m.SnapshotDropsTotal,
 		m.CycleBudgetSkipsTotal,
+		m.AdminRediscoveryTotal,
 		m.MetricsRenderDuration,
 		m.MetricsPayloadBytes,
 		m.BGPWalkerOutcomeTotal,


### PR DESCRIPTION
Adds `POST /admin/rediscover` to trigger an out-of-cycle SNMP walk against specific targets.

- **Auth-gated:** returns 403 unless `listen.web_config_file` is configured (privileged action defaults to deny, unlike read-only `/metrics`). The exporter-toolkit listener enforces mTLS/basic_auth ahead of the handler.
- **Scope-checked:** targets outside `discovery.scope.cidr_allow_list` → 400. Guardrails: POST-only (405), ≤256 targets, 1 MiB body cap, `DisallowUnknownFields`, 2-minute batch deadline.
- **Per-target outcome** (success/timeout/auth-failure/out-of-scope) + edge count in the JSON response.
- **Metric** `network_topology_admin_rediscovery_total{outcome}`.
- Tests cover happy path, 403 no-auth, scope rejection, bad-body, method. `-race` clean.
- `docs/operator/troubleshooting.md` gains "I just fixed a device's SNMP config".

**Concurrency:** the forced walk shares a process-wide cycle mutex with the discovery loop, so the two never poll concurrently. **By design the forced walk is read-only w.r.t. the published graph** — it reports per-target outcome/edge-count to the caller and audits via the metric, but does not mutate `prevGraph`/snapshot/age-counters (those stay owned by the loop). Corrected edges therefore appear on the next regular cycle; the endpoint confirms-a-fix + audits rather than live-injecting topology. Documented in code, troubleshooting, and CHANGELOG.

Closes #73.