### PR TITLE
Harden /admin/rediscover, fix OTLP phantom topology, drop dead stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ the README. The lab-fixture-capture work previously slotted for
 v1.3.1 lands under this milestone instead, renamed to
 [v1.4.0-rc.1 — Lab Fixture Capture](https://github.com/colinedwardwood/network-topology-exporter/milestones).
 
+### Security & correctness (post-merge hardening)
+
+- **`/admin/rediscover` auth gate now requires real client authentication.** The
+  endpoint previously enabled itself whenever `listen.web_config_file` was set —
+  but a TLS-only web-config encrypts without authenticating the caller, so any
+  HTTPS-only deployment exposed the privileged forced-walk endpoint
+  unauthenticated. It now parses the web-config and enables the endpoint only
+  when `basic_auth_users` is set or a client-cert-requiring `client_auth_type`
+  (`RequireAnyClientCert`/`RequireAndVerifyClientCert`) is configured; otherwise
+  it stays `403` (fails closed on an unreadable/unparseable config). Regression
+  test `TestWebConfigHasClientAuth`.
+- **`/admin/rediscover` no longer monopolises the discovery cycle.** The forced
+  walk now acquires the cycle mutex **per target** instead of around the whole
+  batch, so a large or slow/unreachable batch can no longer stall the regular
+  discovery cycle for the full request — bounding the contiguous hold to one
+  device's walk while still serialising each walk against the cycle.
+- **OTLP no longer reports phantom topology.** The edge/device metrics are now
+  **observable gauges** that report exactly the current graph on each
+  collection. The previous synchronous gauges retained every recorded
+  attribute-set under cumulative temporality, so a removed edge/device would
+  linger at the OTLP receiver indefinitely. Regression test
+  `TestPushGraphDropsStaleEdges`.
+- Removed the dead no-op `Config.EmitDeprecationWarnings` stub (no deprecated
+  keys remain after v1.5.0; a future deprecation re-introduces a real one).
+- Documented the topology dashboard's **Grafana SQL Expressions** requirement
+  in `dashboards/test-harness/README.md`.
+
 ### Configuration
 
 - **#63 — Config schema parity audit.** `config/example.yaml` is now the

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Two reusable harness stacks live under `deploy/`:
 | [`deploy/test-harness/`](deploy/test-harness/) | Single-shot test harness — exporter + Alloy shipping a fixed topology to Grafana Cloud, used to validate a build end-to-end. |
 | [`deploy/long-running-test/`](deploy/long-running-test/) | Continuously-running validation lab. A mutator container rotates between four containerlab topologies every UTC hour (chain → cross-link → ring → CLOS) to exercise add/remove/swap reconciliation. Ships to Grafana Cloud with `tester_id=long-running-lab`. |
 
-Curated dashboards for both harnesses live in [`dashboards/test-harness/`](dashboards/test-harness/).
+Curated dashboards for both harnesses live in [`dashboards/test-harness/`](dashboards/test-harness/) — see its [README](dashboards/test-harness/README.md) for what each shows and requirements (the topology Node Graph relies on Grafana SQL Expressions).
 
 ## Architecture
 

--- a/dashboards/test-harness/README.md
+++ b/dashboards/test-harness/README.md
@@ -1,0 +1,33 @@
+# Test-harness dashboards
+
+Curated Grafana dashboards for the test harnesses (`deploy/test-harness/`,
+`deploy/long-running-test/`). Import them into a Grafana stack that scrapes the
+exporter's `/metrics` (and, optionally, has the topology logs in Loki).
+
+| File | Dashboard | Reads |
+|---|---|---|
+| `getting-started.json` | 00. Getting Started | onboarding / health basics |
+| `harness-health.json` | 01. Harness Health | exporter operational metrics |
+| `topology-graph.json` | 02. Network Topology | `network_topology_device_info`, `network_topology_edge_info` |
+| `topology-schedule.json` | 03. Topology Schedule | change events / cycle timing |
+
+## Requirements
+
+> [!IMPORTANT]
+> **`topology-graph.json` requires Grafana [SQL Expressions](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries/).**
+> The Node Graph panel builds its node frame with a server-side SQL expression
+> (`datasource: __expr__`, `type: sql`) that pivots per-protocol arc ratios into
+> the `arc__*` columns the panel colours, and joins in the degree stat. On a
+> Grafana stack where SQL Expressions are unavailable or disabled, that panel
+> renders **no data** (the other panels are unaffected).
+>
+> SQL Expressions are available in Grafana Cloud and in recent OSS/Enterprise
+> releases; on self-managed Grafana confirm the feature is enabled before
+> relying on the topology panel. There is currently no transform-only fallback —
+> the proportional, per-protocol coloured ring is not achievable through the
+> standard transform pipeline (the arc segments cannot be coloured without the
+> SQL-expression frame).
+
+The dashboards use the `$datasource` (Prometheus) and `$tester_id` template
+variables; select your stack's Prometheus datasource and a `tester_id` present
+in the data after import.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,7 +68,6 @@ func Run(ctx context.Context, args []string) int {
 		logger.Error("loading config failed", "error", err)
 		return 1
 	}
-	cfg.EmitDeprecationWarnings(logger)
 	logger.Info("config loaded",
 		"discovery_interval", cfg.Discovery.Interval,
 		"parallelism", cfg.Discovery.Parallelism,
@@ -243,8 +242,10 @@ func Run(ctx context.Context, args []string) int {
 		// Rediscoverer carries its own credential resolver built from the same
 		// config; access to either resolver is serialised by cycleMu, so the
 		// two paths never hit a device concurrently. The endpoint is privileged:
-		// it only runs when listen.web_config_file configures basic_auth/mTLS,
-		// otherwise the handler returns 403.
+		// it only runs when listen.web_config_file actually authenticates the
+		// caller (basic_auth_users, or a client-cert-requiring client_auth_type).
+		// A TLS-only web-config encrypts but does NOT authenticate the client, so
+		// it does not enable the endpoint — the handler returns 403.
 		var cycleMu sync.Mutex
 		adminResolver, err := credentials.New(cfg.Credentials)
 		if err != nil {
@@ -252,7 +253,7 @@ func Run(ctx context.Context, args []string) int {
 			return 1
 		}
 		allowedNets := snmpwalk.ParseCIDRs(cfg.Discovery.Scope.CIDRAllowList)
-		rediscoverer := NewRediscoverer(cfg, m, logger, adminResolver, allowedNets, &cycleMu, cfg.Listen.WebConfigFile != "")
+		rediscoverer := NewRediscoverer(cfg, m, logger, adminResolver, allowedNets, &cycleMu, WebConfigHasClientAuth(cfg.Listen.WebConfigFile))
 		mux.HandleFunc("/admin/rediscover", httpx.NewRediscoverHandler(rediscoverer))
 
 		workerDone.Add(1)

--- a/internal/app/rediscover.go
+++ b/internal/app/rediscover.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
@@ -111,6 +114,42 @@ func NewRediscoverer(
 // uses this to fail closed (403) when no auth is configured.
 func (rd *Rediscoverer) AuthConfigured() bool { return rd.authConfigured }
 
+// WebConfigHasClientAuth reports whether the Prometheus exporter-toolkit
+// web-config at path actually authenticates the CLIENT — i.e. it defines
+// basic_auth_users or requires a client certificate. Plain server TLS
+// (tls_server_config without a client-cert-requiring client_auth_type)
+// encrypts the channel but does NOT authenticate the caller, so it must not
+// gate the privileged /admin/rediscover endpoint. Fails closed: an empty path
+// or an unreadable/unparseable config returns false (endpoint stays 403).
+func WebConfigHasClientAuth(path string) bool {
+	if path == "" {
+		return false
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // operator-supplied config path
+	if err != nil {
+		return false
+	}
+	var wc struct {
+		BasicAuthUsers  map[string]string `yaml:"basic_auth_users"`
+		TLSServerConfig struct {
+			ClientAuthType string `yaml:"client_auth_type"`
+		} `yaml:"tls_server_config"`
+	}
+	if err := yaml.Unmarshal(b, &wc); err != nil {
+		return false
+	}
+	if len(wc.BasicAuthUsers) > 0 {
+		return true
+	}
+	// Only these two require the client to present a certificate. RequestClientCert
+	// and VerifyClientCertIfGiven make the cert optional → not authentication.
+	switch wc.TLSServerConfig.ClientAuthType {
+	case "RequireAnyClientCert", "RequireAndVerifyClientCert":
+		return true
+	}
+	return false
+}
+
 // Rediscover runs a forced out-of-cycle walk against each target IP and
 // returns one result per target in input order. Out-of-scope targets are
 // rejected before any SNMP traffic is sent. The whole batch runs under
@@ -151,9 +190,13 @@ func (rd *Rediscoverer) Rediscover(ctx context.Context, targets []string) []Redi
 		return results
 	}
 
-	// Serialise the SNMP work against the regular cycle.
-	rd.cycleMu.Lock()
-	defer rd.cycleMu.Unlock()
+	// Serialise the SNMP work against the regular cycle, but acquire CycleMu
+	// PER TARGET rather than around the whole batch: a forced rediscover of many
+	// (or slow/unreachable) targets must not monopolise the mutex and stall the
+	// regular discovery cycle for the entire batch. Locking per target bounds
+	// the contiguous hold to one device's walk and lets the regular cycle
+	// interleave between targets, while still guaranteeing the two paths never
+	// hit a device concurrently.
 	for _, p := range toWalk {
 		select {
 		case <-ctx.Done():
@@ -163,7 +206,9 @@ func (rd *Rediscoverer) Rediscover(ctx context.Context, targets []string) []Redi
 			continue
 		default:
 		}
+		rd.cycleMu.Lock()
 		outcome, edges, err := rd.walkOne(ctx, p.ip)
+		rd.cycleMu.Unlock()
 		results[p.idx].Outcome = outcome
 		results[p.idx].Edges = edges
 		if err != nil {

--- a/internal/app/rediscover_auth_test.go
+++ b/internal/app/rediscover_auth_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWebConfigHasClientAuth guards the /admin/rediscover auth predicate.
+// The critical case is TLS-only: a web-config that sets server TLS but no
+// client authentication encrypts the channel without authenticating the
+// caller, so it must NOT enable the privileged endpoint (the handler must
+// keep returning 403). Failing this test reopens a remote, unauthenticated
+// self-DoS vector.
+func TestWebConfigHasClientAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"empty path", "", false}, // handled via path=="" below
+		{"comment only", "# nothing\n", false},
+		{"tls server only (encrypt, no client auth)", "tls_server_config:\n  cert_file: a.pem\n  key_file: a.key\n", false},
+		{"tls request-only client cert (optional)", "tls_server_config:\n  cert_file: a.pem\n  key_file: a.key\n  client_auth_type: RequestClientCert\n", false},
+		{"tls verify-if-given (optional)", "tls_server_config:\n  client_auth_type: VerifyClientCertIfGiven\n", false},
+		{"basic auth users", "basic_auth_users:\n  admin: $2y$10$hash\n", true},
+		{"mTLS require-any", "tls_server_config:\n  client_auth_type: RequireAnyClientCert\n", true},
+		{"mTLS require-and-verify", "tls_server_config:\n  client_auth_type: RequireAndVerifyClientCert\n", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "empty path" {
+				if WebConfigHasClientAuth("") {
+					t.Fatal("empty path: want false")
+				}
+				return
+			}
+			p := filepath.Join(t.TempDir(), "web-config.yml")
+			if err := os.WriteFile(p, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := WebConfigHasClientAuth(p); got != tc.want {
+				t.Errorf("WebConfigHasClientAuth(%q) = %v, want %v", tc.yaml, got, tc.want)
+			}
+		})
+	}
+
+	// A path that does not exist must fail closed (false), not panic.
+	if WebConfigHasClientAuth(filepath.Join(t.TempDir(), "absent.yml")) {
+		t.Error("nonexistent web-config: want false (fail closed)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -795,15 +794,6 @@ func (c *Config) validateFDB() error {
 		return errors.New("fdb.max_vlans must be at most 4096")
 	}
 	return nil
-}
-
-// EmitDeprecationWarnings is a no-op stub retained so call-sites in main
-// continue to compile without modification. All three deprecated config keys
-// (use_v2_mib, strict_device_name_matching, tls_cert_file/tls_key_file) were
-// removed in v1.5.0; the YAML loader now rejects them with a parse error.
-// Returns false always.
-func (c *Config) EmitDeprecationWarnings(_ *slog.Logger) bool {
-	return false
 }
 
 func cidrContainsAny(nets []*net.IPNet, ip net.IP) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1689,31 +1688,6 @@ func TestListenWebConfigFileWithLegacyTLSRejected(t *testing.T) {
 	}
 }
 
-// TestListenTLSRemovedKeysEmitNoWarning verifies that EmitDeprecationWarnings
-// is a no-op now that all deprecated TLS keys have been removed in v1.5.0.
-func TestListenTLSRemovedKeysEmitNoWarning(t *testing.T) {
-	// Only web_config_file (the current API) is used here — the old
-	// tls_cert_file/tls_key_file keys would cause a parse error so we
-	// cannot construct a config that uses them and still calls Load.
-	dir := t.TempDir()
-	webCfgPath := filepath.Join(dir, "web-config.yml")
-	if err := os.WriteFile(webCfgPath, []byte("# empty\n"), 0o600); err != nil {
-		t.Fatalf("write web-config: %v", err)
-	}
-	cfgPath := filepath.Join(dir, "config.yaml")
-	body := "listen:\n  web_config_file: " + webCfgPath + "\n"
-	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if c.EmitDeprecationWarnings(nil) {
-		t.Error("EmitDeprecationWarnings returned true; expected false (no deprecated keys remain)")
-	}
-}
-
 // TestListenTLSNeitherSet verifies that omitting both TLS fields is valid
 // (plain HTTP mode).
 func TestListenTLSNeitherSet(t *testing.T) {
@@ -2305,30 +2279,6 @@ func TestRemovedKeysProduceParseError(t *testing.T) {
 				t.Fatalf("expected parse error for removed deprecated key(s), got nil")
 			}
 		})
-	}
-}
-
-// TestEmitDeprecationWarningsNoopWhenNeitherKeySet verifies that
-// EmitDeprecationWarnings is a silent no-op when only the new keys (or no
-// keys at all) are used.
-func TestEmitDeprecationWarningsNoopWhenNeitherKeySet(t *testing.T) {
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(cfgPath, []byte("targets: []\n"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	c, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-
-	var buf strings.Builder
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	if c.EmitDeprecationWarnings(logger) {
-		t.Errorf("EmitDeprecationWarnings returned true; expected false (no deprecated keys)")
-	}
-	if buf.Len() > 0 {
-		t.Errorf("expected silent no-op; got log output:\n%s", buf.String())
 	}
 }
 

--- a/internal/output/otlp/otlp.go
+++ b/internal/output/otlp/otlp.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -87,9 +88,53 @@ type Exporter struct {
 	meterProvider  *sdkmetric.MeterProvider
 	loggerProvider *log.LoggerProvider
 
-	edgeGauge   otelmetric.Float64Gauge
-	deviceGauge otelmetric.Float64Gauge
-	logger      otellog.Logger
+	// latest holds the most recent graph pushed via PushGraph. The edge/device
+	// metrics are OBSERVABLE gauges whose callbacks read this pointer on every
+	// collection, so each export reflects exactly the current graph — a removed
+	// edge/device is simply not observed and therefore disappears at the
+	// receiver. A synchronous gauge would instead retain every attribute-set
+	// ever recorded under cumulative temporality, leaving phantom links in the
+	// topology at the collector indefinitely.
+	latest atomic.Pointer[discovery.Graph]
+	logger otellog.Logger
+}
+
+// edgeAttrs builds the OTLP attribute set for one topology edge.
+func edgeAttrs(edge discovery.Edge) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("src_device", sanitizeUTF8(edge.SrcDevice)),
+		attribute.String("src_port", sanitizeUTF8(edge.SrcPort)),
+		attribute.String("dst_device", sanitizeUTF8(edge.DstDevice)),
+		attribute.String("dst_port", sanitizeUTF8(edge.DstPort)),
+		attribute.String("proto", sanitizeUTF8(string(edge.DiscoveryProto))),
+		attribute.String("link_kind", sanitizeUTF8(string(edge.LinkKind))),
+		attribute.String("direction", sanitizeUTF8(string(edge.Direction))),
+		attribute.String("confidence", sanitizeUTF8(string(edge.Confidence))),
+		attribute.String("adjacency", sanitizeUTF8(string(edge.Adjacency))),
+		attribute.String("precedence_rank", strconv.Itoa(edge.PrecedenceRank)),
+	}
+	for k, v := range edge.Metadata {
+		attrs = append(attrs, attribute.String(metadataAttrPrefix+k, sanitizeUTF8(v)))
+	}
+	return attrs
+}
+
+// deviceAttrs builds the OTLP attribute set for one device.
+func deviceAttrs(dev discovery.Device) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attribute.String("device", sanitizeUTF8(dev.ID))}
+	if dev.Vendor != "" {
+		attrs = append(attrs, attribute.String("vendor", sanitizeUTF8(dev.Vendor)))
+	}
+	if dev.Model != "" {
+		attrs = append(attrs, attribute.String("model", sanitizeUTF8(dev.Model)))
+	}
+	if dev.OSVersion != "" {
+		attrs = append(attrs, attribute.String("os_version", sanitizeUTF8(dev.OSVersion)))
+	}
+	if dev.Site != "" {
+		attrs = append(attrs, attribute.String("site", sanitizeUTF8(dev.Site)))
+	}
+	return attrs
 }
 
 const (
@@ -173,25 +218,44 @@ func assemble(res *resource.Resource, reader sdkmetric.Reader, proc log.Processo
 		log.WithProcessor(proc),
 	)
 
+	e := &Exporter{
+		meterProvider:  mp,
+		loggerProvider: lp,
+		logger:         lp.Logger(scopeName),
+	}
+
 	meter := mp.Meter(scopeName)
-	edgeGauge, err := meter.Float64Gauge("network_topology_edge_info",
-		otelmetric.WithDescription("Topology edge presence; value 1 with edge attributes."))
-	if err != nil {
+	// Observable gauges: the callback reports exactly the current graph on each
+	// collection, so removed edges/devices vanish at the receiver instead of
+	// lingering as phantom topology under cumulative temporality.
+	if _, err := meter.Float64ObservableGauge("network_topology_edge_info",
+		otelmetric.WithDescription("Topology edge presence; value 1 with edge attributes."),
+		otelmetric.WithFloat64Callback(func(_ context.Context, o otelmetric.Float64Observer) error {
+			if g := e.latest.Load(); g != nil {
+				for _, edge := range g.Edges {
+					o.Observe(1.0, otelmetric.WithAttributes(edgeAttrs(edge)...))
+				}
+			}
+			return nil
+		}),
+	); err != nil {
 		return nil, fmt.Errorf("otlp: create edge gauge: %w", err)
 	}
-	deviceGauge, err := meter.Float64Gauge("network_topology_device_info",
-		otelmetric.WithDescription("Discovered device presence; value 1 with device attributes."))
-	if err != nil {
+	if _, err := meter.Float64ObservableGauge("network_topology_device_info",
+		otelmetric.WithDescription("Discovered device presence; value 1 with device attributes."),
+		otelmetric.WithFloat64Callback(func(_ context.Context, o otelmetric.Float64Observer) error {
+			if g := e.latest.Load(); g != nil {
+				for _, dev := range g.Devices {
+					o.Observe(1.0, otelmetric.WithAttributes(deviceAttrs(dev)...))
+				}
+			}
+			return nil
+		}),
+	); err != nil {
 		return nil, fmt.Errorf("otlp: create device gauge: %w", err)
 	}
 
-	return &Exporter{
-		meterProvider:  mp,
-		loggerProvider: lp,
-		edgeGauge:      edgeGauge,
-		deviceGauge:    deviceGauge,
-		logger:         lp.Logger(scopeName),
-	}, nil
+	return e, nil
 }
 
 // newMetricExporter builds the OTLP metric exporter for the configured
@@ -286,47 +350,13 @@ func sanitizeUTF8(s string) string {
 	return strings.ToValidUTF8(s, "�")
 }
 
-// PushGraph records graph.Edges and graph.Devices as OTLP gauge measurements
-// and force-flushes them through the MeterProvider's OTLP exporter.
+// PushGraph publishes the current graph as the snapshot the observable edge/
+// device gauges report, then force-flushes a collection through the OTLP
+// exporter. Because the gauges observe this snapshot (rather than accumulating
+// recorded measurements), each push emits exactly the edges/devices present in
+// g — edges removed since the last push are not re-emitted.
 func (e *Exporter) PushGraph(ctx context.Context, g discovery.Graph) error {
-	for _, edge := range g.Edges {
-		attrs := []attribute.KeyValue{
-			attribute.String("src_device", sanitizeUTF8(edge.SrcDevice)),
-			attribute.String("src_port", sanitizeUTF8(edge.SrcPort)),
-			attribute.String("dst_device", sanitizeUTF8(edge.DstDevice)),
-			attribute.String("dst_port", sanitizeUTF8(edge.DstPort)),
-			attribute.String("proto", sanitizeUTF8(string(edge.DiscoveryProto))),
-			attribute.String("link_kind", sanitizeUTF8(string(edge.LinkKind))),
-			attribute.String("direction", sanitizeUTF8(string(edge.Direction))),
-			attribute.String("confidence", sanitizeUTF8(string(edge.Confidence))),
-			attribute.String("adjacency", sanitizeUTF8(string(edge.Adjacency))),
-			attribute.String("precedence_rank", strconv.Itoa(edge.PrecedenceRank)),
-		}
-		for k, v := range edge.Metadata {
-			attrs = append(attrs, attribute.String(metadataAttrPrefix+k, sanitizeUTF8(v)))
-		}
-		e.edgeGauge.Record(ctx, 1.0, otelmetric.WithAttributes(attrs...))
-	}
-
-	for _, dev := range g.Devices {
-		attrs := []attribute.KeyValue{
-			attribute.String("device", sanitizeUTF8(dev.ID)),
-		}
-		if dev.Vendor != "" {
-			attrs = append(attrs, attribute.String("vendor", sanitizeUTF8(dev.Vendor)))
-		}
-		if dev.Model != "" {
-			attrs = append(attrs, attribute.String("model", sanitizeUTF8(dev.Model)))
-		}
-		if dev.OSVersion != "" {
-			attrs = append(attrs, attribute.String("os_version", sanitizeUTF8(dev.OSVersion)))
-		}
-		if dev.Site != "" {
-			attrs = append(attrs, attribute.String("site", sanitizeUTF8(dev.Site)))
-		}
-		e.deviceGauge.Record(ctx, 1.0, otelmetric.WithAttributes(attrs...))
-	}
-
+	e.latest.Store(&g)
 	if err := e.meterProvider.ForceFlush(ctx); err != nil {
 		return fmt.Errorf("otlp: flush metrics: %w", err)
 	}

--- a/internal/output/otlp/otlp_test.go
+++ b/internal/output/otlp/otlp_test.go
@@ -502,3 +502,39 @@ func TestNewGRPCConstructs(t *testing.T) {
 	defer cancel()
 	_ = exp.Shutdown(ctx)
 }
+
+// TestPushGraphDropsStaleEdges proves the observable-gauge fix for the
+// cumulative-temporality phantom-edge flaw: pushing a graph with fewer edges
+// than the previous push must NOT leave the removed edge reported at the
+// receiver. The old synchronous Float64Gauge retained every recorded
+// attribute-set and would fail this test.
+func TestPushGraphDropsStaleEdges(t *testing.T) {
+	exp, reader, _ := newTestExporter("")
+	ctx := context.Background()
+
+	two := discovery.Graph{Edges: []discovery.Edge{
+		{SrcDevice: "a", SrcPort: "1", DstDevice: "b", DstPort: "2", DiscoveryProto: "lldp", LinkKind: "ethernet"},
+		{SrcDevice: "c", SrcPort: "3", DstDevice: "d", DstPort: "4", DiscoveryProto: "lldp", LinkKind: "ethernet"},
+	}}
+	if err := exp.PushGraph(ctx, two); err != nil {
+		t.Fatalf("PushGraph(two): %v", err)
+	}
+	if pts := collectMetrics(t, reader)["network_topology_edge_info"]; len(pts) != 2 {
+		t.Fatalf("first push: edge points = %d, want 2", len(pts))
+	}
+
+	// Remove the c→d edge.
+	one := discovery.Graph{Edges: []discovery.Edge{
+		{SrcDevice: "a", SrcPort: "1", DstDevice: "b", DstPort: "2", DiscoveryProto: "lldp", LinkKind: "ethernet"},
+	}}
+	if err := exp.PushGraph(ctx, one); err != nil {
+		t.Fatalf("PushGraph(one): %v", err)
+	}
+	pts := collectMetrics(t, reader)["network_topology_edge_info"]
+	if len(pts) != 1 {
+		t.Fatalf("after edge removal: edge points = %d, want 1 (the removed edge must not persist)", len(pts))
+	}
+	if pts[0]["src_device"] != "a" {
+		t.Errorf("surviving edge src_device = %q, want a", pts[0]["src_device"])
+	}
+}


### PR DESCRIPTION
Remediation of the issues found in the adversarial review of this milestone's merged work. All grounded in `file:line` evidence; regression-tested.

### Security
- **`/admin/rediscover` auth gate.** Was enabled by `listen.web_config_file != ""` — but a TLS-only web-config encrypts without authenticating the caller, so any HTTPS-only deployment exposed the privileged forced-walk endpoint **unauthenticated**. Now gated on real client auth (`basic_auth_users`, or a client-cert-requiring `client_auth_type`); fails closed otherwise. New `WebConfigHasClientAuth` + `TestWebConfigHasClientAuth` (the TLS-only → false case is the guard).

### Availability
- **`/admin/rediscover` cycle hold.** The forced walk held the cycle mutex around the whole batch (up to the ~2-min request deadline), so a slow/unreachable batch stalled the regular discovery cycle. Now locks **per target**, bounding the contiguous hold to one device's walk while still serialising each walk against the cycle.

### Correctness
- **OTLP phantom topology.** Edge/device metrics were synchronous gauges; under cumulative temporality every recorded attribute-set persisted, so a removed edge lingered at the receiver indefinitely. Now **observable gauges** that report exactly the current graph each collection. New `TestPushGraphDropsStaleEdges`.

### Cleanup / docs
- Removed the dead no-op `Config.EmitDeprecationWarnings` stub (+ its call site and the two tests pinning it).
- Documented the topology dashboard's **Grafana SQL Expressions** requirement (`dashboards/test-harness/README.md`).

### Verified-clean (no change needed)
- **Relicense consent:** the full history (423 commits) has a single author, so the Apache→AGPL relicense needed no third-party consent.

`go build`/`vet`/`test ./...` and `-race` on app/otlp/config all pass.