### PR TITLE
Bump Go toolchain to 1.26.4 (clears GO-2026-5037/5039 stdlib vulns)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - name: go vet
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - name: integration tests
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       # Short fuzz pass per target — ~30s each — runs on every push / PR.
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - uses: golangci/golangci-lint-action@v7
@@ -111,7 +111,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - name: install govulncheck
@@ -183,7 +183,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - name: install containerlab
@@ -206,7 +206,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       - name: install containerlab
@@ -275,7 +275,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
 
       - uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26.4'
           cache: true
 
       # 10 minutes per target across 16 fuzz harnesses. Coverage-guided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,11 @@ v1.3.1 lands under this milestone instead, renamed to
   documented in `docs/operator/security.md` § "Verifying release artefact
   provenance." Closes the supply-chain attestation gap identified in the
   May 2026 architectural review.
+- **Go toolchain bumped to 1.26.4** (`go.mod` `toolchain` directive + CI/Docker
+  pins) to pick up the standard-library fixes for `GO-2026-5037` (inefficient
+  candidate hostname parsing in `crypto/x509`) and `GO-2026-5039` (unescaped
+  inputs in `net/textproto` errors), both reachable from the federation hub's
+  HTTP server. `govulncheck ./...` is clean again.
 - **#72 — Per-target SNMP PDU rate limiter.** New
   `discovery.per_target_pdu_rate_per_second` (default `0` = unlimited, today's
   behaviour) caps the steady-state SNMP request rate against an individual

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ─── builder ────────────────────────────────────────────────────────────────
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/colinedwardwood/network-topology-exporter
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/gosnmp/gosnmp v1.43.2


### PR DESCRIPTION
## Why
The CI **vulnerability-scan** (`govulncheck`) job has been red on `main` since two Go standard-library advisories were published, both reachable from `federation.Hub.Serve` → `http.Server.Serve`:

- **GO-2026-5037** — inefficient candidate hostname parsing in `crypto/x509`
- **GO-2026-5039** — unescaped arbitrary inputs in `net/textproto` errors

Both are **fixed in go1.26.4**. CI was pinned to Go `1.25`.

## What
- `go.mod`: `go 1.26.0` + `toolchain go1.26.4` (guarantees the fixed toolchain for every `go` invocation via `GOTOOLCHAIN=auto`).
- All `setup-go` pins → `1.26.4` (8× in `ci.yml`, 1× in `fuzz-nightly.yml`).
- Dockerfile builder base → `golang:1.26-alpine` (the `toolchain` directive forces ≥1.26.4 at build).

## Verification (local, under the resulting go1.26.4)
- `govulncheck ./...` → **exit 0, "No vulnerabilities found"** (was 2 vulns)
- `go build ./...`, `go vet ./...` clean
- `go test ./... -race` → all 25 packages pass
- both workflow files parse as valid YAML

Pure toolchain/CI change — no application code touched.