### PR TITLE
v1.6.0 operator readiness: rate limiter, protocol scoping, Kustomize, release mirror, OSS-Fuzz (#72 #74 #78 #79 #84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,12 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-test, integration-test, lint, helm-lint, docker]
+    env:
+      # Secrets cannot be referenced directly in `if:` expressions, so derive a
+      # plain env flag from the Docker Hub token. When the DOCKERHUB_TOKEN secret
+      # is absent this is 'false' and the release stays GHCR-only; once the secret
+      # is provisioned it flips to 'true' and the image is mirrored to Docker Hub.
+      DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     permissions:
       contents: write       # create GitHub release
       packages: write       # push to ghcr.io
@@ -281,13 +287,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Gated on DOCKERHUB_ENABLED: skipped (not failed) when the secret is absent.
+      - name: log in to Docker Hub
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: sigstore/cosign-installer@v3
+
+      # Build the metadata-action images list: GHCR always, Docker Hub appended
+      # only when the mirror is enabled. Emitting a multiline value via a heredoc
+      # to $GITHUB_OUTPUT lets metadata-action push every tag to both registries
+      # from a single build-push, so the cosign loop and binary steps stay shared.
+      - name: compute image registries
+        id: imgs
+        run: |
+          {
+            echo "images<<EOF"
+            echo "ghcr.io/${{ github.repository }}"
+            if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
+              echo "docker.io/${{ github.repository }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.imgs.outputs.images }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -325,6 +356,15 @@ jobs:
           subject-digest: ${{ steps.build_push.outputs.digest }}
           push-to-registry: true
 
+      # Same digest, mirrored to Docker Hub; only runs when the mirror is enabled.
+      - name: attest container image build provenance (Docker Hub)
+        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: docker.io/${{ github.repository }}
+          subject-digest: ${{ steps.build_push.outputs.digest }}
+          push-to-registry: true
+
       - name: go build release binaries
         run: |
           mkdir -p bin
@@ -353,6 +393,37 @@ jobs:
             bin/topology-exporter-linux-amd64
             bin/topology-exporter-linux-arm64
 
+      # Offline install bundle for air-gapped / proxy-restricted shops that can
+      # reach neither ghcr.io nor docker.io. Contains the static binaries plus
+      # their cosign sigs/certs, the example config, the Helm chart, and the
+      # Helm-free Kustomize overlay tree.
+      - name: assemble offline tarball
+        env:
+          TARBALL: network-topology-exporter-${{ github.ref_name }}-offline.tar.gz
+        run: |
+          staging="offline/network-topology-exporter-${{ github.ref_name }}"
+          mkdir -p "${staging}/bin" "${staging}/config" "${staging}/deploy"
+          cp bin/topology-exporter-linux-amd64 \
+             bin/topology-exporter-linux-amd64.sig \
+             bin/topology-exporter-linux-amd64.cert \
+             bin/topology-exporter-linux-arm64 \
+             bin/topology-exporter-linux-arm64.sig \
+             bin/topology-exporter-linux-arm64.cert \
+             "${staging}/bin/"
+          cp config/example.yaml "${staging}/config/"
+          cp -R deploy/helm/topology-exporter "${staging}/deploy/helm-chart"
+          cp -R deploy/kustomize "${staging}/deploy/kustomize"
+          tar -czf "${TARBALL}" -C offline "network-topology-exporter-${{ github.ref_name }}"
+
+      - name: sign offline tarball (cosign keyless)
+        env:
+          TARBALL: network-topology-exporter-${{ github.ref_name }}-offline.tar.gz
+        run: |
+          cosign sign-blob --yes \
+            --output-signature "${TARBALL}.sig" \
+            --output-certificate "${TARBALL}.cert" \
+            "${TARBALL}"
+
       - name: create github release
         uses: softprops/action-gh-release@v2
         with:
@@ -363,4 +434,7 @@ jobs:
             bin/topology-exporter-linux-arm64
             bin/topology-exporter-linux-arm64.sig
             bin/topology-exporter-linux-arm64.cert
+            network-topology-exporter-${{ github.ref_name }}-offline.tar.gz
+            network-topology-exporter-${{ github.ref_name }}-offline.tar.gz.sig
+            network-topology-exporter-${{ github.ref_name }}-offline.tar.gz.cert
           generate_release_notes: true

--- a/.github/workflows/kustomize-smoke.yml
+++ b/.github/workflows/kustomize-smoke.yml
@@ -1,0 +1,73 @@
+name: kustomize-smoke
+
+# Validates the Kustomize manifests under deploy/kustomize. The render job is
+# the REQUIRED check (fast, no external dependencies). The kind live-apply job
+# is best-effort: it needs the GHCR image to be pullable, so it is allowed to
+# fail without blocking PRs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/kustomize/**'
+      - '.github/workflows/kustomize-smoke.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/kustomize/**'
+      - '.github/workflows/kustomize-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+
+  render:
+    name: render overlays (required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # kubectl ships with kustomize built in (kubectl kustomize).
+      - name: validate overlays render
+        run: |
+          set -euo pipefail
+          for ov in standalone hub spoke; do
+            echo "::group::kubectl kustomize deploy/kustomize/overlays/$ov"
+            kubectl kustomize "deploy/kustomize/overlays/$ov"
+            echo "::endgroup::"
+          done
+
+  kind-apply:
+    name: kind live-apply (best-effort)
+    runs-on: ubuntu-latest
+    needs: render
+    # Soft gate: a failure here (e.g. the image tag is not yet in GHCR) must
+    # not block the PR. Keep the `render` job as the required status check.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          wait: 120s
+
+      - name: apply standalone overlay
+        run: kubectl apply -k deploy/kustomize/overlays/standalone
+
+      - name: wait for deployment to become Available
+        run: |
+          set -euo pipefail
+          # If the image is not pullable this will time out; that is acceptable
+          # for a best-effort job (continue-on-error keeps it non-blocking).
+          kubectl wait --for=condition=available \
+            --timeout=180s \
+            deployment/topology-exporter
+
+      - name: dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -o wide || true
+          kubectl describe deployment/topology-exporter || true
+          kubectl get events --sort-by=.lastTimestamp || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,22 @@ v1.3.1 lands under this milestone instead, renamed to
   documented in `docs/operator/security.md` § "Verifying release artefact
   provenance." Closes the supply-chain attestation gap identified in the
   May 2026 architectural review.
+- **#72 — Per-target SNMP PDU rate limiter.** New
+  `discovery.per_target_pdu_rate_per_second` (default `0` = unlimited, today's
+  behaviour) caps the steady-state SNMP request rate against an individual
+  device, so a high-`parallelism`, all-modules run can no longer self-DoS a slow
+  target's SNMP daemon. The limiter is per-target, applied at the `BulkWalk`
+  boundary (covers every walker uniformly), and waits on `ctx.Done()` so a stuck
+  target never blocks a worker past `discovery.timeout_per_device`. New histogram
+  `network_topology_snmp_rate_limit_wait_seconds` surfaces when the limit is
+  biting. Closes the self-DoS gap tracked in `docs/operator/threat-model.md`.
+  Closes #72.
+- **#84 — OSS-Fuzz integration staged.** New `oss-fuzz/` directory holds the
+  `project.yaml` / `Dockerfile` / `build.sh` to enroll the project in Google
+  OSS-Fuzz for continuous fuzzing of the native Go harnesses. `build.sh`
+  auto-discovers every `Fuzz*` target under `internal/discovery/` (16 today), so
+  new harnesses are picked up with no edit. The upstream `google/oss-fuzz`
+  application and PR are tracked as remaining steps on #84.
 
 ### Discovery
 
@@ -225,6 +241,16 @@ v1.3.1 lands under this milestone instead, renamed to
   cost without coverage. README BGP vendor-coverage table updated to
   describe what was validated where. Closes #58.
 
+- **#74 — Protocol-level discovery scoping.** New `discovery.target_overrides`
+  (a list of `{cidr, modules}` rules) restricts which modules run against a
+  CIDR, resolved most-specific-first (longest-prefix match, same precedence
+  model as `credentials.assignments`) and intersected with globally-enabled
+  modules. Heterogeneous fleets can now skip irrelevant walks — e.g. BGP against
+  access switches — eliminating guaranteed `mib_unimplemented` noise and a wasted
+  SNMP cycle. An override referencing a globally-disabled module is a config
+  error; IPs matching no override run all enabled modules (unchanged default).
+  The admin `/admin/rediscover` path honours overrides too. Closes #74.
+
 ### Operability
 
 - **Admin endpoint for forced out-of-cycle re-discovery.** New
@@ -245,6 +271,19 @@ v1.3.1 lands under this milestone instead, renamed to
   device's edges land in `/metrics` on the next regular cycle. New audit metric
   `network_topology_admin_rediscovery_total{outcome}`. See
   `docs/operator/troubleshooting.md` § 4a. Closes #73.
+- **#78 — Release artefacts mirrored beyond GHCR.** The release pipeline now
+  mirrors the multi-arch image to Docker Hub
+  (`docker.io/colinedwardwood/network-topology-exporter`) alongside GHCR, and
+  publishes a cosign-signed offline tarball (static binaries + sigs, example
+  config, Helm chart, Kustomize overlays) attached to each GitHub Release for
+  air-gapped / proxy-restricted environments. The Docker Hub push is gated on the
+  `DOCKERHUB_TOKEN` secret, so releases stay GHCR-complete until the repo owner
+  provisions the Docker Hub repo + secrets (remaining steps on #78).
+- **#79 — Kustomize manifests.** New `deploy/kustomize/` (base + `standalone` /
+  `hub` / `spoke` overlays) lets the exporter be installed with `kubectl apply
+  -k`, Argo CD, or Flux without Helm. The manifests mirror the Helm chart's
+  rendered output; a new `kustomize-smoke` CI workflow validates that all three
+  overlays render. Closes the Helm-only deployment gap (#79).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,42 @@ docker run --rm -p 9100:9100 \
   network-topology-exporter:dev
 ```
 
+## Installation
+
+Released images are multi-arch (`linux/amd64`, `linux/arm64`), cosign-keyless
+signed, and carry SLSA build-provenance attestations. Three install paths cover
+registry-restricted and air-gapped environments:
+
+1. **GHCR (default):**
+
+   ```bash
+   docker pull ghcr.io/colinedwardwood/network-topology-exporter:latest
+   ```
+
+2. **Docker Hub (mirror)** — for shops that cannot reach `ghcr.io`. The same
+   image (identical digest) is mirrored from each release:
+
+   ```bash
+   docker pull docker.io/colinedwardwood/network-topology-exporter:latest
+   ```
+
+3. **Offline tarball (air-gapped)** — each GitHub Release attaches a
+   cosign-signed `network-topology-exporter-<version>-offline.tar.gz` bundling
+   the static binaries (with sigs/certs), the example config, the Helm chart,
+   and the Kustomize overlays for `curl`-and-untar deployment.
+
+### Kubernetes
+
+| Method | Command |
+|---|---|
+| Helm | `helm install topology-exporter deploy/helm/topology-exporter` |
+| Kustomize | `kubectl apply -k deploy/kustomize/overlays/standalone` |
+
+The Kustomize overlays `standalone`, `hub`, and `spoke` map to the corresponding
+`federation.role`; they mirror the Helm chart's rendered output for GitOps
+(Argo CD / Flux) or Helm-free clusters. See
+[`deploy/kustomize/README.md`](deploy/kustomize/README.md).
+
 ## Emitted signals
 
 ### Prometheus metrics
@@ -304,6 +340,8 @@ Stability promises and GA criteria: [`docs/operator/stability.md`](docs/operator
 Upgrade runbook (per-minor-version breaking changes, backup steps, rollout order): [`docs/operator/upgrades.md`](docs/operator/upgrades.md).
 
 SLO guidance (SLI definitions, multi-burn-rate alerts, copy-pasteable PromQL): [`docs/operator/slos.md`](docs/operator/slos.md).
+
+Continuous fuzzing: the project's native Go fuzz harnesses run per-PR (short) and nightly (long) in CI, and are staged for Google OSS-Fuzz enrollment — see [`oss-fuzz/`](oss-fuzz/) for the integration files and submission steps.
 
 To report a vulnerability privately: [`SECURITY.md`](SECURITY.md).
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -47,6 +47,14 @@ discovery:
   # 0 = no additional cap (default); must be < timeout_per_device when set.
   # timeout_per_module: 3s
 
+  # Per-target SNMP request (PDU) rate cap. A high parallelism with every
+  # module enabled can otherwise fire hundreds of PDUs/sec at a single slow
+  # device and self-DoS its SNMP daemon. This paces the steady-state walk rate
+  # against each device independently (per-target isolation). 0 = unlimited
+  # (default — unchanged behaviour); set a positive value (e.g. 50) only if a
+  # target's agent struggles under load.
+  # per_target_pdu_rate_per_second: 50
+
   # Polling-scope guard (hard allow-list). The exporter polls only IPs within
   # these CIDRs. LLDP/CDP-discovered neighbours outside this range surface as
   # network_topology_out_of_scope_neighbours_total but are never polled.

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -63,6 +63,24 @@ discovery:
     cidr_allow_list:
       - 198.51.100.0/24
 
+  # Per-target protocol scoping (issue #74). By default every module enabled
+  # below runs against every in-scope target. On a heterogeneous fleet that
+  # wastes cycles and pollutes metrics — e.g. walking BGP against an access
+  # switch yields a guaranteed mib_unimplemented walker outcome. An override
+  # restricts an IP (matched by longest-prefix CIDR, same precedence as
+  # credentials.assignments) to ONLY the listed modules, intersected with the
+  # global modules.<m>.enabled gates. An IP matching no override runs ALL
+  # enabled modules (unchanged default). Rules:
+  #   - every listed module must also be enabled globally (modules.<m>.enabled)
+  #   - the modules list must be non-empty (to poll nothing at a CIDR, remove it
+  #     from scope.cidr_allow_list instead)
+  #   - most-specific CIDR wins; equal-prefix duplicate CIDRs are rejected
+  # target_overrides:
+  #   - cidr: 198.51.100.0/26      # core routers: full L3 topology
+  #     modules: [bgp, isis, lldp]
+  #   - cidr: 198.51.100.128/25    # access switches: L2 only, never BGP
+  #     modules: [lldp, cdp, fdb]
+
   # Unidirectional link expiry: remove a link that has not been confirmed from
   # both sides after this many consecutive cycles (default 3; must be >= 1).
   unconfirmed_link_ttl_cycles: 3

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -1,0 +1,113 @@
+# Kustomize manifests
+
+Plain-YAML Kubernetes manifests for `network-topology-exporter`, for shops that
+deploy with `kubectl apply -k`, Argo CD, or Flux rather than Helm.
+
+These manifests **mirror the rendered output of the Helm chart** in
+[`deploy/helm/topology-exporter`](../helm/topology-exporter). The two install
+paths must stay in sync — see [Relationship to the Helm chart](#relationship-to-the-helm-chart).
+
+## Layout
+
+```
+deploy/kustomize/
+  base/                       # all shared resources (do not apply directly)
+    serviceaccount.yaml
+    configmap.yaml            # sample config (federation.role: standalone)
+    secret.yaml               # PLACEHOLDER values only — replace before applying
+    service.yaml
+    networkpolicy.yaml
+    deployment.yaml
+    kustomization.yaml
+  overlays/
+    standalone/               # config.federation.role: standalone
+    hub/                      # config.federation.role: hub
+    spoke/                    # config.federation.role: spoke
+```
+
+## Federation modes
+
+Each overlay selects one federation mode via `config.federation.role`
+(see `internal/config` — valid roles: `standalone`, `uncoordinated`, `spoke`,
+`hub`). Apply exactly one overlay; never apply `base/` on its own.
+
+| Overlay      | `federation.role` | What it does                                                                 |
+|--------------|-------------------|------------------------------------------------------------------------------|
+| `standalone` | `standalone`      | Single-instance discovery, no federation. The default.                       |
+| `hub`        | `hub`             | Pure aggregator. Receives spoke pushes on a separate mTLS listener (`:9101`). |
+| `spoke`      | `spoke`           | Local discovery + pushes its domain graph to a hub over mTLS.                |
+
+## Apply
+
+```sh
+# Standalone (default single-instance mode)
+kubectl apply -k deploy/kustomize/overlays/standalone
+
+# Hub (aggregator)
+kubectl apply -k deploy/kustomize/overlays/hub
+
+# Spoke (pushes to a hub)
+kubectl apply -k deploy/kustomize/overlays/spoke
+```
+
+Render without applying to inspect the result:
+
+```sh
+kubectl kustomize deploy/kustomize/overlays/standalone
+```
+
+## Customising config and secrets
+
+- **Exporter config** lives in the `topology-exporter` ConfigMap
+  (`config.yaml`). Edit `base/configmap.yaml` for cross-mode defaults, or the
+  per-mode `overlays/<mode>/configmap.yaml` for that mode. The discovery scope,
+  modules, credentials, and `targets` are environment-specific and intended to
+  be edited.
+- **Secrets** — `base/secret.yaml` ships with **placeholder values only**
+  (`REPLACE_ME`). Never commit real secrets. Either replace the placeholders
+  before applying, or (preferred) manage the Secret out-of-band
+  (Sealed Secrets, External Secrets, SOPS, Vault) and drop `secret.yaml` from
+  `base/kustomization.yaml`. Consume secret values in the Deployment via
+  `env`/`valueFrom.secretKeyRef`.
+- **Image / tag** — pin per environment:
+
+  ```sh
+  cd deploy/kustomize/overlays/standalone
+  kustomize edit set image \
+    ghcr.io/colinedwardwood/network-topology-exporter=ghcr.io/colinedwardwood/network-topology-exporter:1.6.0
+  ```
+
+  (or edit `images:` in `base/kustomization.yaml`).
+
+### Federation mTLS (hub and spoke)
+
+The hub and spoke overlays reference TLS material at
+`/etc/topology-exporter/pki/{ca.crt,tls.crt,tls.key}`. Provide it by creating a
+TLS Secret and mounting it into the Deployment (add a `volumes`/`volumeMounts`
+patch in the overlay):
+
+```sh
+kubectl create secret generic topology-exporter-pki \
+  --from-file=ca.crt --from-file=tls.crt --from-file=tls.key
+```
+
+For the spoke, also set a unique `federation.spoke.spoke_id` and the correct
+`hub_url` (the hub's Service DNS name on port `9101`).
+
+## Relationship to the Helm chart
+
+The Helm chart (`deploy/helm/topology-exporter`) is the source of truth for the
+resource shape: names, labels, ports, securityContext, probes, and RBAC. These
+Kustomize manifests reproduce the chart's **default** rendered output so the two
+paths do not drift.
+
+**When you change the chart, update these manifests to match.** Regenerate the
+reference output and diff it:
+
+```sh
+helm template te deploy/helm/topology-exporter
+```
+
+The `kustomize-smoke` CI workflow only validates that the overlays *render*; it
+does not detect drift from the chart, so keeping them in sync is a manual step
+in any PR that touches the chart's rendered shape.

--- a/deploy/kustomize/base/configmap.yaml
+++ b/deploy/kustomize/base/configmap.yaml
@@ -1,0 +1,45 @@
+# Sample topology-exporter configuration, mirroring the Helm chart default
+# (deploy/helm/topology-exporter/values.yaml -> .config). Mounted read-only at
+# /etc/topology-exporter/config.yaml.
+#
+# Customise the discovery scope, modules, credentials, and targets for your
+# environment. Overlays patch the federation.* block to select the mode.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topology-exporter
+data:
+  config.yaml: |
+    discovery:
+      interval: 60s
+      timeout_per_device: 10s
+      parallelism: 20
+      unconfirmed_link_ttl_cycles: 3
+      scope:
+        cidr_allow_list: []
+    modules:
+      snmp:
+        enabled: true
+        version: v2c
+      lldp:
+        enabled: true
+      cdp:
+        enabled: true
+      bgp:
+        enabled: false
+      ospf:
+        enabled: false
+      fdb:
+        enabled: false
+    credentials:
+      profiles: []
+      assignments: []
+      fallback_order: []
+      trial_rate_per_second: 5
+    snapshot:
+      path: /var/lib/topology-exporter/snapshot.json
+    federation:
+      role: standalone
+      spoke_timeout: 3m
+      known_inter_domain_links: []
+    targets: []

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topology-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: topology-exporter
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+        prometheus.io/path: /metrics
+    spec:
+      serviceAccountName: topology-exporter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: topology-exporter
+          # Image (repository:tag) is set by kustomization.yaml `images:`.
+          image: ghcr.io/colinedwardwood/network-topology-exporter:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - --config.file=/etc/topology-exporter/config.yaml
+            - --web.listen-address=:9100
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/topology-exporter
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: topology-exporter

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base manifests for network-topology-exporter. These mirror the rendered
+# output of the Helm chart (deploy/helm/topology-exporter) so the two install
+# paths stay in sync. Keep them aligned — see deploy/kustomize/README.md.
+#
+# Apply an overlay (standalone | hub | spoke), not this base directly:
+#   kubectl apply -k deploy/kustomize/overlays/standalone
+
+resources:
+  - serviceaccount.yaml
+  - configmap.yaml
+  - secret.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - deployment.yaml
+
+# Common labels applied to every resource and used as selector labels.
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: topology-exporter
+      app.kubernetes.io/managed-by: kustomize
+
+# Pin the container image. Override the tag per environment with:
+#   kustomize edit set image ghcr.io/colinedwardwood/network-topology-exporter=:1.6.0
+images:
+  - name: ghcr.io/colinedwardwood/network-topology-exporter
+    newName: ghcr.io/colinedwardwood/network-topology-exporter
+    newTag: latest

--- a/deploy/kustomize/base/networkpolicy.yaml
+++ b/deploy/kustomize/base/networkpolicy.yaml
@@ -1,0 +1,17 @@
+# Baseline NetworkPolicy: allow Prometheus to scrape the metrics port.
+# The hub overlay adds an ingress rule for the spoke-push federation port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: topology-exporter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: topology-exporter
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow Prometheus scraping on the metrics port from anywhere.
+    - ports:
+        - port: 9100
+          protocol: TCP

--- a/deploy/kustomize/base/secret.yaml
+++ b/deploy/kustomize/base/secret.yaml
@@ -1,0 +1,19 @@
+# Sample Secret for sensitive exporter inputs (e.g. the SNMP community string).
+# This file ships with PLACEHOLDER values ONLY — never commit a real secret.
+# Replace REPLACE_ME before applying, or manage this Secret out-of-band
+# (sealed-secrets, External Secrets, SOPS, vault) and remove it from the
+# kustomization resource list.
+#
+# To consume these values, reference them from the Deployment via env/valueFrom
+# secretKeyRef (see deploy/kustomize/README.md).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: topology-exporter
+type: Opaque
+stringData:
+  # SNMP v2c community string used by the snmp module.
+  SNMP_COMMUNITY: "REPLACE_ME"
+  # SNMPv3 auth/priv passwords (only needed when using snmp version v3).
+  SNMP_V3_AUTH_PASSWORD: "REPLACE_ME"
+  SNMP_V3_PRIV_PASSWORD: "REPLACE_ME"

--- a/deploy/kustomize/base/service.yaml
+++ b/deploy/kustomize/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: topology-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: topology-exporter

--- a/deploy/kustomize/base/serviceaccount.yaml
+++ b/deploy/kustomize/base/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: topology-exporter
+# The exporter polls network devices and exposes /metrics; it never talks to
+# the Kubernetes API, so its token must not be mounted (matches the Helm chart).
+automountServiceAccountToken: false

--- a/deploy/kustomize/overlays/hub/configmap.yaml
+++ b/deploy/kustomize/overlays/hub/configmap.yaml
@@ -1,0 +1,50 @@
+# Hub-mode config: pure aggregator. No local SNMP discovery; receives spoke
+# pushes over mTLS on the federation listener (default :9101).
+# Replaces the base ConfigMap's config.yaml (federation.role: hub).
+#
+# You MUST provide the mTLS material referenced below via federation TLS files
+# mounted from a Secret (see deploy/kustomize/README.md). Paths shown match the
+# Helm chart's /etc/topology-exporter/pki mount.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topology-exporter
+data:
+  config.yaml: |
+    discovery:
+      interval: 60s
+      timeout_per_device: 10s
+      parallelism: 20
+      unconfirmed_link_ttl_cycles: 3
+      scope:
+        cidr_allow_list: []
+    modules:
+      snmp:
+        enabled: false
+      lldp:
+        enabled: false
+      cdp:
+        enabled: false
+      bgp:
+        enabled: false
+      ospf:
+        enabled: false
+      fdb:
+        enabled: false
+    credentials:
+      profiles: []
+      assignments: []
+      fallback_order: []
+      trial_rate_per_second: 5
+    snapshot:
+      path: /var/lib/topology-exporter/snapshot.json
+    federation:
+      role: hub
+      spoke_timeout: 3m
+      known_inter_domain_links: []
+      hub:
+        listen_addr: ":9101"
+        tls_ca_cert: /etc/topology-exporter/pki/ca.crt
+        tls_cert: /etc/topology-exporter/pki/tls.crt
+        tls_key: /etc/topology-exporter/pki/tls.key
+    targets: []

--- a/deploy/kustomize/overlays/hub/kustomization.yaml
+++ b/deploy/kustomize/overlays/hub/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Hub overlay: pure aggregator that receives spoke pushes on a separate mTLS
+# listener (default :9101). Maps to config.federation.role: hub.
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      app.kubernetes.io/instance: hub
+
+# Replace the base config (federation.role: hub + listener/TLS settings).
+patches:
+  - path: configmap.yaml
+    target:
+      kind: ConfigMap
+      name: topology-exporter
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: topology-exporter
+  - path: patch-service.yaml
+    target:
+      kind: Service
+      name: topology-exporter
+  - path: patch-networkpolicy.yaml
+    target:
+      kind: NetworkPolicy
+      name: topology-exporter

--- a/deploy/kustomize/overlays/hub/patch-deployment.yaml
+++ b/deploy/kustomize/overlays/hub/patch-deployment.yaml
@@ -1,0 +1,17 @@
+# Hub deltas to the base Deployment: expose the federation listener port.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topology-exporter
+spec:
+  template:
+    spec:
+      containers:
+        - name: topology-exporter
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+            - name: hub
+              containerPort: 9101
+              protocol: TCP

--- a/deploy/kustomize/overlays/hub/patch-networkpolicy.yaml
+++ b/deploy/kustomize/overlays/hub/patch-networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Hub deltas to the base NetworkPolicy: allow spoke pods to push on the
+# federation port (9101) in addition to Prometheus scraping on 9100.
+# Tighten the second rule's `from` selector to match your spoke pods.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: topology-exporter
+spec:
+  ingress:
+    # Allow Prometheus scraping on the metrics port from anywhere.
+    - ports:
+        - port: 9100
+          protocol: TCP
+    # Allow spoke push on the hub federation port.
+    - from:
+        - podSelector:
+            matchLabels:
+              topology-exporter/role: spoke
+      ports:
+        - port: 9101
+          protocol: TCP

--- a/deploy/kustomize/overlays/hub/patch-service.yaml
+++ b/deploy/kustomize/overlays/hub/patch-service.yaml
@@ -1,0 +1,16 @@
+# Hub deltas to the base Service: expose the federation listener port so
+# spokes can reach the hub for pushes.
+apiVersion: v1
+kind: Service
+metadata:
+  name: topology-exporter
+spec:
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: metrics
+      protocol: TCP
+    - name: hub
+      port: 9101
+      targetPort: hub
+      protocol: TCP

--- a/deploy/kustomize/overlays/spoke/configmap.yaml
+++ b/deploy/kustomize/overlays/spoke/configmap.yaml
@@ -1,0 +1,53 @@
+# Spoke-mode config: runs local discovery and pushes its domain graph to the
+# hub over mTLS. Replaces the base ConfigMap's config.yaml
+# (federation.role: spoke).
+#
+# Set spoke_id to a unique name and hub_url to your hub Service, e.g.
+# https://topology-exporter-hub.<namespace>.svc:9101. Provide the mTLS material
+# referenced below via a Secret mounted at /etc/topology-exporter/pki
+# (see deploy/kustomize/README.md).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topology-exporter
+data:
+  config.yaml: |
+    discovery:
+      interval: 60s
+      timeout_per_device: 10s
+      parallelism: 20
+      unconfirmed_link_ttl_cycles: 3
+      scope:
+        cidr_allow_list: []
+    modules:
+      snmp:
+        enabled: true
+        version: v2c
+      lldp:
+        enabled: true
+      cdp:
+        enabled: true
+      bgp:
+        enabled: false
+      ospf:
+        enabled: false
+      fdb:
+        enabled: false
+    credentials:
+      profiles: []
+      assignments: []
+      fallback_order: []
+      trial_rate_per_second: 5
+    snapshot:
+      path: /var/lib/topology-exporter/snapshot.json
+    federation:
+      role: spoke
+      spoke_timeout: 3m
+      known_inter_domain_links: []
+      spoke:
+        spoke_id: REPLACE_ME-spoke-id
+        hub_url: https://topology-exporter-hub:9101
+        tls_ca_cert: /etc/topology-exporter/pki/ca.crt
+        tls_cert: /etc/topology-exporter/pki/tls.crt
+        tls_key: /etc/topology-exporter/pki/tls.key
+    targets: []

--- a/deploy/kustomize/overlays/spoke/kustomization.yaml
+++ b/deploy/kustomize/overlays/spoke/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Spoke overlay: local discovery + push to a hub over mTLS.
+# Maps to config.federation.role: spoke.
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      app.kubernetes.io/instance: spoke
+
+# Replace the base config (federation.role: spoke + spoke_id/hub_url/TLS) and
+# tag the pods so the hub NetworkPolicy admits them.
+patches:
+  - path: configmap.yaml
+    target:
+      kind: ConfigMap
+      name: topology-exporter
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: topology-exporter

--- a/deploy/kustomize/overlays/spoke/patch-deployment.yaml
+++ b/deploy/kustomize/overlays/spoke/patch-deployment.yaml
@@ -1,0 +1,11 @@
+# Spoke deltas to the base Deployment: tag the pods so the hub's NetworkPolicy
+# ingress rule (podSelector topology-exporter/role: spoke) admits their pushes.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topology-exporter
+spec:
+  template:
+    metadata:
+      labels:
+        topology-exporter/role: spoke

--- a/deploy/kustomize/overlays/standalone/kustomization.yaml
+++ b/deploy/kustomize/overlays/standalone/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone overlay: single-instance discovery, no federation.
+# Maps to config.federation.role: standalone (the base default).
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      app.kubernetes.io/instance: standalone
+
+# The base ConfigMap already sets federation.role: standalone. This overlay is
+# the deltas-only entry point; customise config/secret here for your site.

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.51.0
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -51,7 +52,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/grpc v1.80.0 // indirect

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -272,9 +272,22 @@ func RunCycle(
 				{"isis", cfg.Modules.ISIS.Enabled, isis.Walk},
 				{"mpls_te", cfg.Modules.MPLSTE.Enabled, mpls.Walk},
 			}
+			// Issue #74: resolve this target's per-protocol scope once. When an
+			// override matches, only the listed modules run (intersected with
+			// the global mod.Enabled gate below); when none matches, allowed is
+			// nil/overrideMatched=false and ALL enabled modules run — today's
+			// unchanged default. The headline case: bgp.Walk only fires where
+			// bgp is in the override's module set, so the walker outcome
+			// counters partition naturally.
+			allowedMods, overrideMatched := cfg.ModulesForIP(ip)
 			modStatus := map[string]int{}
 			for _, mod := range mods {
 				if !mod.Enabled {
+					continue
+				}
+				// Per-target protocol scoping: an override never widens beyond
+				// mod.Enabled (intersection), it only narrows.
+				if overrideMatched && !allowedMods[mod.Proto] {
 					continue
 				}
 				modStart := time.Now()

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
@@ -215,6 +216,23 @@ func RunCycle(
 				m.DiscoveryDecodeIssues.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
 				m.DiscoveryQuarantinedRowsTotal.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
 			})
+
+			// Issue #72: per-target SNMP PDU rate limiter. When configured, cap
+			// the steady-state request rate against this single device so a high
+			// parallelism + all-modules run cannot self-DoS its SNMP daemon. One
+			// limiter per device per cycle (per-target isolation — never shared
+			// across devices). Burst is set equal to the rate so a freshly-built
+			// limiter starts with a full 1-second bucket (no artificial stall on
+			// the first walk) while still pacing sustained throughput to the
+			// configured ceiling. Unset/0 injects nothing — zero overhead,
+			// unchanged behaviour.
+			if rps := cfg.Discovery.PerTargetPDURatePerSecond; rps > 0 {
+				lim := rate.NewLimiter(rate.Limit(rps), rps)
+				devCtx = snmpwalk.ContextWithRateLimiter(devCtx, lim)
+				devCtx = snmpwalk.ContextWithRateLimitWaitObserver(devCtx, func(d time.Duration) {
+					m.SNMPRateLimitWaitSeconds.Observe(d.Seconds())
+				})
+			}
 
 			resolver.RecordSuccess(ip.String(), profileName)
 			m.CredentialTrialsTotal.WithLabelValues("ok").Inc()

--- a/internal/app/rediscover.go
+++ b/internal/app/rediscover.go
@@ -285,9 +285,17 @@ func (rd *Rediscoverer) walkOne(ctx context.Context, ip net.IP) (RediscoverOutco
 		{"mpls_te", rd.cfg.Modules.MPLSTE.Enabled, mpls.Walk},
 	}
 
+	// Issue #74: honour the same per-target protocol scope as the regular
+	// cycle so a forced rediscover does not walk a module (e.g. bgp) against a
+	// target an override has scoped it out of.
+	allowedMods, overrideMatched := rd.cfg.ModulesForIP(ip)
+
 	var edgeCount int
 	for _, mod := range mods {
 		if !mod.Enabled {
+			continue
+		}
+		if overrideMatched && !allowedMods[mod.Proto] {
 			continue
 		}
 		modCtx := devCtx

--- a/internal/app/target_override_cycle_test.go
+++ b/internal/app/target_override_cycle_test.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
+)
+
+// TestCycleHonoursTargetOverride proves the issue #74 per-target protocol
+// scope: with both lldp and cdp enabled globally but an override scoping the
+// target to lldp only, the cycle dispatches lldp.walk and skips cdp.walk. The
+// per-module spans are the observable proof a walker fired (or did not).
+func TestCycleHonoursTargetOverride(t *testing.T) {
+	t.Setenv("TEST_COMM", "public")
+	sr := installRecorder(t)
+
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Discovery.Interval = 30 * time.Second
+	cfg.Discovery.CycleBudgetFraction = 1
+	cfg.Discovery.UnconfirmedLinkTTLCycles = 3
+	// Both modules enabled globally; the override must narrow to lldp only.
+	cfg.Modules.LLDP.Enabled = true
+	cfg.Modules.CDP.Enabled = true
+
+	m := metrics.New(false)
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+	cfg.Targets = []config.TargetConfig{{Host: ip.String(), Port: int(port)}}
+
+	// Scope this target (matched by /32) to lldp only.
+	cfg.Discovery.Scope.CIDRAllowList = []string{"127.0.0.0/8"}
+	cfg.Discovery.TargetOverrides = []config.TargetOverride{
+		{CIDR: ip.String() + "/32", Modules: []string{"lldp"}},
+	}
+	if err := cfg.BuildTargetOverrideResolver(); err != nil {
+		t.Fatalf("BuildTargetOverrideResolver: %v", err)
+	}
+
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	allow := snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	ctx, root := tracing.Tracer().Start(ctx, "discovery.cycle")
+	g, _, _, _ := RunCycle(ctx, slogDiscard(), cfg, m, nil, nil, resolver, allow, map[graph.EdgeKey]int{})
+	root.End()
+
+	if len(g.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(g.Devices))
+	}
+
+	names := map[string]bool{}
+	for _, s := range sr.Ended() {
+		names[s.Name()] = true
+	}
+	if !names["lldp.walk"] {
+		t.Errorf("expected lldp.walk span (in-override module must run); got %v", spanNames(sr.Ended()))
+	}
+	if names["cdp.walk"] {
+		t.Errorf("cdp.walk span present but cdp is not in the override; out-of-override module must be skipped")
+	}
+}
+
+// TestCycleNoOverrideRunsAllEnabled is the control: with no target_overrides,
+// every enabled module dispatches — confirming the default path is unchanged.
+func TestCycleNoOverrideRunsAllEnabled(t *testing.T) {
+	t.Setenv("TEST_COMM", "public")
+	sr := installRecorder(t)
+
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Discovery.Interval = 30 * time.Second
+	cfg.Discovery.CycleBudgetFraction = 1
+	cfg.Discovery.UnconfirmedLinkTTLCycles = 3
+	cfg.Modules.LLDP.Enabled = true
+	cfg.Modules.CDP.Enabled = true
+
+	m := metrics.New(false)
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+	cfg.Targets = []config.TargetConfig{{Host: ip.String(), Port: int(port)}}
+	cfg.Discovery.Scope.CIDRAllowList = []string{"127.0.0.0/8"}
+	if err := cfg.BuildTargetOverrideResolver(); err != nil {
+		t.Fatalf("BuildTargetOverrideResolver: %v", err)
+	}
+
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	allow := snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	ctx, root := tracing.Tracer().Start(ctx, "discovery.cycle")
+	RunCycle(ctx, slogDiscard(), cfg, m, nil, nil, resolver, allow, map[graph.EdgeKey]int{})
+	root.End()
+
+	names := map[string]bool{}
+	for _, s := range sr.Ended() {
+		names[s.Name()] = true
+	}
+	if !names["lldp.walk"] || !names["cdp.walk"] {
+		t.Errorf("expected both lldp.walk and cdp.walk with no override; got %v", spanNames(sr.Ended()))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,15 @@ type DiscoveryConfig struct {
 	// this value. Mirrors FederationHubConfig.MaxGraphEdges for standalone
 	// and spoke mode.
 	MaxGraphEdges int `yaml:"max_graph_edges"`
+
+	// PerTargetPDURatePerSecond caps the steady-state SNMP request (PDU) rate
+	// issued against a single device during a discovery cycle. A misconfigured
+	// high parallelism with all modules enabled can otherwise drive hundreds of
+	// PDUs/sec at one target and self-DoS its SNMP daemon (issue #72). The cap
+	// is applied per device per cycle (per-target isolation — limiters are not
+	// shared across devices). 0 (default) means unlimited, preserving today's
+	// behaviour. Must be >= 0.
+	PerTargetPDURatePerSecond int `yaml:"per_target_pdu_rate_per_second"`
 }
 
 // ScopeConfig is the LD-11 polling-scope guard. CIDRAllowList is mandatory
@@ -447,6 +456,9 @@ func (c *Config) validate() error {
 	}
 	if c.Discovery.MaxGraphEdges < 0 {
 		return errors.New("discovery.max_graph_edges must be >= 0 (0 = unlimited)")
+	}
+	if c.Discovery.PerTargetPDURatePerSecond < 0 {
+		return errors.New("discovery.per_target_pdu_rate_per_second must be >= 0 (0 = unlimited)")
 	}
 	if c.Discovery.Interval <= 0 {
 		return errors.New("discovery.interval must be > 0")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -211,6 +212,32 @@ type DiscoveryConfig struct {
 	// shared across devices). 0 (default) means unlimited, preserving today's
 	// behaviour. Must be >= 0.
 	PerTargetPDURatePerSecond int `yaml:"per_target_pdu_rate_per_second"`
+
+	// TargetOverrides scopes discovery to a subset of the globally-enabled
+	// modules on a per-CIDR basis (issue #74). For an IP matching an override's
+	// cidr, ONLY the listed modules run (intersected with modules.<m>.enabled);
+	// an IP matching no override runs ALL enabled modules — today's behaviour,
+	// unchanged. Heterogeneous fleets use this so e.g. BGP is not walked against
+	// an access switch that does not speak BGP (avoiding a guaranteed
+	// mib_unimplemented walker outcome). Most-specific CIDR wins (longest prefix
+	// match), the same precedence model as credentials.assignments.
+	TargetOverrides []TargetOverride `yaml:"target_overrides"`
+
+	// overrideResolver is the parsed, longest-prefix-sorted form of
+	// TargetOverrides, built once during validate() so the discovery loop never
+	// re-parses CIDRs per device per cycle. nil when no overrides are
+	// configured (the unchanged default path).
+	overrideResolver *targetOverrideResolver
+}
+
+// TargetOverride restricts the modules that run against IPs inside CIDR to the
+// listed Modules (issue #74). See DiscoveryConfig.TargetOverrides for the full
+// semantics. Each module name must be one of the canonical module identifiers
+// (lldp, cdp, fdb, ospf, bgp, isis, mpls_te) and must be enabled globally; an
+// empty Modules list is rejected as ambiguous.
+type TargetOverride struct {
+	CIDR    string   `yaml:"cidr"`
+	Modules []string `yaml:"modules"`
 }
 
 // ScopeConfig is the LD-11 polling-scope guard. CIDRAllowList is mandatory
@@ -467,6 +494,9 @@ func (c *Config) validate() error {
 		return errors.New("discovery.timeout_per_device must be > 0")
 	}
 	if err := c.validateScope(); err != nil {
+		return err
+	}
+	if err := c.validateTargetOverrides(); err != nil {
 		return err
 	}
 	if c.Modules.SNMP.Enabled {
@@ -805,6 +835,170 @@ func (c *Config) validateFDB() error {
 	if c.Modules.FDB.MaxVlans > 4096 {
 		return errors.New("fdb.max_vlans must be at most 4096")
 	}
+	return nil
+}
+
+// scopableModules is the canonical set of per-target-scopable module names,
+// matching the module dispatch table in internal/app/cycle.go and the toggles
+// on ModulesConfig. snmp/arp are intentionally excluded: snmp is the transport
+// (always required to reach a device) and arp is enrichment driven by fdb, not
+// an independently dispatched edge source.
+var scopableModules = map[string]struct{}{
+	"lldp":    {},
+	"cdp":     {},
+	"fdb":     {},
+	"ospf":    {},
+	"bgp":     {},
+	"isis":    {},
+	"mpls_te": {},
+}
+
+// moduleGloballyEnabled reports whether module m is enabled via modules.<m>.enabled.
+// m is assumed to be one of scopableModules (validated upstream).
+func (c *Config) moduleGloballyEnabled(m string) bool {
+	switch m {
+	case "lldp":
+		return c.Modules.LLDP.Enabled
+	case "cdp":
+		return c.Modules.CDP.Enabled
+	case "fdb":
+		return c.Modules.FDB.Enabled
+	case "ospf":
+		return c.Modules.OSPF.Enabled
+	case "bgp":
+		return c.Modules.BGP.Enabled
+	case "isis":
+		return c.Modules.ISIS.Enabled
+	case "mpls_te":
+		return c.Modules.MPLSTE.Enabled
+	default:
+		return false
+	}
+}
+
+// targetOverride is the parsed form of one TargetOverride: the CIDR is parsed
+// into a *net.IPNet once at validate() time, the prefix length is cached for
+// the longest-prefix sort, and the module set is materialised into a lookup map.
+type targetOverride struct {
+	net       *net.IPNet
+	prefixLen int
+	modules   map[string]bool
+}
+
+// targetOverrideResolver answers "which modules may run against this IP" by
+// longest-prefix match over the configured overrides. Built once during
+// validate(); read-only and safe for concurrent use thereafter. It mirrors the
+// most-specific-CIDR-wins model in internal/credentials (Resolver.cidrs).
+type targetOverrideResolver struct {
+	overrides []targetOverride
+}
+
+// buildTargetOverrideResolver parses the overrides and sorts them
+// longest-prefix-first so ModulesForIP returns the most-specific match on its
+// first hit. Tiebreak: when two overrides have an equal prefix length, the
+// first-declared (lower config index) wins — sort.SliceStable preserves config
+// order for equal keys, and validate() rejects exact-duplicate CIDRs so an
+// ambiguous equal-prefix overlap of the *same* network can never silently
+// shadow. CIDRs are assumed already validated by validateTargetOverrides.
+func buildTargetOverrideResolver(overrides []TargetOverride) *targetOverrideResolver {
+	if len(overrides) == 0 {
+		return nil
+	}
+	r := &targetOverrideResolver{overrides: make([]targetOverride, 0, len(overrides))}
+	for _, o := range overrides {
+		_, n, err := net.ParseCIDR(o.CIDR)
+		if err != nil {
+			continue // unreachable: validated upstream.
+		}
+		ones, _ := n.Mask.Size()
+		mods := make(map[string]bool, len(o.Modules))
+		for _, m := range o.Modules {
+			mods[m] = true
+		}
+		r.overrides = append(r.overrides, targetOverride{net: n, prefixLen: ones, modules: mods})
+	}
+	// Most-specific CIDR wins — longest prefix first. SliceStable keeps
+	// config order for equal prefix lengths (first-declared tiebreak).
+	sort.SliceStable(r.overrides, func(i, j int) bool {
+		return r.overrides[i].prefixLen > r.overrides[j].prefixLen
+	})
+	return r
+}
+
+// ModulesForIP returns the set of module names permitted to run against ip,
+// resolved by longest-prefix match over discovery.target_overrides. The
+// returned map is the override's module set (already intersected at config-load
+// time only against the canonical/enabled checks in validation — callers must
+// still AND against the live modules.<m>.enabled gate). When no override
+// matches ip, it returns (nil, false), the signal to run ALL globally-enabled
+// modules (today's unchanged default). The returned map must be treated as
+// read-only.
+func (c *Config) ModulesForIP(ip net.IP) (allowed map[string]bool, matched bool) {
+	r := c.Discovery.overrideResolver
+	if r == nil {
+		return nil, false
+	}
+	for _, o := range r.overrides {
+		if o.net.Contains(ip) {
+			return o.modules, true
+		}
+	}
+	return nil, false
+}
+
+// BuildTargetOverrideResolver validates discovery.target_overrides and rebuilds
+// the cached longest-prefix resolver consulted by ModulesForIP. Load() calls
+// this during validate(); it is also exported so code that constructs a Config
+// programmatically (e.g. tests) can populate the resolver without re-parsing a
+// YAML file. Returns the same errors as the load-time validation path.
+func (c *Config) BuildTargetOverrideResolver() error {
+	return c.validateTargetOverrides()
+}
+
+// validateTargetOverrides enforces the issue #74 invariants: every cidr parses,
+// every referenced module is a recognised name AND enabled globally, and the
+// modules list is non-empty. On success it builds the cached resolver.
+func (c *Config) validateTargetOverrides() error {
+	if len(c.Discovery.TargetOverrides) == 0 {
+		c.Discovery.overrideResolver = nil
+		return nil
+	}
+	seenCIDR := make(map[string]int, len(c.Discovery.TargetOverrides))
+	for i, o := range c.Discovery.TargetOverrides {
+		_, n, err := net.ParseCIDR(o.CIDR)
+		if err != nil {
+			return fmt.Errorf("discovery.target_overrides[%d]: invalid cidr %q: %w", i, o.CIDR, err)
+		}
+		// Reject exact-duplicate CIDRs: two overrides for the same network have
+		// equal prefix length and would make the winner depend on declaration
+		// order alone — an ambiguity better surfaced as a config error.
+		key := n.String()
+		if first, dup := seenCIDR[key]; dup {
+			return fmt.Errorf("discovery.target_overrides[%d]: duplicate cidr %q (already declared at [%d])", i, o.CIDR, first)
+		}
+		seenCIDR[key] = i
+		// An empty modules list is ambiguous: if an operator wants nothing
+		// polled at a CIDR they should exclude it from discovery.scope instead.
+		if len(o.Modules) == 0 {
+			return fmt.Errorf("discovery.target_overrides[%d] (cidr %q): modules must list at least one module (to poll nothing, remove the CIDR from discovery.scope)", i, o.CIDR)
+		}
+		seenMod := make(map[string]struct{}, len(o.Modules))
+		for _, m := range o.Modules {
+			if _, ok := scopableModules[m]; !ok {
+				return fmt.Errorf("discovery.target_overrides[%d] (cidr %q): unknown module %q (allowed: bgp, cdp, fdb, isis, lldp, mpls_te, ospf)", i, o.CIDR, m)
+			}
+			if _, dup := seenMod[m]; dup {
+				return fmt.Errorf("discovery.target_overrides[%d] (cidr %q): duplicate module %q", i, o.CIDR, m)
+			}
+			seenMod[m] = struct{}{}
+			// Acceptance criterion: an override may only narrow, never widen —
+			// every referenced module must be enabled globally.
+			if !c.moduleGloballyEnabled(m) {
+				return fmt.Errorf("discovery.target_overrides[%d] (cidr %q): module %q is not enabled globally (set modules.%s.enabled: true or remove it from the override)", i, o.CIDR, m, m)
+			}
+		}
+	}
+	c.Discovery.overrideResolver = buildTargetOverrideResolver(c.Discovery.TargetOverrides)
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1860,6 +1860,33 @@ func TestDiscoveryMaxGraphEdgesNegativeFails(t *testing.T) {
 	}
 }
 
+// TestDiscoveryPerTargetPDURateNegativeFails verifies that a negative
+// discovery.per_target_pdu_rate_per_second causes validate to return an error
+// (issue #72). The default (0 = unlimited) is exercised implicitly by every
+// other config test that omits the field.
+func TestDiscoveryPerTargetPDURateNegativeFails(t *testing.T) {
+	c := &Config{}
+	c.applyDefaults()
+	c.Discovery.PerTargetPDURatePerSecond = -1
+	err := c.validate()
+	if err == nil {
+		t.Fatal("expected error for per_target_pdu_rate_per_second=-1, got nil")
+	}
+	if !strings.Contains(err.Error(), "per_target_pdu_rate_per_second") {
+		t.Errorf("error %q should mention per_target_pdu_rate_per_second", err.Error())
+	}
+}
+
+// TestDiscoveryPerTargetPDURateDefaultUnlimited verifies the field defaults to
+// 0 (unlimited) — applyDefaults must not set it, preserving today's behaviour.
+func TestDiscoveryPerTargetPDURateDefaultUnlimited(t *testing.T) {
+	c := &Config{}
+	c.applyDefaults()
+	if c.Discovery.PerTargetPDURatePerSecond != 0 {
+		t.Errorf("PerTargetPDURatePerSecond default = %d, want 0 (unlimited)", c.Discovery.PerTargetPDURatePerSecond)
+	}
+}
+
 // TestFederationHubMaxGraphDevicesNegativeFails verifies that a negative
 // federation.hub.max_graph_devices causes Load to return an error.
 func TestFederationHubMaxGraphDevicesNegativeFails(t *testing.T) {

--- a/internal/config/target_overrides_test.go
+++ b/internal/config/target_overrides_test.go
@@ -1,0 +1,297 @@
+package config
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeOverrideConfig writes body to a temp config file and loads it, returning
+// the parsed config and any load error. Used by the issue #74 tests below.
+func writeOverrideConfig(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return Load(path)
+}
+
+// Issue #74: longest-prefix-match resolution. Overlapping CIDRs (/8, /16, /32)
+// must resolve most-specific-first, and the matching override's module set must
+// be returned.
+func TestModulesForIPLongestPrefixWins(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.0.0.0/8
+      modules: [lldp]
+    - cidr: 10.1.0.0/16
+      modules: [lldp, cdp]
+    - cidr: 10.1.2.3/32
+      modules: [lldp, cdp, bgp]
+modules:
+  lldp:
+    enabled: true
+  cdp:
+    enabled: true
+  bgp:
+    enabled: true
+targets:
+  - host: 10.1.2.3
+`
+	c, err := writeOverrideConfig(t, body)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	cases := []struct {
+		ip   string
+		want map[string]bool
+	}{
+		{"10.1.2.3", map[string]bool{"lldp": true, "cdp": true, "bgp": true}}, // /32 wins
+		{"10.1.9.9", map[string]bool{"lldp": true, "cdp": true}},              // /16 wins
+		{"10.9.9.9", map[string]bool{"lldp": true}},                           // /8 wins
+	}
+	for _, tc := range cases {
+		got, matched := c.ModulesForIP(net.ParseIP(tc.ip))
+		if !matched {
+			t.Errorf("ModulesForIP(%s) matched=false, want true", tc.ip)
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("ModulesForIP(%s) = %v, want %v", tc.ip, got, tc.want)
+			continue
+		}
+		for m := range tc.want {
+			if !got[m] {
+				t.Errorf("ModulesForIP(%s) missing module %q (got %v)", tc.ip, m, got)
+			}
+		}
+	}
+}
+
+// An IP matching no override returns (nil, false) — the signal to run all
+// enabled modules, today's unchanged default.
+func TestModulesForIPNoMatch(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: [lldp]
+modules:
+  lldp:
+    enabled: true
+targets:
+  - host: 10.9.9.9
+`
+	c, err := writeOverrideConfig(t, body)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, matched := c.ModulesForIP(net.ParseIP("10.9.9.9"))
+	if matched {
+		t.Errorf("ModulesForIP(10.9.9.9) matched=true (got %v), want false", got)
+	}
+	if got != nil {
+		t.Errorf("ModulesForIP(10.9.9.9) = %v, want nil", got)
+	}
+}
+
+// With no target_overrides at all, ModulesForIP always returns (nil, false) so
+// the discovery loop runs every enabled module — byte-for-byte today's default.
+func TestModulesForIPNoOverridesConfigured(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+modules:
+  lldp:
+    enabled: true
+targets:
+  - host: 10.1.2.3
+`
+	c, err := writeOverrideConfig(t, body)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Discovery.overrideResolver != nil {
+		t.Fatal("overrideResolver should be nil when no overrides are configured")
+	}
+	if got, matched := c.ModulesForIP(net.ParseIP("10.1.2.3")); matched || got != nil {
+		t.Errorf("ModulesForIP = (%v, %v), want (nil, false)", got, matched)
+	}
+}
+
+// Equal-prefix tiebreak: two overrides with the SAME prefix length but different
+// networks resolve deterministically by first-declared. (Exact-duplicate CIDRs
+// are a separate, rejected case — see TestTargetOverrideRejectsDuplicateCIDR.)
+func TestModulesForIPEqualPrefixTiebreak(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: [lldp]
+    - cidr: 10.2.0.0/16
+      modules: [cdp]
+modules:
+  lldp:
+    enabled: true
+  cdp:
+    enabled: true
+targets:
+  - host: 10.1.0.1
+`
+	c, err := writeOverrideConfig(t, body)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, matched := c.ModulesForIP(net.ParseIP("10.2.0.1"))
+	if !matched || !got["cdp"] || got["lldp"] {
+		t.Errorf("ModulesForIP(10.2.0.1) = (%v, %v), want cdp-only", got, matched)
+	}
+}
+
+// Validation: an override referencing a globally-disabled module is rejected.
+func TestTargetOverrideRejectsDisabledModule(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: [bgp]
+modules:
+  lldp:
+    enabled: true
+  bgp:
+    enabled: false
+targets:
+  - host: 10.1.0.1
+`
+	_, err := writeOverrideConfig(t, body)
+	if err == nil {
+		t.Fatal("expected error for override referencing globally-disabled module")
+	}
+	if !strings.Contains(err.Error(), "not enabled globally") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Validation: a malformed CIDR is rejected.
+func TestTargetOverrideRejectsMalformedCIDR(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: not-a-cidr
+      modules: [lldp]
+modules:
+  lldp:
+    enabled: true
+targets:
+  - host: 10.1.0.1
+`
+	_, err := writeOverrideConfig(t, body)
+	if err == nil {
+		t.Fatal("expected error for malformed cidr")
+	}
+	if !strings.Contains(err.Error(), "invalid cidr") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Validation: an empty modules list is rejected as ambiguous.
+func TestTargetOverrideRejectsEmptyModules(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: []
+modules:
+  lldp:
+    enabled: true
+targets:
+  - host: 10.1.0.1
+`
+	_, err := writeOverrideConfig(t, body)
+	if err == nil {
+		t.Fatal("expected error for empty modules list")
+	}
+	if !strings.Contains(err.Error(), "at least one module") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Validation: an unknown module name is rejected.
+func TestTargetOverrideRejectsUnknownModule(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: [snmp]
+modules:
+  lldp:
+    enabled: true
+targets:
+  - host: 10.1.0.1
+`
+	_, err := writeOverrideConfig(t, body)
+	if err == nil {
+		t.Fatal("expected error for unknown module name")
+	}
+	if !strings.Contains(err.Error(), "unknown module") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Validation: two overrides for the exact-same network are rejected.
+func TestTargetOverrideRejectsDuplicateCIDR(t *testing.T) {
+	body := `
+discovery:
+  scope:
+    cidr_allow_list:
+      - 10.0.0.0/8
+  target_overrides:
+    - cidr: 10.1.0.0/16
+      modules: [lldp]
+    - cidr: 10.1.0.0/16
+      modules: [cdp]
+modules:
+  lldp:
+    enabled: true
+  cdp:
+    enabled: true
+targets:
+  - host: 10.1.0.1
+`
+	_, err := writeOverrideConfig(t, body)
+	if err == nil {
+		t.Fatal("expected error for duplicate cidr")
+	}
+	if !strings.Contains(err.Error(), "duplicate cidr") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/discovery/snmp/snmp.go
+++ b/internal/discovery/snmp/snmp.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	g "github.com/gosnmp/gosnmp"
+	"golang.org/x/time/rate"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
 )
@@ -203,6 +204,48 @@ func Open(p Params) (*g.GoSNMP, error) {
 	return client, nil
 }
 
+type rateLimiterKey struct{}
+type rateLimitWaitObserverKey struct{}
+
+// ContextWithRateLimiter returns a child context carrying a per-target SNMP
+// request-rate limiter. BulkWalk consults the limiter before issuing each walk
+// so that the steady-state PDU rate against an individual device cannot exceed
+// the operator-configured ceiling, preventing a self-DoS of the device's SNMP
+// daemon (issue #72). A nil limiter returns the original context unchanged
+// (the default — zero overhead, unlimited rate). The limiter is injected per
+// device per cycle in internal/app/cycle.go; it deliberately lives behind a
+// context seam (mirroring ContextWithDecodeIssueReporter) so that this package
+// stays free of any prometheus-client dependency.
+func ContextWithRateLimiter(ctx context.Context, l *rate.Limiter) context.Context {
+	if l == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, rateLimiterKey{}, l)
+}
+
+func rateLimiterFrom(ctx context.Context) *rate.Limiter {
+	l, _ := ctx.Value(rateLimiterKey{}).(*rate.Limiter)
+	return l
+}
+
+// ContextWithRateLimitWaitObserver returns a child context carrying a callback
+// invoked with the duration BulkWalk spent blocked on the per-target rate
+// limiter. cycle.go wires this to the network_topology_snmp_rate_limit_wait_seconds
+// histogram; carrying it as a context callback (rather than a metrics handle)
+// keeps the prometheus-client import out of this package. A nil callback
+// returns the original context unchanged.
+func ContextWithRateLimitWaitObserver(ctx context.Context, fn func(time.Duration)) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, rateLimitWaitObserverKey{}, fn)
+}
+
+func rateLimitWaitObserverFrom(ctx context.Context) func(time.Duration) {
+	fn, _ := ctx.Value(rateLimitWaitObserverKey{}).(func(time.Duration))
+	return fn
+}
+
 // BulkWalk walks rootOID using BulkWalkAll, falling back to WalkAll for
 // devices that reject GetBulk PDUs (some older IOS/JunOS revisions, some AP
 // controllers). ctx is checked before each attempt and wraps the blocking
@@ -211,6 +254,20 @@ func Open(p Params) (*g.GoSNMP, error) {
 func BulkWalk(ctx context.Context, client *g.GoSNMP, rootOID string) ([]g.SnmpPDU, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+
+	// Per-target rate limit (issue #72): block here until a token is available
+	// before issuing the walk. Wait is ctx-aware — on cancellation/deadline it
+	// returns promptly with an error and we do NOT issue the walk. When no
+	// limiter is installed (the default), this is a no-op with zero overhead.
+	if l := rateLimiterFrom(ctx); l != nil {
+		start := time.Now()
+		if err := l.Wait(ctx); err != nil {
+			return nil, err
+		}
+		if obs := rateLimitWaitObserverFrom(ctx); obs != nil {
+			obs(time.Since(start))
+		}
 	}
 
 	type walkResult struct {

--- a/internal/discovery/snmp/snmp_test.go
+++ b/internal/discovery/snmp/snmp_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	gsnmp "github.com/gosnmp/gosnmp"
+	"golang.org/x/time/rate"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
 )
@@ -1493,5 +1494,108 @@ func TestParseStrictAcceptsValid(t *testing.T) {
 	}
 	if len(nets) != 2 {
 		t.Errorf("ParseCIDRsStrict returned %d nets, want 2", len(nets))
+	}
+}
+
+// ContextWithRateLimiter: a nil limiter returns the original context unchanged
+// (the default / unlimited path).
+func TestContextWithRateLimiterNil(t *testing.T) {
+	ctx := context.Background()
+	if got := ContextWithRateLimiter(ctx, nil); got != ctx {
+		t.Error("ContextWithRateLimiter(nil) should return the original context")
+	}
+	if rateLimiterFrom(ctx) != nil {
+		t.Error("rateLimiterFrom should be nil on a bare context")
+	}
+}
+
+// ContextWithRateLimiter: BulkWalk paces throughput to the configured rate.
+// We drive several real BulkWalks through the ctx seam at a known low rate and
+// assert the total elapsed time is consistent with the limiter biting. Burst
+// equals the rate (mirroring cycle.go), so the first `rate` calls are free and
+// each subsequent call costs ~1/rate. Tolerances are generous and durations
+// short to keep the timing assertion non-flaky.
+func TestBulkWalkRateLimiterPacesThroughput(t *testing.T) {
+	pdus := []gsnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.1.1.0", Type: gsnmp.OctetString, Value: []byte("desc")},
+	}
+	addr := snmptest.Start(t, "public", pdus)
+	ip, port := snmptest.ParseAddr(addr)
+
+	p := Params{IP: ip, Port: port, Community: []byte("public"), Timeout: 3 * time.Second}
+	client, err := Open(p)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = client.Conn.Close() }()
+
+	// Rate 5/s, burst 1: the bucket starts with 1 token, so the first walk is
+	// free and each of the next N-1 walks waits ~200ms. 4 paced waits ≈ 800ms.
+	const calls = 5
+	lim := rate.NewLimiter(rate.Limit(5), 1)
+	var totalWait time.Duration
+	ctx := ContextWithRateLimiter(context.Background(), lim)
+	ctx = ContextWithRateLimitWaitObserver(ctx, func(d time.Duration) { totalWait += d })
+
+	start := time.Now()
+	for i := 0; i < calls; i++ {
+		if _, err := BulkWalk(ctx, client, "1.3.6.1.2.1.1"); err != nil {
+			t.Fatalf("BulkWalk #%d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// (calls-1) paced waits at 1/5s = 800ms expected. Lower bound guards that
+	// the limiter actually held; we deliberately omit a tight upper bound to
+	// avoid flakiness under load.
+	const wantMin = 600 * time.Millisecond
+	if elapsed < wantMin {
+		t.Errorf("elapsed %v < %v: rate limiter did not pace throughput", elapsed, wantMin)
+	}
+	if totalWait <= 0 {
+		t.Error("expected non-zero observed wait time from the rate-limit observer")
+	}
+}
+
+// ContextWithRateLimiter: a cancelled context interrupts a waiting limit-block
+// promptly and the walk is NOT issued. We set an effectively-infinite delay
+// (rate so low the second token never arrives in-test) and a deadline already
+// in the past, then assert Wait returns an error fast. A counting observer
+// proves the wait callback is not fired on the error path.
+func TestBulkWalkRateLimiterCtxCancel(t *testing.T) {
+	pdus := []gsnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.1.1.0", Type: gsnmp.OctetString, Value: []byte("desc")},
+	}
+	addr := snmptest.Start(t, "public", pdus)
+	ip, port := snmptest.ParseAddr(addr)
+
+	p := Params{IP: ip, Port: port, Community: []byte("public"), Timeout: 3 * time.Second}
+	client, err := Open(p)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = client.Conn.Close() }()
+
+	// Rate of ~1 token/hour, burst 0: no token is ever immediately available,
+	// so Wait must block — until the context deadline (already expired) trips.
+	lim := rate.NewLimiter(rate.Limit(1.0/3600.0), 0)
+	observed := false
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = ContextWithRateLimiter(ctx, lim)
+	ctx = ContextWithRateLimitWaitObserver(ctx, func(time.Duration) { observed = true })
+	cancel() // already cancelled before the call
+
+	start := time.Now()
+	_, err = BulkWalk(ctx, client, "1.3.6.1.2.1.1")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled-context rate-limit wait, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Wait took %v to return after cancel, want prompt return", elapsed)
+	}
+	if observed {
+		t.Error("rate-limit wait observer should not fire when Wait returns an error")
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -40,6 +40,7 @@ type Metrics struct {
 	DiscoveryCycleDuration        prometheus.Histogram
 	DiscoveryModuleDuration       *prometheus.HistogramVec
 	SNMPWalksTotal                *prometheus.CounterVec
+	SNMPRateLimitWaitSeconds      prometheus.Histogram
 	DiscoveryDecodeIssues         *prometheus.CounterVec
 	DiscoveryQuarantinedRowsTotal *prometheus.CounterVec
 	DiscoveryDegradedTotal        *prometheus.CounterVec
@@ -249,6 +250,11 @@ func New(emitBoundaryObs bool) *Metrics {
 			Name: "network_topology_snmp_walks_total",
 			Help: "SNMP walk attempts, partitioned by terminal status and sub-reason. Reason values are the underlying strings of the WalkReason constants in sub_reason.go; status=ok and status=timeout rows carry reason=n/a.",
 		}, []string{"status", "reason"}), // status ∈ {ok, timeout, error}; reason ∈ WalkReason
+		SNMPRateLimitWaitSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "network_topology_snmp_rate_limit_wait_seconds",
+			Help:    "Time spent blocked on the per-target SNMP rate limiter before issuing a walk; non-zero observations mean the per_target_pdu_rate_per_second limit is biting (issue #72).",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 12), // ~1ms .. ~4s
+		}),
 		DiscoveryDecodeIssues: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "network_topology_discovery_decode_issues_total",
 			Help: "SNMP decode anomalies by module, OID, and reason.",
@@ -371,6 +377,7 @@ func New(emitBoundaryObs bool) *Metrics {
 		m.DiscoveryCycleDuration,
 		m.DiscoveryModuleDuration,
 		m.SNMPWalksTotal,
+		m.SNMPRateLimitWaitSeconds,
 		m.DiscoveryDecodeIssues,
 		m.DiscoveryQuarantinedRowsTotal,
 		m.DiscoveryDegradedTotal,

--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-go
+RUN git clone --depth 1 https://github.com/colinedwardwood/network-topology-exporter.git $SRC/network-topology-exporter
+WORKDIR $SRC/network-topology-exporter
+COPY build.sh $SRC/

--- a/oss-fuzz/README.md
+++ b/oss-fuzz/README.md
@@ -1,0 +1,120 @@
+# OSS-Fuzz integration (staging copy)
+
+This directory is a **staging copy** of the OSS-Fuzz project integration for
+`network-topology-exporter`. The files here are intended to be submitted
+*verbatim* to Google's [OSS-Fuzz](https://github.com/google/oss-fuzz)
+repository under:
+
+```
+projects/network-topology-exporter/
+```
+
+Once accepted, OSS-Fuzz continuously builds and runs this project's native Go
+fuzz harnesses ([`testing.F`](https://pkg.go.dev/testing#F)) and reports any
+crashes back to the maintainers.
+
+Keeping a copy in-repo lets us version the integration alongside the code,
+review changes in normal PRs, and re-test locally before pushing updates
+upstream.
+
+> **Note:** These files target the OSS-Fuzz build environment. They reference
+> `compile_native_go_fuzzer`, `$SRC`, and the `base-builder-go` base image,
+> which only exist inside OSS-Fuzz's Docker images. They are **not** executed
+> by this repository's CI.
+
+## Files
+
+| File           | Purpose                                                              |
+| -------------- | ------------------------------------------------------------------- |
+| `project.yaml` | OSS-Fuzz project metadata (language, contacts, engines, sanitizers).|
+| `Dockerfile`   | Clones this repo into the `base-builder-go` image.                  |
+| `build.sh`     | Auto-discovers and compiles every fuzz target.                      |
+
+## Before submitting — fill the placeholders
+
+`project.yaml` contains `REPLACE_WITH_MAINTAINER_EMAIL` placeholders. Replace
+**all** of them before submitting:
+
+- `primary_contact` — the maintainer email that OSS-Fuzz associates with the
+  project. It must be tied to a Google account so the contact can access the
+  OSS-Fuzz dashboard and ClusterFuzz crash reports.
+- `auto_ccs` — additional addresses CC'd on bug reports (optional; remove the
+  list if not needed).
+
+Do not commit a real email to this staging copy unless you intend it to be
+public — OSS-Fuzz's `projects/` tree is a public repository.
+
+## Submitting to google/oss-fuzz
+
+1. Fork [`google/oss-fuzz`](https://github.com/google/oss-fuzz).
+2. Create `projects/network-topology-exporter/` in your fork.
+3. Copy these three files into it (with placeholders filled in):
+   - `project.yaml`
+   - `Dockerfile`
+   - `build.sh`
+4. Open a PR against `google/oss-fuzz` from your fork. The OSS-Fuzz team
+   reviews new project applications; the `primary_contact` must be a real,
+   reachable maintainer.
+
+See the OSS-Fuzz
+[new project guide](https://google.github.io/oss-fuzz/getting-started/new-project-guide/)
+and its [Go-specific notes](https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/)
+for the authoritative process.
+
+## Testing the integration locally
+
+Clone OSS-Fuzz and drive the build with `infra/helper.py`. From a checkout of
+`google/oss-fuzz` that contains your `projects/network-topology-exporter/`
+directory:
+
+```bash
+# Build the fuzzers with the address sanitizer.
+python infra/helper.py build_fuzzers --sanitizer address network-topology-exporter
+
+# Sanity-check that the built fuzzers are valid.
+python infra/helper.py check_build network-topology-exporter
+
+# Run a single fuzzer (output names follow the <pkg>_<FuzzFuncName> convention).
+python infra/helper.py run_fuzzer network-topology-exporter bgp_FuzzSplitOIDParts
+```
+
+`build_fuzzers` builds from your local OSS-Fuzz checkout but pulls the project
+source by `git clone` (see `Dockerfile`), so make sure the code you want to
+fuzz is pushed to the `main_repo`.
+
+## Auto-discovery convention (build.sh)
+
+`build.sh` does **not** hardcode a list of fuzz targets. Instead it scans:
+
+```
+internal/discovery/<pkg>/*_test.go
+```
+
+for any `func Fuzz*(f *testing.F)` declaration and registers each one with
+`compile_native_go_fuzzer`. The output binary for each target is named
+`<pkg>_<FuzzFuncName>` so targets from different packages never collide.
+
+**To add a new fuzzer to OSS-Fuzz:** add a `func FuzzXxx(f *testing.F)` to any
+package under `internal/discovery/`. No edit to `build.sh` is needed — it will
+be picked up automatically on the next build.
+
+At the time of writing, the convention discovers the following targets:
+
+| Package | Fuzz function                  | OSS-Fuzz binary                       |
+| ------- | ------------------------------ | ------------------------------------- |
+| bgp     | FuzzDecodeCiscoCbgpPeer2Index  | bgp_FuzzDecodeCiscoCbgpPeer2Index     |
+| bgp     | FuzzDecodeAristaBgp4v2Index    | bgp_FuzzDecodeAristaBgp4v2Index       |
+| bgp     | FuzzDecodeBgp4v2InstanceIndex  | bgp_FuzzDecodeBgp4v2InstanceIndex     |
+| bgp     | FuzzSplitOIDParts              | bgp_FuzzSplitOIDParts                 |
+| bgp     | FuzzReadInetAddrAt             | bgp_FuzzReadInetAddrAt                |
+| fdb     | FuzzParseQBridgeIndex          | fdb_FuzzParseQBridgeIndex             |
+| lldp    | FuzzDecodePortID               | lldp_FuzzDecodePortID                 |
+| lldp    | FuzzDecodeChassisID            | lldp_FuzzDecodeChassisID              |
+| mpls    | FuzzParseTunnelSuffix          | mpls_FuzzParseTunnelSuffix            |
+| mpls    | FuzzParseIPFromParts           | mpls_FuzzParseIPFromParts             |
+| ospf    | FuzzParseNbrOID                | ospf_FuzzParseNbrOID                  |
+| snmp    | FuzzPDUString                  | snmp_FuzzPDUString                    |
+| snmp    | FuzzPDUBytes                   | snmp_FuzzPDUBytes                     |
+| snmp    | FuzzPDUInt                     | snmp_FuzzPDUInt                       |
+| snmp    | FuzzPDUIntStrict               | snmp_FuzzPDUIntStrict                 |
+| snmp    | FuzzPDUIPv4                    | snmp_FuzzPDUIPv4                      |

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -eu
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# OSS-Fuzz build script for network-topology-exporter.
+#
+# AUTO-DISCOVERY CONVENTION
+# -------------------------
+# Every native Go fuzz harness in this project lives in a `*_test.go` file
+# (conventionally `fuzz_test.go`) inside a package under:
+#
+#     internal/discovery/<pkg>/
+#
+# and is declared as `func FuzzXxx(f *testing.F)`. This script scans those
+# packages, finds every `func Fuzz*` target, and registers it with
+# `compile_native_go_fuzzer` automatically. To add a new fuzzer to OSS-Fuzz,
+# just add a `func FuzzXxx(f *testing.F)` to a discovery package -- no edit to
+# this file is required.
+#
+# Each fuzzer's output binary is named `<pkg>_<FuzzFuncName>` so binaries from
+# different packages never collide (e.g. two packages could both expose a
+# `FuzzDecode`).
+
+# Resolve the module path from go.mod so import paths are always correct,
+# independent of where the source is checked out.
+MODULE_PATH="$(go list -m)"
+
+for fuzz_file in internal/discovery/*/*_test.go; do
+  [ -e "$fuzz_file" ] || continue
+
+  # Only files that actually declare a Fuzz target are of interest.
+  grep -qE '^func Fuzz[A-Za-z0-9_]+\(' "$fuzz_file" || continue
+
+  pkg_dir="$(dirname "$fuzz_file")"          # e.g. internal/discovery/bgp
+  pkg_name="$(basename "$pkg_dir")"          # e.g. bgp
+  import_path="${MODULE_PATH}/${pkg_dir}"    # full Go import path
+
+  # Extract each Fuzz function name declared in this file.
+  for fuzz_func in $(grep -oE '^func Fuzz[A-Za-z0-9_]+' "$fuzz_file" | awk '{print $2}'); do
+    out_name="${pkg_name}_${fuzz_func}"
+    echo "Registering fuzzer: ${import_path} ${fuzz_func} -> ${out_name}"
+    compile_native_go_fuzzer "${import_path}" "${fuzz_func}" "${out_name}"
+  done
+done

--- a/oss-fuzz/project.yaml
+++ b/oss-fuzz/project.yaml
@@ -1,0 +1,17 @@
+homepage: "https://github.com/colinedwardwood/network-topology-exporter"
+language: go
+main_repo: "https://github.com/colinedwardwood/network-topology-exporter"
+# REPLACE_WITH_MAINTAINER_EMAIL before submitting to google/oss-fuzz.
+# Must be a Google-account-associated email so the contact can access the
+# OSS-Fuzz dashboard and ClusterFuzz crash reports.
+primary_contact: "REPLACE_WITH_MAINTAINER_EMAIL"
+# Additional addresses CC'd on bug reports. Replace before submitting.
+auto_ccs:
+  - "REPLACE_WITH_MAINTAINER_EMAIL"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - none
+architectures:
+  - x86_64


### PR DESCRIPTION
Advances the **v1.6.0 — Operator readiness** milestone. Two issues land complete (#72, #74); three (#78, #79, #84) land their full in-repo portion and stay open pending external/owner steps (listed below).

## Fully complete

**#72 — Per-target SNMP PDU rate limiter.** `discovery.per_target_pdu_rate_per_second` (default `0` = unlimited). Per-target token bucket at the `BulkWalk` boundary (covers every walker), ctx-aware so a stuck target can't outlast `timeout_per_device`. New histogram `network_topology_snmp_rate_limit_wait_seconds`. Injected via a context seam (mirrors the decode-reporter pattern) so the snmp package stays Prometheus-free. Closes the self-DoS gap in the threat model.

**#74 — Protocol-level discovery scoping.** `discovery.target_overrides: [{cidr, modules}]`, longest-prefix match (same precedence as `credentials.assignments`), intersected with globally-enabled modules. Skips irrelevant walks (e.g. BGP on access switches) → no more guaranteed `mib_unimplemented` noise. Disabled-module references are a config error; no-match = all enabled modules (unchanged default). Admin rediscover honours it too.

## In-repo complete, issue stays open

**#79 — Kustomize manifests.** `deploy/kustomize/` base + `standalone`/`hub`/`spoke` overlays mirroring the Helm chart; all three render under `kubectl kustomize` (v5.6.0, verified). New `kustomize-smoke` CI workflow (render = required job; kind live-apply = best-effort). _Remaining: live cluster smoke needs a pullable published image; hub/spoke mTLS PKI volume is operator-provided (documented)._

**#78 — Release mirror + offline tarball.** `ci.yml` release job extended: Docker Hub mirror (gated on `DOCKERHUB_TOKEN` so releases stay GHCR-complete without it) and a cosign-signed offline tarball (binaries+sigs, example config, Helm chart, Kustomize) on each Release. _Remaining: owner must create the Docker Hub repo + add `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets._

**#84 — OSS-Fuzz integration staged.** `oss-fuzz/` (`project.yaml`/`Dockerfile`/`build.sh`) ready to copy to `google/oss-fuzz`. `build.sh` auto-discovers all 16 `Fuzz*` targets under `internal/discovery/`. _Remaining: fill contact placeholders, submit the application, open the upstream PR, triage first crash (1–2 mo lead time)._

## Notes
- New `WalkerMetrics` interface methods stay nil-tolerant; discovery never imports the Prometheus client.
- Default behaviour is byte-for-byte unchanged when the new config fields are unset.
- Docs: README Installation (3 image paths + Helm/Kustomize) + Security/OSS-Fuzz line; CHANGELOG entries for all five.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race` — all 25 packages pass
- [x] all three Kustomize overlays render via `kubectl kustomize`
- [x] `ci.yml` + `kustomize-smoke.yml` parse as valid YAML

Closes #72, closes #74