### PR TITLE
Opt-in OpenTelemetry tracing of the discovery cycle (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,24 @@ v1.3.1 lands under this milestone instead, renamed to
   Mutator emits structured JSON events to stdout; Alloy ships them to
   Loki labelled `tester_id=long-running-lab, job=long-running-mutator`.
 
+### Observability
+
+- **#68 — Opt-in OpenTelemetry tracing of the discovery cycle (v1.7.0 work).**
+  The exporter can now emit OTel traces of its own discovery cycle. A new
+  `output.otlp.traces` block (`enabled`, default `false`; `sample_rate`, default
+  `0.1`, validated to `[0,1]`) turns it on. Tracing reuses the **#82 OTLP SDK
+  path** — the same `TracerProvider`-style SDK, the existing
+  `output.otlp.endpoint`, `output.otlp.protocol`, and transport — so it gets no
+  endpoint of its own. Spans nest per cycle: `discovery.cycle` →
+  `target.poll` → (`credentials.resolve`, `<module>.walk` for lldp/cdp/fdb/ospf/
+  bgp/isis/mpls_te), plus `graph.reconcile`, and on a federation spoke
+  `spoke.push`. The spoke injects a W3C `traceparent` into its outbound push so
+  the hub's `hub.handlePush` span continues the same trace (TraceContext set as
+  the global propagator). Head sampling is
+  `ParentBased(TraceIDRatioBased(sample_rate))`, keeping each trace whole. When
+  disabled, no provider is installed and the instrumentation resolves to the
+  OTel no-op tracer at effectively zero cost. See `docs/operator/tracing.md`.
+
 ### Security
 
 - **Fuzz coverage for SNMP parsers and index decoders.** Sixteen new

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ output:
 |--------|-----------|---------|
 | Full graph | `POST /v1/metrics` | `network_topology_edge_info` and `network_topology_device_info` gauge metrics, one data point per edge/device. Sent every cycle when there are changes, and unconditionally every `heartbeat_cycles` cycles. Metric names match the Prometheus `/metrics` series. |
 | Change events | `POST /v1/logs` | OTLP log records — severity INFO for added/updated edges, WARN for removed edges. Mirrors the JSON log lines already written to stderr. |
+| Discovery-cycle traces (opt-in) | `POST /v1/traces` | OTel spans of the exporter's own discovery cycle — `discovery.cycle` → `target.poll` → `<module>.walk` / `credentials.resolve`, plus `graph.reconcile` and (federation spoke) `spoke.push` continued on the hub as `hub.handlePush`. Disabled by default; enable with `output.otlp.traces.enabled`. See [`docs/operator/tracing.md`](docs/operator/tracing.md). |
 
 **Heartbeat semantics:** If no topology change is detected, the exporter skips the `/v1/metrics` push to avoid redundant data. Every `heartbeat_cycles` cycles (default: every 10th cycle) the full graph is pushed unconditionally so downstream receivers can detect a stale or silently-dropped connection.
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -180,6 +180,18 @@ snapshot:
 #     # exporters do not implement OTLP/JSON) — a wire-format change from the
 #     # pre-v1.5.0 hand-rolled JSON path. Receivers must accept protobuf.
 #     protocol: http
+#     # traces: opt-in OpenTelemetry tracing of the exporter's own discovery
+#     # cycle (v1.7.0, issue #68). Disabled by default. When enabled, spans are
+#     # exported over the SAME endpoint + protocol + auth as the metrics/logs
+#     # above — tracing has no endpoint of its own. See docs/operator/tracing.md.
+#     traces:
+#       # enabled turns on tracing. Default false (instrumentation is a no-op).
+#       enabled: false
+#       # sample_rate is the head-sampling ratio in [0,1] applied to the root
+#       # discovery.cycle span; child spans inherit the parent decision
+#       # (ParentBased). Default 0.1. Use 1.0 to trace every cycle while
+#       # debugging; keep it small in production to bound trace volume.
+#       sample_rate: 0.1
 
 # ─── Per-device enrichment ─────────────────────────────────────────────────
 # Targets attach enrichment metadata (SNMP port, site label, custom labels)

