### PR TITLE
Fix golangci-lint failures from the session-pool merge (#83 follow-up)

### DIFF
--- a/internal/discovery/snmp/pool.go
+++ b/internal/discovery/snmp/pool.go
@@ -28,8 +28,10 @@ type SessionPoolMetrics interface {
 
 // Eviction reasons for SessionPoolMetrics.RecordEviction. Closed low-cardinality set.
 const (
-	evictionReasonIdle               = "idle"
-	evictionReasonCredentialRotation = "credential_rotation"
+	evictionReasonIdle = "idle"
+	// evictionReasonCredentialRotation is a metric label value, not a secret;
+	// gosec G101 trips on the "credential" substring in the identifier.
+	evictionReasonCredentialRotation = "credential_rotation" //nolint:gosec // G101 false positive: metric label value, not a credential
 	evictionReasonConnectionError    = "connection_error"
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,20 +36,20 @@ type Metrics struct {
 	SnapshotLoadedDevicesTotal prometheus.Gauge
 
 	// Discovery cycle health. All aggregates — no per-device label values.
-	DiscoveryDevicesTotal         *prometheus.GaugeVec
-	DiscoveryCycleDuration        prometheus.Histogram
-	DiscoveryModuleDuration       *prometheus.HistogramVec
-	SNMPWalksTotal                *prometheus.CounterVec
-	SNMPRateLimitWaitSeconds      prometheus.Histogram
+	DiscoveryDevicesTotal    *prometheus.GaugeVec
+	DiscoveryCycleDuration   prometheus.Histogram
+	DiscoveryModuleDuration  *prometheus.HistogramVec
+	SNMPWalksTotal           *prometheus.CounterVec
+	SNMPRateLimitWaitSeconds prometheus.Histogram
 
 	// SNMP session pool (issue #83). Zero unless discovery.snmp.session_pool is
 	// enabled. SNMPSessionPoolSize is the current count of pooled sessions;
 	// hits/misses partition Checkout outcomes; evictions partition session
 	// removal by reason (idle | credential_rotation | connection_error).
-	SNMPSessionPoolSize      prometheus.Gauge
-	SNMPSessionPoolHits      prometheus.Counter
-	SNMPSessionPoolMisses    prometheus.Counter
-	SNMPSessionPoolEvictions *prometheus.CounterVec
+	SNMPSessionPoolSize           prometheus.Gauge
+	SNMPSessionPoolHits           prometheus.Counter
+	SNMPSessionPoolMisses         prometheus.Counter
+	SNMPSessionPoolEvictions      *prometheus.CounterVec
 	DiscoveryDecodeIssues         *prometheus.CounterVec
 	DiscoveryQuarantinedRowsTotal *prometheus.CounterVec
 	DiscoveryDegradedTotal        *prometheus.CounterVec


### PR DESCRIPTION
PR #109 (v1.7.0) merged with two golangci-lint v2.12 violations that `go vet` doesn't catch (gofmt + gosec aren't part of `vet`), turning the lint job red on `main`. This greens it:

- **gofmt** — `internal/metrics/metrics.go`: the session-pool metric fields shifted the struct's field-alignment column; re-ran `gofmt`.
- **gosec G101** — `internal/discovery/snmp/pool.go`: `evictionReasonCredentialRotation = "credential_rotation"` is a metric **label value**, not a secret. gosec trips on the `credential` substring in the identifier; added a justified `//nolint:gosec`.

Verified: `golangci-lint run ./...` → 0 issues; `go build`/`vet`/`test -race` green.

(Process note: I'll run golangci-lint locally before merging future PRs, not just `go vet`.)