### PR TITLE
Add OTLP validation harness (test asset)

### DIFF
--- a/deploy/otlp-validation/.env.example
+++ b/deploy/otlp-validation/.env.example
@@ -1,0 +1,12 @@
+# Grafana Cloud OTLP gateway connection for the validation harness.
+# Copy to .env (gitignored) and fill in. Find these under
+# Connections -> OTLP in your Grafana Cloud stack.
+
+# OTLP gateway base URL (the harness appends /v1/metrics, /v1/logs, /v1/traces).
+GCLOUD_OTLP_ENDPOINT=https://otlp-gateway-prod-<region>.grafana.net/otlp
+
+# OTLP instance ID (the basic-auth username for the gateway).
+GCLOUD_OTLP_USER=000000
+
+# Grafana Cloud access-policy token with metrics/logs/traces write scopes.
+GCLOUD_TOKEN=glc_replace_me

--- a/deploy/otlp-validation/README.md
+++ b/deploy/otlp-validation/README.md
@@ -1,0 +1,60 @@
+# OTLP validation harness
+
+A self-contained stack for validating the exporter's **OTLP push** path
+(metrics, logs, traces) end-to-end through **Grafana Alloy** to a Grafana Cloud
+OTLP gateway. This is a test/validation asset — not a deployment template (for
+operator deployments see `deploy/test-harness/` and `deploy/long-running-test/`).
+
+## What it exercises
+
+- `output.otlp` metric + log push (`internal/output/otlp`).
+- `output.otlp.traces` — discovery-cycle tracing (`internal/tracing`).
+- The **observable-gauge** behaviour: when a device or edge disappears, the
+  exporter stops exporting its series — no stale/phantom topology at the
+  receiver. (Regression-tested in `internal/output/otlp/otlp_test.go`
+  `TestPushGraphDropsStaleEdges`; this harness confirms it on the wire.)
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | `snmpsim` (one discoverable device) + the exporter (built from this repo) + Alloy (OTLP receiver → Grafana Cloud OTLP gateway) |
+| `exporter-config.yaml` | exporter config with `output.otlp` + `traces` enabled, pointed at the snmpsim target |
+| `alloy-config.alloy` | Alloy: `otelcol.receiver.otlp` → `otelcol.exporter.otlphttp` to the gateway |
+| `.env.example` | connection settings — copy to `.env` (gitignored) and fill in |
+
+## Run
+
+```bash
+cp .env.example .env          # fill in GCLOUD_OTLP_ENDPOINT, GCLOUD_OTLP_USER, GCLOUD_TOKEN
+docker compose up -d --build  # builds the exporter from the repo Dockerfile
+```
+
+Verify in Grafana Cloud:
+
+- **Metrics** (Mimir): `network_topology_device_info{service_name="network-topology-exporter"}`
+  — the snmpsim device (`zeus.snmplabs.com`) arriving over the OTLP path.
+- **Traces** (Tempo): TraceQL `{ name = "discovery.cycle" }`.
+
+### Staleness check (the observable-gauge fix)
+
+```bash
+docker compose stop snmpsim   # remove the device
+# wait ~90s, then in Grafana Cloud confirm the series stops receiving samples:
+#   count_over_time(network_topology_device_info{service_name="network-topology-exporter"}[1m]) -> 0
+```
+
+The series must drop to zero new samples — the exporter does not keep pushing a
+device that no longer exists.
+
+```bash
+docker compose down
+```
+
+## Notes
+
+- `snmpsim` serves its default `public` recording (sysName `zeus.snmplabs.com`),
+  which the exporter discovers as a single device. Point `exporter-config.yaml`
+  at real devices for richer topology.
+- The OTLP gateway endpoint, instance ID, and token come from the environment
+  (`.env`) so no stack-specific values or secrets live in the committed files.

--- a/deploy/otlp-validation/alloy-config.alloy
+++ b/deploy/otlp-validation/alloy-config.alloy
@@ -1,0 +1,34 @@
+// Alloy config for the OTLP validation harness: receive OTLP from the exporter
+// and forward metrics + logs + traces to a Grafana Cloud OTLP gateway. The
+// gateway endpoint, instance ID, and token all come from the environment
+// (.env) so no stack-specific values or secrets live in this file.
+
+logging {
+  level = "info"
+}
+
+otelcol.receiver.otlp "in" {
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  output {
+    metrics = [otelcol.exporter.otlphttp.gcloud.input]
+    logs    = [otelcol.exporter.otlphttp.gcloud.input]
+    traces  = [otelcol.exporter.otlphttp.gcloud.input]
+  }
+}
+
+otelcol.auth.basic "gcloud" {
+  username = sys.env("GCLOUD_OTLP_USER")
+  password = sys.env("GCLOUD_TOKEN")
+}
+
+otelcol.exporter.otlphttp "gcloud" {
+  client {
+    endpoint = sys.env("GCLOUD_OTLP_ENDPOINT")
+    auth     = otelcol.auth.basic.gcloud.handler
+  }
+}