--- a/docs/operator/tracing.md
+++ b/docs/operator/tracing.md
@@ -1,0 +1,127 @@
+# Tracing the discovery cycle
+
+The exporter can emit OpenTelemetry traces of its **own discovery cycle** so you
+can see, per cycle, how long each target poll took, which credential profile
+won, how each protocol walk fared, and — in federation — how a spoke push lands
+on the hub. This is operational self-observability of the exporter, not of the
+network it discovers.
+
+Tracing is **opt-in and disabled by default**. It is an additive signal layered
+on the same OpenTelemetry Go SDK that already powers the OTLP metrics and logs
+output (issue #82): when enabled, spans are exported over the **same**
+`output.otlp.endpoint`, `output.otlp.protocol`, and transport — tracing does not
+get its own endpoint or auth.
+
+## Enabling
+
+```yaml
+output:
+  otlp:
+    enabled: true
+    endpoint: "http://alloy:4318"   # shared by metrics, logs, AND traces
+    protocol: http                  # http (default) or grpc
+    traces:
+      enabled: true
+      sample_rate: 0.1              # head sampling ratio, [0, 1]; default 0.1
+```
+
+`output.otlp.enabled` controls the metrics/logs push. Tracing keys off
+`output.otlp.traces.enabled` and reuses `endpoint`/`protocol` regardless — so
+you can run traces alongside the metrics/logs push. The receiver must be an OTLP
+trace receiver (Grafana Tempo, a Grafana Alloy `otelcol.receiver.otlp`, or an
+OpenTelemetry Collector feeding Tempo/Jaeger). The wire encoding is protobuf
+(the only encoding the OTel Go SDK exporters implement).
+
+When `traces.enabled` is `false` (the default), no `TracerProvider` is
+installed; the instrumentation calls resolve to the OpenTelemetry no-op tracer
+and emit nothing, at effectively zero cost.
+
+## Sampling
+
+Sampling is **head-based**: `ParentBased(TraceIDRatioBased(sample_rate))`.
+
+- The root `discovery.cycle` span is sampled with probability `sample_rate`.
+- Every child span (`target.poll`, `<module>.walk`, `credentials.resolve`,
+  `graph.reconcile`, `spoke.push`) inherits the parent's decision. A sampled
+  cycle keeps all of its children; an unsampled cycle drops them all. This keeps
+  each trace whole rather than half-sampling its spans.
+- A spoke push that is sampled propagates its decision to the hub via the W3C
+  `traceparent` header, so `hub.handlePush` joins the same sampled trace.
+
+Guidance:
+
+- **Debugging / low cycle rate:** `sample_rate: 1.0` traces every cycle. Because
+  the exporter runs one cycle per `discovery.interval` (default 60s), a fleet of
+  a few hundred targets at 1.0 is still a very low span rate.
+- **Production / large fleets:** keep `sample_rate` small (the `0.1` default, or
+  lower) to bound trace volume and receiver cost. The per-cycle metrics already
+  give you aggregate timing; traces are for drill-down.
+- `sample_rate: 0.0` is honoured (sample nothing) — useful to wire up the export
+  path without yet emitting traces.
+
+## Spans emitted
+
+Spans nest via context so a single cycle forms one trace tree:
+
+```
+discovery.cycle
+├── target.poll                (one per target)
+│   ├── credentials.resolve
+│   ├── lldp.walk
+│   ├── cdp.walk
+│   ├── fdb.walk
+│   ├── ospf.walk
+│   ├── bgp.walk
+│   ├── isis.walk
+│   └── mpls_te.walk
+├── graph.reconcile
+└── spoke.push                 (federation spoke role only)
+        │  … W3C traceparent over HTTP …
+        └── hub.handlePush      (recorded on the hub process)
+```
+
+| Span | Emitted | Key attributes |
+| --- | --- | --- |
+| `discovery.cycle` | once per cycle (root) | `cycle.number`, `cycle.start_time`, `cycle.device_count`, `cycle.edge_count`, `cycle.device_errors` |
+| `target.poll` | once per target | `target.ip`, `credential.profile`, `target.latency_seconds` |
+| `credentials.resolve` | per target, during credential trial | `credential.candidates`, `credential.trials`, `credential.limiter_wait_seconds`, `credential.winning_profile` |
+| `<module>.walk` | per enabled module per target — `lldp.walk`, `cdp.walk`, `fdb.walk`, `ospf.walk`, `bgp.walk`, `isis.walk`, `mpls_te.walk` | `walk.pdu_count`, `walk.outcome` (`ok` / `degraded` / `failed`) |
+| `graph.reconcile` | once per cycle | `reconcile.input_edges`, `reconcile.output_edges`, `reconcile.edges.<proto>` (per-source input counts) |
+| `spoke.push` | per cycle, spoke role only | `spoke.id`, `spoke.devices`, `spoke.edges` |
+| `hub.handlePush` | per accepted push, hub process | `spoke.id` |
+
+Failures set the span status to `Error` and attach the error via
+`span.RecordError` (e.g. DNS resolution failure or credential resolve failure on
+`target.poll`, a module walk error on `<module>.walk`).
+
+> The module span name uses the module's protocol identifier, so the MPLS module
+> emits `mpls_te.walk` (matching the `mpls_te` Prometheus label), not `mpls.walk`.
+
+## Federation: trace context across the spoke → hub push
+
+The exporter sets the global propagator to **W3C TraceContext** (+ Baggage). On
+a federation **spoke**, the `spoke.push` span's context is injected as a
+`traceparent` HTTP header on the outbound push to the hub. On the **hub**, the
+`/spoke/push` handler extracts that header and starts `hub.handlePush` as a child
+of `spoke.push`, so both spans share one trace ID. To see the full cross-process
+trace, enable tracing (`output.otlp.traces.enabled: true`) on **both** the spoke
+and the hub, pointed at the same Tempo/Jaeger back end.
+
+If the spoke is tracing but the hub is not (or vice versa), the link is simply
+not recorded on the side that has tracing off; nothing breaks.
+
+## Verifying against a live receiver
+
+The in-memory unit tests cover span names, nesting, attributes, the
+disabled-is-a-no-op guarantee, and the spoke→hub `traceparent` round-trip. To
+confirm spans actually land on a live Tempo/Jaeger receiver, run the
+env-guarded integration test:
+
+```
+TRACING_INTEGRATION_ENDPOINT=http://localhost:4318 \
+TRACING_INTEGRATION_PROTOCOL=http \
+go test ./internal/tracing/ -run TestTracingIntegration -v
+```
+
+then look for the `integration.smoke` / `integration.child` trace in your back
+end. Repeat with `TRACING_INTEGRATION_PROTOCOL=grpc` against `:4317`.

--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,15 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.51.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -40,7 +44,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,12 @@ go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQ
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0/go.mod h1:HBy4BjzgVE8139ieRI75oXm3EcDN+6GhD88JT1Kjvxg=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/log v0.19.0 h1:KUZs/GOsw79TBBMfDWsXS+KZ4g2Ckzksd1ymzsIEbo4=
 go.opentelemetry.io/otel/log v0.19.0/go.mod h1:5DQYeGmxVIr4n0/BcJvF4upsraHjg6vudJJpnkL6Ipk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snapshot"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 	"github.com/colinedwardwood/network-topology-exporter/internal/version"
 )
 
@@ -137,6 +138,34 @@ func Run(ctx context.Context, args []string) int {
 
 	var workerDone sync.WaitGroup
 	var otlpWg sync.WaitGroup
+
+	// Issue #68: opt-in OpenTelemetry tracing of the discovery cycle. Built
+	// before the role switch so both hub mode (which records hub.handlePush on
+	// the receiving side of a spoke push) and spoke/standalone mode (which
+	// records discovery.cycle and spoke.push) install the same global
+	// TracerProvider + W3C TraceContext propagator. When traces.enabled is
+	// false, no provider is installed and the global tracer stays the OTel
+	// no-op, so all instrumentation is a cheap no-op.
+	var traceProvider *tracing.Provider
+	if cfg.Output.OTLP.Traces.Enabled {
+		sampleRate := 0.1
+		if cfg.Output.OTLP.Traces.SampleRate != nil {
+			sampleRate = *cfg.Output.OTLP.Traces.SampleRate
+		}
+		var err error
+		traceProvider, err = tracing.New(ctx, tracing.Config{
+			Endpoint:   cfg.Output.OTLP.Endpoint,
+			Timeout:    cfg.Output.OTLP.Timeout,
+			Protocol:   tracing.Protocol(cfg.Output.OTLP.Protocol),
+			InstanceID: cfg.Federation.Spoke.SpokeID, // empty in non-spoke roles → falls back to hostname
+			SampleRate: sampleRate,
+		})
+		if err != nil {
+			logger.Error("building tracer provider", "error", err)
+			return 1
+		}
+		logger.Info("tracing enabled", "sample_rate", sampleRate, "protocol", cfg.Output.OTLP.Protocol)
+	}
 
 	switch cfg.Federation.Role {
 	case "hub":
@@ -291,6 +320,13 @@ func Run(ctx context.Context, args []string) int {
 	}
 	otlpWg.Wait()
 	logger.Info("otlp push goroutines drained")
+	if traceProvider != nil {
+		if err := traceProvider.Shutdown(shutdownCtx); err != nil {
+			logger.Error("tracer provider shutdown error", "error", err)
+		} else {
+			logger.Info("tracer provider flushed and shut down")
+		}
+	}
 	logger.Info("clean shutdown complete")
 	return 0
 }

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -10,6 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
@@ -23,6 +27,7 @@ import (
 	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
 
 // LargeTopologyEdgeThreshold is the edge count above which the exporter
@@ -140,12 +145,25 @@ func RunCycle(
 			}
 			defer func() { <-sem }()
 
+			// Issue #68: per-target span, child of discovery.cycle. targetCtx
+			// flows into the credential resolve and every module walk so they
+			// nest under target.poll. No-op when tracing is disabled.
+			targetStart := time.Now()
+			targetCtx, targetSpan := tracing.Tracer().Start(cycleCtx, "target.poll",
+				trace.WithAttributes(attribute.String("target.ip", target.Host)))
+			defer func() {
+				targetSpan.SetAttributes(
+					attribute.Float64("target.latency_seconds", time.Since(targetStart).Seconds()))
+				targetSpan.End()
+			}()
+
 			ip := net.ParseIP(target.Host)
 			if ip == nil {
-				addrs, err := net.DefaultResolver.LookupHost(cycleCtx, target.Host)
+				addrs, err := net.DefaultResolver.LookupHost(targetCtx, target.Host)
 				if err != nil || len(addrs) == 0 {
 					logger.Warn("host resolution failed", "host", target.Host, "error", err)
 					recordFail(metrics.DiscoveryReasonDNSFailed)
+					targetSpan.SetStatus(codes.Error, "dns resolution failed")
 					return
 				}
 				ip = net.ParseIP(addrs[0])
@@ -157,12 +175,16 @@ func RunCycle(
 				logger.Warn("resolved target outside allow-list, skipping",
 					"host", target.Host, "ip", ip)
 				recordFail(metrics.DiscoveryReasonOutsideAllowList)
+				targetSpan.SetStatus(codes.Error, "outside allow-list")
 				return
 			}
 
-			dev, params, profileName, err := WalkSystemWithCredentials(cycleCtx, cfg, resolver, ip, target, logger)
+			dev, params, profileName, err := WalkSystemWithCredentials(targetCtx, cfg, resolver, ip, target, logger)
+			targetSpan.SetAttributes(attribute.String("credential.profile", profileName))
 			if err != nil {
 				logger.Warn("snmp walk failed", "target", target.Host, "error", err)
+				targetSpan.RecordError(err)
+				targetSpan.SetStatus(codes.Error, "credential resolve / system walk failed")
 				m.DiscoveryHardFailTotal.WithLabelValues("system", "system_group_walk_error").Inc()
 				m.CredentialTrialsTotal.WithLabelValues("failed").Inc()
 				// Issue #20: partition the walk-failure counter by
@@ -187,7 +209,7 @@ func RunCycle(
 			// becomes unreachable to a sensible cleanup. Issue #5.
 			defer params.Zeroize()
 
-			devCtx, cancel := context.WithTimeout(cycleCtx, cfg.Discovery.TimeoutPerDevice)
+			devCtx, cancel := context.WithTimeout(targetCtx, cfg.Discovery.TimeoutPerDevice)
 			defer cancel()
 			devCtx = snmpwalk.ContextWithDecodeIssueReporter(devCtx, func(issue snmpwalk.DecodeIssue) {
 				m.DiscoveryDecodeIssues.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
@@ -238,16 +260,25 @@ func RunCycle(
 					continue
 				}
 				modStart := time.Now()
-				modCtx := devCtx
+				// Issue #68: per-module span, child of target.poll. Span name
+				// is "<proto>.walk" (e.g. lldp.walk, bgp.walk; the MPLS module
+				// uses its mpls_te proto identifier → mpls_te.walk). No-op when
+				// tracing is disabled.
+				modCtx, modSpan := tracing.Tracer().Start(devCtx, mod.Proto+".walk")
 				var modCancel context.CancelFunc = func() {}
 				if cfg.Discovery.TimeoutPerModule > 0 {
-					modCtx, modCancel = context.WithTimeout(devCtx, cfg.Discovery.TimeoutPerModule)
+					modCtx, modCancel = context.WithTimeout(modCtx, cfg.Discovery.TimeoutPerModule)
 				}
 				edges, oos, err := mod.Walk(modCtx, params, dev.ID, allowedNets)
 				modCancel()
 				m.DiscoveryModuleDuration.WithLabelValues(mod.Proto).Observe(time.Since(modStart).Seconds())
+				modSpan.SetAttributes(attribute.Int("walk.pdu_count", len(edges)))
 				if err != nil {
 					logger.Debug(mod.Proto+" walk failed", "target", target.Host, "error", err)
+					modSpan.SetAttributes(attribute.String("walk.outcome", "failed"))
+					modSpan.RecordError(err)
+					modSpan.SetStatus(codes.Error, "module walk failed")
+					modSpan.End()
 					reason := "module_walk_error"
 					var policyErr *discovery.PolicyError
 					if errors.As(err, &policyErr) && policyErr.Reason != "" {
@@ -275,14 +306,17 @@ func RunCycle(
 					m.DiscoveryDegradedTotal.WithLabelValues(mod.Proto, reason).Inc()
 				}
 				if len(degradedReasons) > 0 {
+					modSpan.SetAttributes(attribute.String("walk.outcome", "degraded"))
 					if _, ok := modStatus[mod.Proto]; !ok {
 						modStatus[mod.Proto] = 1
 					}
 				} else {
+					modSpan.SetAttributes(attribute.String("walk.outcome", "ok"))
 					if _, ok := modStatus[mod.Proto]; !ok {
 						modStatus[mod.Proto] = 0
 					}
 				}
+				modSpan.End()
 				allEdges = append(allEdges, edges...)
 				// Tag each OOS entry with the protocol that reported it so the
 				// boundary_observation_info metric and hub OOS matching have a
@@ -391,8 +425,23 @@ func RunCycle(
 	}
 	canonicalEdges := SynthesizeEdges(logger, rawEdges, ipToID, allARPMACs, m.FDBSuppressedMACs)
 
-	// Phase 2 complete; run reconciliation.
+	// Phase 2 complete; run reconciliation. Issue #68: graph.reconcile span,
+	// child of discovery.cycle, with per-source (discovery protocol) input edge
+	// counts as attributes. No-op when tracing is disabled.
+	_, reconcileSpan := tracing.Tracer().Start(ctx, "graph.reconcile")
+	bySource := make(map[discovery.DiscoveryProtocol]int)
+	for _, e := range canonicalEdges {
+		bySource[e.DiscoveryProto]++
+	}
+	reconcileAttrs := make([]attribute.KeyValue, 0, len(bySource)+2)
+	reconcileAttrs = append(reconcileAttrs, attribute.Int("reconcile.input_edges", len(canonicalEdges)))
+	for proto, n := range bySource {
+		reconcileAttrs = append(reconcileAttrs, attribute.Int("reconcile.edges."+string(proto), n))
+	}
 	reconciledEdges, conflicts := graph.Reconcile(canonicalEdges)
+	reconcileAttrs = append(reconcileAttrs, attribute.Int("reconcile.output_edges", len(reconciledEdges)))
+	reconcileSpan.SetAttributes(reconcileAttrs...)
+	reconcileSpan.End()
 
 	// LD-14: advance unconfirmed-link age counters and drop expired edges.
 	ages := maps.Clone(prevAges)

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -9,6 +9,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/app/httpx"
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
@@ -21,6 +24,7 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snapshot"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
 
 // SnapshotWriteTimeout caps how long the background snapshot write goroutine
@@ -241,16 +245,32 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 		cycleNum++
 		lc.M.GoRoutines.Set(float64(runtime.NumGoroutine()))
 		start := time.Now()
+
+		// Issue #68: root span for the cycle. cycleCtx carries the span so all
+		// per-target / per-module / reconcile spans nest under it. When tracing
+		// is disabled the tracer is the OTel no-op and this is free.
+		cycleCtx, cycleSpan := tracing.Tracer().Start(ctx, "discovery.cycle",
+			trace.WithAttributes(
+				attribute.Int("cycle.number", cycleNum),
+				attribute.String("cycle.start_time", start.Format(time.RFC3339Nano)),
+			))
+		defer cycleSpan.End()
+
 		// Serialise the cycle's SNMP work against forced out-of-cycle walks
 		// (issue #73): the Rediscoverer holds the same mutex, so a regular
 		// cycle and an admin rediscover never walk devices concurrently.
 		if lc.CycleMu != nil {
 			lc.CycleMu.Lock()
 		}
-		newGraph, newAges, conflicts, deviceErrors := RunCycle(ctx, lc.Logger, lc.Cfg, lc.M, lc.WalkerMetrics, lc.WarnLimiter, resolver, allowedNets, ages)
+		newGraph, newAges, conflicts, deviceErrors := RunCycle(cycleCtx, lc.Logger, lc.Cfg, lc.M, lc.WalkerMetrics, lc.WarnLimiter, resolver, allowedNets, ages)
 		if lc.CycleMu != nil {
 			lc.CycleMu.Unlock()
 		}
+		cycleSpan.SetAttributes(
+			attribute.Int("cycle.device_count", len(newGraph.Devices)),
+			attribute.Int("cycle.edge_count", len(newGraph.Edges)),
+			attribute.Int("cycle.device_errors", deviceErrors),
+		)
 		if ctx.Err() != nil {
 			return
 		}
@@ -355,7 +375,10 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 				OutOfScope: newGraph.OutOfScope,
 				Ages:       ageMap,
 			}
-			if err := lc.Spoke.Push(ctx, payload); err != nil && ctx.Err() == nil {
+			// Pass cycleCtx so the spoke.push span nests under discovery.cycle
+			// and carries the cycle's trace context into the outbound HTTP push
+			// (issue #68: spoke→hub W3C traceparent propagation).
+			if err := lc.Spoke.Push(cycleCtx, payload); err != nil && ctx.Err() == nil {
 				lc.Logger.Warn("spoke push failed", "error", err)
 			}
 		}

--- a/internal/app/probe.go
+++ b/internal/app/probe.go
@@ -9,10 +9,14 @@ import (
 	"os"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
 	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
 
 // CredentialCandidate pairs a fully-populated snmpwalk.Params with the name of
@@ -98,8 +102,16 @@ func CredentialCandidates(cfg *config.Config, resolver *credentials.Resolver, ip
 // because the caller will use them for module walks; the caller MUST zeroize
 // them after those walks complete.
 func WalkSystemWithCredentials(ctx context.Context, cfg *config.Config, resolver *credentials.Resolver, ip net.IP, t config.TargetConfig, logger *slog.Logger) (*discovery.Device, snmpwalk.Params, string, error) {
+	// Issue #68: credentials.resolve span. Records how many candidates the
+	// fallback ladder produced, how many were tried, and the cumulative
+	// trial-limiter wait. Child of target.poll. No-op when tracing is disabled.
+	ctx, span := tracing.Tracer().Start(ctx, "credentials.resolve")
+	defer span.End()
+
 	candidates := CredentialCandidates(cfg, resolver, ip, t, logger)
+	span.SetAttributes(attribute.Int("credential.candidates", len(candidates)))
 	if len(candidates) == 0 {
+		span.SetStatus(codes.Error, "no usable credential profiles")
 		return nil, snmpwalk.Params{}, "", fmt.Errorf("no usable credential profiles for %s", ip)
 	}
 
@@ -115,16 +127,35 @@ func WalkSystemWithCredentials(ctx context.Context, cfg *config.Config, resolver
 
 	var lastErr error
 	allTimedOut := true // true until we see a non-timeout failure
+	var trials int
+	var limiterWait time.Duration
 	for i := range candidates {
 		c := &candidates[i]
+		trials++
+		// Measure how long the LD-12 trial limiter made this trial wait so the
+		// span surfaces token-bucket back-pressure during credential resolve.
+		acquireStart := time.Now()
 		if err := resolver.AcquireTrial(ctx); err != nil {
+			limiterWait += time.Since(acquireStart)
+			span.SetAttributes(
+				attribute.Int("credential.trials", trials),
+				attribute.Float64("credential.limiter_wait_seconds", limiterWait.Seconds()),
+			)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "trial limiter acquire failed")
 			zeroizeFromIdx(i)
 			return nil, snmpwalk.Params{}, "", err
 		}
+		limiterWait += time.Since(acquireStart)
 		trialCtx, cancel := context.WithTimeout(ctx, cfg.Discovery.TimeoutPerDevice)
 		dev, err := snmpwalk.Walk(trialCtx, c.Params)
 		cancel()
 		if err == nil {
+			span.SetAttributes(
+				attribute.Int("credential.trials", trials),
+				attribute.Float64("credential.limiter_wait_seconds", limiterWait.Seconds()),
+				attribute.String("credential.winning_profile", c.ProfileName),
+			)
 			// Caller owns c.Params now and must zeroize it after module walks.
 			zeroizeFromIdx(i + 1)
 			return dev, c.Params, c.ProfileName, nil
@@ -151,6 +182,14 @@ func WalkSystemWithCredentials(ctx context.Context, cfg *config.Config, resolver
 	// the cached profile is still likely correct.
 	if !allTimedOut {
 		resolver.RecordFailure(ip.String())
+	}
+	span.SetAttributes(
+		attribute.Int("credential.trials", trials),
+		attribute.Float64("credential.limiter_wait_seconds", limiterWait.Seconds()),
+	)
+	if lastErr != nil {
+		span.RecordError(lastErr)
+		span.SetStatus(codes.Error, "all credential candidates failed")
 	}
 	return nil, snmpwalk.Params{}, "", lastErr
 }

--- a/internal/app/tracing_cycle_test.go
+++ b/internal/app/tracing_cycle_test.go
@@ -1,0 +1,208 @@
+package app
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
+)
+
+// installRecorder installs an always-sample SDK TracerProvider backed by an
+// in-memory SpanRecorder as the global provider, restoring the previous global
+// at test end. It returns the recorder so the test can read exported spans.
+func installRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sr),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+// runSingleTargetCycle stands up an in-process SNMP agent advertising one LLDP
+// neighbour and runs a single RunCycle against it under a root discovery.cycle
+// span, returning the recorded spans.
+func runSingleTargetCycle(t *testing.T, sr *tracetest.SpanRecorder) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	t.Setenv("TEST_COMM", "public")
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Discovery.Interval = 30 * time.Second
+	cfg.Discovery.CycleBudgetFraction = 1
+	cfg.Discovery.UnconfirmedLinkTTLCycles = 3
+	m := metrics.New(false)
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+
+	cfg.Targets = []config.TargetConfig{{Host: ip.String(), Port: int(port)}}
+
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	allow := snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	// Wrap RunCycle in a root span exactly as the production cycle() closure does.
+	ctx, root := tracing.Tracer().Start(ctx, "discovery.cycle")
+	g, _, _, _ := RunCycle(ctx, slogDiscard(), cfg, m, nil, nil, resolver, allow, map[graph.EdgeKey]int{})
+	root.End()
+
+	if len(g.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(g.Devices))
+	}
+	return sr.Ended()
+}
+
+// TestCycleEmitsExpectedSpans asserts a single discovery cycle emits the
+// discovery.cycle root plus target.poll, credentials.resolve, lldp.walk, and
+// graph.reconcile children, with target.poll nested under discovery.cycle.
+func TestCycleEmitsExpectedSpans(t *testing.T) {
+	sr := installRecorder(t)
+	spans := runSingleTargetCycle(t, sr)
+
+	byName := map[string]sdktrace.ReadOnlySpan{}
+	for _, s := range spans {
+		byName[s.Name()] = s
+	}
+	for _, want := range []string{"discovery.cycle", "target.poll", "credentials.resolve", "lldp.walk", "graph.reconcile"} {
+		if _, ok := byName[want]; !ok {
+			t.Errorf("missing span %q; got spans %v", want, spanNames(spans))
+		}
+	}
+
+	// Nesting: target.poll is a child of discovery.cycle.
+	cycle := byName["discovery.cycle"]
+	target := byName["target.poll"]
+	if cycle == nil || target == nil {
+		t.Fatalf("cannot check nesting: cycle=%v target=%v", cycle, target)
+	}
+	if target.Parent().SpanID() != cycle.SpanContext().SpanID() {
+		t.Errorf("target.poll parent = %v, want discovery.cycle %v",
+			target.Parent().SpanID(), cycle.SpanContext().SpanID())
+	}
+	// lldp.walk is a child of target.poll.
+	if w := byName["lldp.walk"]; w.Parent().SpanID() != target.SpanContext().SpanID() {
+		t.Errorf("lldp.walk parent = %v, want target.poll %v",
+			w.Parent().SpanID(), target.SpanContext().SpanID())
+	}
+	// credentials.resolve is a child of target.poll.
+	if c := byName["credentials.resolve"]; c.Parent().SpanID() != target.SpanContext().SpanID() {
+		t.Errorf("credentials.resolve parent = %v, want target.poll %v",
+			c.Parent().SpanID(), target.SpanContext().SpanID())
+	}
+
+	// Key attributes.
+	if got := attrString(target, "target.ip"); got != "127.0.0.1" {
+		t.Errorf("target.poll target.ip = %q, want 127.0.0.1", got)
+	}
+	if got := attrString(byName["lldp.walk"], "walk.outcome"); got == "" {
+		t.Errorf("lldp.walk missing walk.outcome attribute")
+	}
+	if !hasAttr(byName["lldp.walk"], "walk.pdu_count") {
+		t.Errorf("lldp.walk missing walk.pdu_count attribute")
+	}
+	if !hasAttr(byName["graph.reconcile"], "reconcile.output_edges") {
+		t.Errorf("graph.reconcile missing reconcile.output_edges attribute")
+	}
+	if !hasAttr(byName["credentials.resolve"], "credential.winning_profile") {
+		// winning_profile only set on success; the single-community fallback has
+		// an empty profile name, so accept either presence or candidates count.
+		if !hasAttr(byName["credentials.resolve"], "credential.candidates") {
+			t.Errorf("credentials.resolve missing credential attributes")
+		}
+	}
+}
+
+// TestTracingDisabledNoSpans asserts that when no SDK TracerProvider is
+// installed as the global (the default no-op tracer — i.e. traces.enabled is
+// false and tracing.New was never called), a full discovery cycle exports zero
+// spans into a SpanRecorder that is NOT wired to the global provider. This
+// proves instrumentation is a no-op when tracing is disabled.
+func TestTracingDisabledNoSpans(t *testing.T) {
+	// A recorder attached to a provider we never install globally. Because the
+	// global stays the default no-op tracer, the production instrumentation
+	// (tracing.Tracer().Start) emits nothing, and this recorder sees nothing.
+	sr := tracetest.NewSpanRecorder()
+	_ = sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	// The global TracerProvider is left as the default no-op (installRecorder's
+	// t.Cleanup has already restored it for any prior test in this package), so
+	// tracing.Tracer() returns the no-op tracer.
+
+	t.Setenv("TEST_COMM", "public")
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Discovery.Interval = 30 * time.Second
+	cfg.Discovery.CycleBudgetFraction = 1
+	cfg.Discovery.UnconfirmedLinkTTLCycles = 3
+	m := metrics.New(false)
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+	cfg.Targets = []config.TargetConfig{{Host: ip.String(), Port: int(port)}}
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	allow := snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	ctx, root := tracing.Tracer().Start(ctx, "discovery.cycle")
+	RunCycle(ctx, slogDiscard(), cfg, m, nil, nil, resolver, allow, map[graph.EdgeKey]int{})
+	root.End()
+
+	if got := len(sr.Ended()); got != 0 {
+		t.Errorf("expected 0 spans with tracing disabled, got %d", got)
+	}
+}
+
+func spanNames(spans []sdktrace.ReadOnlySpan) []string {
+	out := make([]string, len(spans))
+	for i, s := range spans {
+		out[i] = s.Name()
+	}
+	return out
+}
+
+func attrString(s sdktrace.ReadOnlySpan, key string) string {
+	if s == nil {
+		return ""
+	}
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func hasAttr(s sdktrace.ReadOnlySpan, key string) bool {
+	if s == nil {
+		return false
+	}
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,30 @@ type OTLPOutputConfig struct {
 	// OTLP/JSON. This is a wire-format change from the pre-v1.5.0 hand-rolled
 	// JSON path; OTLP receivers must accept protobuf (the OTLP default).
 	Protocol string `yaml:"protocol"`
+
+	// Traces configures opt-in OpenTelemetry tracing of the exporter's own
+	// discovery cycle (issue #68). It reuses Endpoint, Protocol, and auth from
+	// this block — tracing has no endpoint of its own.
+	Traces OTLPTracesConfig `yaml:"traces"`
+}
+
+// OTLPTracesConfig configures the opt-in trace signal layered on the OTLP
+// output. Tracing is disabled by default; when enabled it exports spans of the
+// discovery cycle over the same Endpoint/Protocol as OTLP metrics and logs.
+type OTLPTracesConfig struct {
+	// Enabled turns on tracing of the discovery cycle. Default false: when
+	// off, instrumentation calls resolve to the OTel no-op tracer and emit
+	// nothing.
+	Enabled bool `yaml:"enabled"`
+	// SampleRate is the head-sampling ratio in [0,1] applied to the root
+	// discovery.cycle span; child spans inherit the parent decision
+	// (ParentBased). Default 0.1. Set to 1.0 to sample every cycle (useful for
+	// low-cardinality debugging) or to a small fraction in production.
+	//
+	// A pointer so a config that omits sample_rate gets the 0.1 default while a
+	// config that explicitly sets sample_rate: 0.0 (sample nothing) is honoured
+	// rather than silently overridden by the default.
+	SampleRate *float64 `yaml:"sample_rate"`
 }
 
 // FederationConfig is the LD-15–LD-20 multi-instance coordination config.
@@ -385,6 +409,10 @@ func (c *Config) applyDefaults() {
 	if c.Output.OTLP.Protocol == "" {
 		c.Output.OTLP.Protocol = "http"
 	}
+	if c.Output.OTLP.Traces.SampleRate == nil {
+		def := 0.1
+		c.Output.OTLP.Traces.SampleRate = &def
+	}
 }
 
 func (c *Config) validateListen() error {
@@ -459,6 +487,9 @@ func (c *Config) validate() error {
 	case "", "http", "grpc":
 	default:
 		return fmt.Errorf("output.otlp.protocol must be http or grpc, got %q", c.Output.OTLP.Protocol)
+	}
+	if sr := c.Output.OTLP.Traces.SampleRate; sr != nil && (*sr < 0 || *sr > 1) {
+		return fmt.Errorf("output.otlp.traces.sample_rate must be in [0, 1], got %v", *sr)
 	}
 	if c.Output.OTLP.Enabled {
 		// gRPC endpoints are bare host:port authorities (or a URL); HTTP

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2331,3 +2331,69 @@ func TestEmitDeprecationWarningsNoopWhenNeitherKeySet(t *testing.T) {
 		t.Errorf("expected silent no-op; got log output:\n%s", buf.String())
 	}
 }
+
+// TestTracesDefaultSampleRate verifies output.otlp.traces defaults: disabled
+// with a 0.1 sample rate when the block is omitted (issue #68).
+func TestTracesDefaultSampleRate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("targets: []\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Output.OTLP.Traces.Enabled {
+		t.Error("traces.enabled default = true, want false")
+	}
+	if c.Output.OTLP.Traces.SampleRate == nil || *c.Output.OTLP.Traces.SampleRate != 0.1 {
+		t.Errorf("traces.sample_rate default = %v, want 0.1", c.Output.OTLP.Traces.SampleRate)
+	}
+}
+
+// TestTracesExplicitZeroSampleRateHonoured verifies an explicit sample_rate of
+// 0.0 is preserved rather than overridden by the 0.1 default (the reason the
+// field is a pointer).
+func TestTracesExplicitZeroSampleRateHonoured(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	body := `
+targets: []
+output:
+  otlp:
+    traces:
+      enabled: true
+      sample_rate: 0.0
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Output.OTLP.Traces.SampleRate == nil || *c.Output.OTLP.Traces.SampleRate != 0.0 {
+		t.Errorf("traces.sample_rate = %v, want explicit 0.0", c.Output.OTLP.Traces.SampleRate)
+	}
+}
+
+// TestTracesSampleRateOutOfRangeRejected verifies sample_rate outside [0,1] is
+// a validation error.
+func TestTracesSampleRateOutOfRangeRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	body := `
+targets: []
+output:
+  otlp:
+    traces:
+      sample_rate: 1.5
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected validation error for traces.sample_rate=1.5")
+	}
+}

--- a/internal/federation/hub.go
+++ b/internal/federation/hub.go
@@ -20,12 +20,17 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
 	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/limits"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snapshot"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
 
 // Per-push payload caps. These bound the size of a single spoke push and are
@@ -416,6 +421,16 @@ func validateSpokePayload(p SpokePayload) error {
 }
 
 func (h *Hub) handlePush(w http.ResponseWriter, r *http.Request) {
+	// Issue #68: continue the spoke's trace. Extract the W3C traceparent the
+	// spoke injected into the request headers and start hub.handlePush as a
+	// child of the spoke.push span, so the hub span shares the spoke's trace
+	// ID. When the spoke is not tracing, no traceparent is present and this
+	// span starts a fresh (unsampled-by-default) root.
+	ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+	ctx, span := tracing.Tracer().Start(ctx, "hub.handlePush")
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -465,6 +480,7 @@ func (h *Hub) handlePush(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "spoke_id required", http.StatusBadRequest)
 		return
 	}
+	span.SetAttributes(attribute.String("spoke.id", payload.SpokeID))
 	if len(payload.SpokeID) > 128 {
 		http.Error(w, "spoke_id too long (max 128)", http.StatusBadRequest)
 		return

--- a/internal/federation/spoke.go
+++ b/internal/federation/spoke.go
@@ -17,9 +17,16 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
 
 // fatalPushError wraps an error that should not be retried (e.g. a 4xx
@@ -89,8 +96,23 @@ var spokePushBaseBackoff = time.Second
 // times with exponential backoff starting at spokePushBaseBackoff. A cancelled
 // context aborts immediately without retrying.
 func (s *Spoke) Push(ctx context.Context, payload SpokePayload) error {
+	// Issue #68: spoke.push span. The post() helper injects this span's W3C
+	// traceparent into each outbound HTTP request, so the hub's hub.handlePush
+	// span continues the same trace. No-op when tracing is disabled (the
+	// no-op span's SpanContext is not sampled, so the propagator injects
+	// nothing).
+	ctx, span := tracing.Tracer().Start(ctx, "spoke.push",
+		trace.WithAttributes(
+			attribute.String("spoke.id", payload.SpokeID),
+			attribute.Int("spoke.devices", len(payload.Devices)),
+			attribute.Int("spoke.edges", len(payload.Edges)),
+		))
+	defer span.End()
+
 	b, err := json.Marshal(payload)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "marshal payload failed")
 		return fmt.Errorf("spoke: marshal payload: %w", err)
 	}
 
@@ -164,6 +186,11 @@ func (s *Spoke) post(ctx context.Context, body []byte) error {
 		return fmt.Errorf("build push request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Issue #68: inject the W3C traceparent (and baggage) of the active
+	// spoke.push span into the outbound headers so the hub can continue the
+	// trace. When tracing is disabled the active span is the OTel no-op whose
+	// SpanContext is not valid, so the propagator writes no headers.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("push to hub: %w", err)

--- a/internal/federation/tracing_propagation_test.go
+++ b/internal/federation/tracing_propagation_test.go
@@ -1,0 +1,102 @@
+package federation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// installTracing installs an always-sample SDK TracerProvider backed by a
+// SpanRecorder plus the W3C TraceContext propagator, restoring the previous
+// globals at test end. Mirrors what tracing.New does in production but without
+// an OTLP exporter so the test stays in-memory.
+func installTracing(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sr),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+	})
+	return sr
+}
+
+// TestSpokeToHubTraceparentPropagation proves the spoke→hub HTTP push carries
+// the W3C traceparent end to end: the spoke injects its spoke.push span's trace
+// context into the outbound request headers, and the hub's handlePush extracts
+// it so hub.handlePush shares the spoke.push trace ID. This is the propagation
+// acceptance test for issue #68.
+func TestSpokeToHubTraceparentPropagation(t *testing.T) {
+	sr := installTracing(t)
+
+	h := NewHub(config.FederationConfig{SpokeTimeout: time.Minute}, metrics.New(false), nil, "")
+
+	// httptest server with no TLS: handlePush handles r.TLS == nil (skips the
+	// cert-CN binding) so the push is accepted and hub.handlePush runs.
+	srv := httptest.NewServer(http.HandlerFunc(h.handlePush))
+	defer srv.Close()
+
+	s := newTestSpokeFor(t, srv.URL)
+	err := s.Push(context.Background(), SpokePayload{
+		SpokeID: "dc-test",
+		CycleAt: time.Now(),
+		Devices: []discovery.Device{{ID: "sw-1"}},
+		Edges: []discovery.Edge{{
+			SrcDevice:      "sw-1",
+			SrcPort:        "Gi0/1",
+			DstDevice:      "sw-2",
+			DiscoveryProto: discovery.DiscoveryProtocolLLDP,
+			Direction:      discovery.DirectionUnidirectional,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	var spokeSpan, hubSpan sdktrace.ReadOnlySpan
+	for _, sp := range sr.Ended() {
+		switch sp.Name() {
+		case "spoke.push":
+			spokeSpan = sp
+		case "hub.handlePush":
+			hubSpan = sp
+		}
+	}
+	if spokeSpan == nil {
+		t.Fatal("no spoke.push span recorded")
+	}
+	if hubSpan == nil {
+		t.Fatal("no hub.handlePush span recorded")
+	}
+
+	spokeTID := spokeSpan.SpanContext().TraceID()
+	hubTID := hubSpan.SpanContext().TraceID()
+	if spokeTID != hubTID {
+		t.Errorf("trace ID mismatch: spoke.push %s != hub.handlePush %s", spokeTID, hubTID)
+	}
+	// The hub span's parent must be the spoke.push span (continued across the
+	// wire via traceparent).
+	if hubSpan.Parent().SpanID() != spokeSpan.SpanContext().SpanID() {
+		t.Errorf("hub.handlePush parent = %s, want spoke.push %s",
+			hubSpan.Parent().SpanID(), spokeSpan.SpanContext().SpanID())
+	}
+}

--- a/internal/tracing/integration_test.go
+++ b/internal/tracing/integration_test.go
@@ -1,0 +1,57 @@
+package tracing_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
+)
+
+// TestTracingIntegration exercises a real span export against a live OTLP trace
+// receiver (e.g. Grafana Tempo, a Grafana Alloy otelcol.receiver.otlp, or an
+// OpenTelemetry Collector feeding Tempo/Jaeger). It is skipped unless
+// TRACING_INTEGRATION_ENDPOINT is set, because CI and the sandbox have no
+// receiver. This is the manual follow-up the maintainer must run to satisfy the
+// "spans show on a live Tempo/Jaeger receiver" acceptance item in issue #68.
+//
+// Run with, for example:
+//
+//	TRACING_INTEGRATION_ENDPOINT=http://localhost:4318 \
+//	TRACING_INTEGRATION_PROTOCOL=http \
+//	go test ./internal/tracing/ -run TestTracingIntegration -v
+//
+// then confirm a trace named "integration.smoke" with a child "integration.child"
+// arrives at the receiver. Repeat with TRACING_INTEGRATION_PROTOCOL=grpc against :4317.
+func TestTracingIntegration(t *testing.T) {
+	endpoint := os.Getenv("TRACING_INTEGRATION_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set TRACING_INTEGRATION_ENDPOINT to run the live-receiver integration test")
+	}
+	protocol := tracing.Protocol(os.Getenv("TRACING_INTEGRATION_PROTOCOL"))
+
+	ctx := context.Background()
+	p, err := tracing.New(ctx, tracing.Config{
+		Endpoint:   endpoint,
+		Protocol:   protocol,
+		Timeout:    5 * time.Second,
+		SampleRate: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("tracing.New: %v", err)
+	}
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = p.Shutdown(shutdownCtx)
+	})
+
+	tr := otel.Tracer(tracing.ScopeName)
+	ctx, root := tr.Start(ctx, "integration.smoke")
+	_, child := tr.Start(ctx, "integration.child")
+	child.End()
+	root.End()
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,227 @@
+// Package tracing implements opt-in OpenTelemetry tracing of the exporter's own
+// discovery cycle (issue #68). It is an additive trace signal layered on the
+// same OpenTelemetry Go SDK that the OTLP metrics+logs path uses (issue #82):
+// the TracerProvider exports spans via OTLP over the protocol configured for
+// output.otlp, reusing output.otlp.endpoint and the same transport. Tracing
+// does not get its own endpoint.
+//
+// When tracing is disabled (the default, output.otlp.traces.enabled=false) the
+// package installs no global TracerProvider, so otel.Tracer(...) returns the
+// SDK's no-op tracer and every instrumentation call in the discovery loop is a
+// cheap no-op. Instrumentation sites therefore never branch on an "is tracing
+// on" flag — they unconditionally call tracer.Start / span.SetAttributes and
+// rely on the no-op tracer to elide the work when disabled.
+//
+// Sampling is head-based: ParentBased(TraceIDRatioBased(sample_rate)). A child
+// span (e.g. a target.poll under a sampled discovery.cycle) inherits the
+// parent's sampling decision so a sampled cycle keeps all of its children; an
+// unsampled cycle drops them too. This keeps a trace whole rather than
+// half-sampling its spans.
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/version"
+)
+
+// Protocol selects the OTLP transport for the trace exporter. It mirrors the
+// otlp package's Protocol so tracing reuses output.otlp.protocol verbatim.
+type Protocol string
+
+// Protocol values. ProtocolHTTP (OTLP/HTTP) is the default.
+const (
+	ProtocolHTTP Protocol = "http"
+	ProtocolGRPC Protocol = "grpc"
+)
+
+const (
+	serviceName = "network-topology-exporter"
+	// ScopeName is the instrumentation scope reported on every span emitted by
+	// this exporter. It matches the metrics/logs scope so a single
+	// instrumentation library identifies all three signals.
+	ScopeName = "github.com/colinedwardwood/network-topology-exporter"
+)
+
+// Config holds the settings for the trace exporter. Endpoint, Timeout,
+// Protocol, and InstanceID are reused from the output.otlp block — tracing has
+// no endpoint of its own.
+type Config struct {
+	// Endpoint is the base URL of the OTLP receiver (shared with metrics/logs).
+	Endpoint string
+	// Timeout caps each individual span export. Defaults to 10s when zero.
+	Timeout time.Duration
+	// Protocol selects the OTLP transport: ProtocolHTTP (default) or
+	// ProtocolGRPC. Empty is treated as ProtocolHTTP.
+	Protocol Protocol
+	// InstanceID is emitted as service.instance.id; falls back to os.Hostname()
+	// when empty, mirroring the otlp metric/log exporter.
+	InstanceID string
+	// SampleRate is the head-sampling ratio in [0,1] for the root span. Child
+	// spans inherit the parent decision (ParentBased).
+	SampleRate float64
+}
+
+// Provider owns the OTel SDK TracerProvider for the discovery cycle. It is only
+// constructed when output.otlp.traces.enabled is true; New installs it as the
+// global TracerProvider and sets the W3C TraceContext propagator as the global
+// propagator so spoke→hub HTTP pushes carry traceparent.
+type Provider struct {
+	tp *sdktrace.TracerProvider
+}
+
+// New constructs a Provider, wiring an OTLP trace exporter (over the configured
+// protocol) into an SDK TracerProvider with head sampling
+// ParentBased(TraceIDRatioBased(SampleRate)). It installs the provider as the
+// global TracerProvider and sets the global propagator to W3C TraceContext +
+// Baggage. A zero Timeout becomes 10s; an empty Protocol defaults to HTTP.
+//
+// Callers MUST call Shutdown at process exit to flush buffered spans.
+func New(ctx context.Context, cfg Config) (*Provider, error) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	if cfg.Protocol == "" {
+		cfg.Protocol = ProtocolHTTP
+	}
+	switch cfg.Protocol {
+	case ProtocolHTTP, ProtocolGRPC:
+	default:
+		return nil, fmt.Errorf("tracing: unsupported protocol %q (want http or grpc)", cfg.Protocol)
+	}
+	if cfg.SampleRate < 0 || cfg.SampleRate > 1 {
+		return nil, fmt.Errorf("tracing: sample_rate %v out of range [0,1]", cfg.SampleRate)
+	}
+
+	instanceID := cfg.InstanceID
+	if instanceID == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			slog.Warn("tracing: os.Hostname() failed; service.instance.id will be empty", "error", err)
+		}
+		instanceID = hostname
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(version.Version),
+			semconv.ServiceInstanceID(instanceID),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("tracing: build resource: %w", err)
+	}
+
+	exp, err := newTraceExporter(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("tracing: build trace exporter: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(res),
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.SampleRate))),
+	)
+
+	otel.SetTracerProvider(tp)
+	// Set the global propagator so the federation spoke can inject a W3C
+	// traceparent into its outbound HTTP push and the hub can extract it,
+	// linking hub.handlePush to the spoke's spoke.push span across the wire.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return &Provider{tp: tp}, nil
+}
+
+// Shutdown flushes buffered spans and releases the TracerProvider. Safe to call
+// once at process shutdown. A nil Provider Shutdown is a no-op so callers need
+// not branch on whether tracing was enabled.
+func (p *Provider) Shutdown(ctx context.Context) error {
+	if p == nil || p.tp == nil {
+		return nil
+	}
+	if err := p.tp.Shutdown(ctx); err != nil {
+		return fmt.Errorf("tracing: shutdown tracer provider: %w", err)
+	}
+	return nil
+}
+
+// newTraceExporter builds the OTLP trace exporter for the configured protocol.
+// The endpoint handling mirrors internal/output/otlp so tracing and metrics/
+// logs reach the same receiver with identical scheme/insecure semantics.
+func newTraceExporter(ctx context.Context, cfg Config) (*otlptrace.Exporter, error) {
+	switch cfg.Protocol {
+	case ProtocolGRPC:
+		opts := []otlptracegrpc.Option{otlptracegrpc.WithTimeout(cfg.Timeout)}
+		host, insecure := endpointHostInsecure(cfg.Endpoint)
+		if host != "" {
+			opts = append(opts, otlptracegrpc.WithEndpoint(host))
+		}
+		if insecure {
+			opts = append(opts, otlptracegrpc.WithInsecure())
+		}
+		return otlptracegrpc.New(ctx, opts...)
+	default: // ProtocolHTTP
+		opts := []otlptracehttp.Option{otlptracehttp.WithTimeout(cfg.Timeout)}
+		if u, insecure, ok := endpointURL(cfg.Endpoint); ok {
+			opts = append(opts, otlptracehttp.WithEndpointURL(u))
+			if insecure {
+				opts = append(opts, otlptracehttp.WithInsecure())
+			}
+		}
+		return otlptracehttp.New(ctx, opts...)
+	}
+}
+
+// endpointURL normalises an HTTP base endpoint into the per-signal URL the
+// SDK's WithEndpointURL expects, reporting whether the scheme is plain http so
+// the caller can add WithInsecure. ok is false when endpoint is empty.
+func endpointURL(endpoint string) (rawURL string, insecure bool, ok bool) {
+	if endpoint == "" {
+		return "", false, false
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint, false, true
+	}
+	return endpoint, u.Scheme == "http", true
+}
+
+// endpointHostInsecure extracts host:port and the insecure flag for the gRPC
+// exporter, which takes a bare authority rather than a URL.
+func endpointHostInsecure(endpoint string) (host string, insecure bool) {
+	if endpoint == "" {
+		return "", false
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		return endpoint, true
+	}
+	return u.Host, u.Scheme == "http"
+}
+
+// Tracer returns the exporter's tracer from the global TracerProvider. When
+// tracing is disabled this is the no-op tracer, so every Start call is cheap.
+// Instrumentation sites call this rather than holding a tracer handle so they
+// observe whichever provider New installed (or the default no-op).
+func Tracer() trace.Tracer {
+	return otel.Tracer(ScopeName)
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,48 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNewRejectsBadProtocol verifies New rejects an unsupported protocol.
+func TestNewRejectsBadProtocol(t *testing.T) {
+	_, err := New(context.Background(), Config{Protocol: "carrier-pigeon", SampleRate: 0.1})
+	if err == nil {
+		t.Fatal("expected error for unsupported protocol, got nil")
+	}
+}
+
+// TestNewRejectsOutOfRangeSampleRate verifies the [0,1] range is enforced.
+func TestNewRejectsOutOfRangeSampleRate(t *testing.T) {
+	for _, sr := range []float64{-0.1, 1.5} {
+		if _, err := New(context.Background(), Config{SampleRate: sr}); err == nil {
+			t.Errorf("sample_rate %v: expected range error, got nil", sr)
+		}
+	}
+}
+
+// TestNewInstallsProviderAndShutdown verifies New builds a provider over HTTP
+// (no live receiver needed — the exporter connects lazily) and that Shutdown is
+// safe, including on a nil Provider.
+func TestNewInstallsProviderAndShutdown(t *testing.T) {
+	p, err := New(context.Background(), Config{
+		Endpoint:   "http://127.0.0.1:4318",
+		Protocol:   ProtocolHTTP,
+		SampleRate: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p == nil {
+		t.Fatal("New returned nil provider without error")
+	}
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+
+	var nilP *Provider
+	if err := nilP.Shutdown(context.Background()); err != nil {
+		t.Errorf("nil Provider Shutdown should be a no-op, got %v", err)
+	}
+}


### PR DESCRIPTION
Adds opt-in self-tracing of the discovery cycle, reusing the OTel SDK plumbing from #82. Disabled by default (`output.otlp.traces.enabled: false`).

- Spans: root `discovery.cycle` → `target.poll` (IP, credential profile, latency) → `<module>.walk` (pdu count, outcome); plus `credentials.resolve`, `graph.reconcile` (per-source edge counts).
- Federation: `spoke.push` injects W3C `traceparent`; hub extracts it and runs `hub.handlePush` as a child span — cross-process trace linking.
- Head sampling: `ParentBased(TraceIDRatioBased(sample_rate))`, configurable via `output.otlp.traces.sample_rate` (default 0.1). Reuses the existing `output.otlp` endpoint/protocol/auth.
- New `internal/tracing` package builds the `TracerProvider`; disabled = global no-op (proven by `TestTracingDisabledNoSpans`). Propagation proven by `TestSpokeToHubTraceparentPropagation`.
- Docs: `docs/operator/tracing.md`; `config/example.yaml`, README, CHANGELOG updated.

`go build`/`vet`/`test ./...` and `-race` on app+federation+tracing all pass. Note: the MPLS module span is `mpls_te.walk` (matches its Prometheus label).

**Manual follow-up:** live Tempo/Jaeger verification via the env-guarded scaffold (`TRACING_INTEGRATION_ENDPOINT=… go test ./internal/tracing/ -run TestTracingIntegration`).

Closes #68.