--- a/deploy/otlp-validation/docker-compose.yml
+++ b/deploy/otlp-validation/docker-compose.yml
@@ -1,0 +1,44 @@
+# OTLP validation harness. Run from this directory:
+#   cp .env.example .env   # fill in the Grafana Cloud OTLP details
+#   docker compose up -d --build
+# See README.md for the verification steps.
+services:
+  snmpsim:
+    image: tandrup/snmpsim:latest
+    container_name: otlp-validation-snmpsim
+    networks:
+      net:
+        ipv4_address: 172.28.0.10
+    restart: unless-stopped
+
+  exporter:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: otlp-validation-exporter
+    depends_on: [snmpsim, alloy]
+    volumes:
+      - ./exporter-config.yaml:/etc/topology-exporter/config.yaml:ro
+    environment:
+      - SNMP_COMMUNITY=public
+    networks: [net]
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: otlp-validation-alloy
+    volumes:
+      - ./alloy-config.alloy:/etc/alloy/config.alloy:ro
+    command: run --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    environment:
+      - GCLOUD_OTLP_ENDPOINT=${GCLOUD_OTLP_ENDPOINT}
+      - GCLOUD_OTLP_USER=${GCLOUD_OTLP_USER}
+      - GCLOUD_TOKEN=${GCLOUD_TOKEN}
+    networks: [net]
+    restart: unless-stopped
+
+networks:
+  net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/deploy/otlp-validation/exporter-config.yaml
+++ b/deploy/otlp-validation/exporter-config.yaml
@@ -1,0 +1,47 @@
+# Exporter config for the OTLP validation harness. Pushes OTLP
+# (metrics + logs + traces) to the Alloy OTLP receiver, which forwards to the
+# Grafana Cloud OTLP gateway. Discovers the snmpsim device so device_info flows
+# over OTLP and the observable-gauge staleness fix can be exercised (stop
+# snmpsim -> device_info stops being exported).
+discovery:
+  interval: 15s
+  timeout_per_device: 4s
+  parallelism: 5
+  scope:
+    cidr_allow_list:
+      - "172.28.0.0/16"      # the compose network subnet (see docker-compose.yml)
+
+modules:
+  snmp: { enabled: true, version: v2c }
+  lldp: { enabled: true }
+  cdp:  { enabled: true }
+  bgp:  { enabled: false }
+  ospf: { enabled: false }
+  isis: { enabled: false }
+  fdb:  { enabled: false }
+
+credentials:
+  profiles:
+    - name: sim-v2c
+      type: snmp_v2c
+      community_env: SNMP_COMMUNITY
+  fallback_order: [sim-v2c]
+
+output:
+  otlp:
+    enabled: true
+    endpoint: "http://alloy:4318"   # Alloy OTLP/HTTP receiver
+    protocol: http
+    timeout: 10s
+    heartbeat_cycles: 1             # push every cycle so churn shows quickly
+    traces:
+      enabled: true
+      sample_rate: 1.0              # trace every cycle for validation
+
+snapshot:
+  path: /tmp/snapshot.json
+
+targets:
+  - host: 172.28.0.10               # snmpsim static IP
+    port: 161
+    site: sim


### PR DESCRIPTION
Adds `deploy/otlp-validation/` — a self-contained stack for validating the exporter's OTLP push path end-to-end, kept separate from the operator deployment templates (`deploy/test-harness/`, `deploy/long-running-test/`).

**Stack:** `snmpsim` (one discoverable device) → exporter (built from the repo, `output.otlp` + `traces` enabled) → Alloy `otelcol.receiver.otlp` → `otelcol.exporter.otlphttp` to a Grafana Cloud OTLP gateway.

**Validates:**
- OTLP metric + log push (`internal/output/otlp`)
- discovery-cycle tracing (`internal/tracing`)
- the observable-gauge behaviour — a removed device/edge stops being exported (no phantom topology), the on-the-wire counterpart of `TestPushGraphDropsStaleEdges`

**Files:** `docker-compose.yml`, `exporter-config.yaml`, `alloy-config.alloy`, `.env.example`, `README.md` (run + verification steps incl. the staleness check).

Gateway endpoint, instance ID, and token come from the environment (`.env`, gitignored) — no stack-specific values or secrets in the committed files.