### PR TITLE
Quality & supply-chain hardening: goleak, coverage gate, SBOM, license gate, Dependabot, benchmarks+k6, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# Code ownership for review routing. Every path requires review from the
+# owner before merge (when branch protection enforces CODEOWNERS reviews).
+# Path-specific entries make ownership explicit as the project grows and more
+# contributors come on; today they all resolve to the maintainer.
+#
+# Order matters: the LAST matching pattern wins for a given file.
+
+# Default owner for everything.
+*                                   @colinedwardwood
+
+# Discovery walkers and the SNMP layer — the core protocol-correctness surface.
+/internal/discovery/                @colinedwardwood
+
+# Graph reconciliation and federation — cross-domain correctness and HA.
+/internal/graph/                    @colinedwardwood
+/internal/federation/              @colinedwardwood
+
+# Credential handling and config schema — security-sensitive.
+/internal/credentials/              @colinedwardwood
+/internal/config/                   @colinedwardwood
+
+# Metrics surface — the public contract operators alert on.
+/internal/metrics/                  @colinedwardwood
+/docs/metrics.md                    @colinedwardwood
+
+# CI, release pipeline, and supply-chain config.
+/.github/                           @colinedwardwood
+/Dockerfile                         @colinedwardwood
+/oss-fuzz/                          @colinedwardwood
+
+# Deployment manifests.
+/deploy/                            @colinedwardwood
+
+# Operator-facing documentation.
+/docs/                              @colinedwardwood

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+
+updates:
+  # Go module dependencies. Grouped so a routine bump week is one PR, not ten.
+  # The govulncheck CI job gates security relevance; this keeps deps fresh.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+      # Major bumps stay individual — they may carry breaking changes.
+
+  # GitHub Actions used by the workflows in .github/workflows/.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+
+  # The runtime/builder base images in the Dockerfile.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing! Keep the description tight — reviewers read this first.
+See CONTRIBUTING.md for the clean-room development rules and conventions.
+-->
+
+## What this PR does
+
+<!-- One or two sentences. What changes, and why. -->
+
+## Which issue(s) this closes
+
+<!-- e.g. "Closes #123". Use one "Closes #N" per issue — GitHub only links the
+     issue immediately after each keyword. -->
+Closes #
+
+## Special notes for reviewers
+
+<!-- Anything non-obvious: a design trade-off, a follow-up left open, a config
+     migration, a breaking change. Delete if none. -->
+
+## Checklist
+
+- [ ] Tests added/updated and `go test ./... -race` passes
+- [ ] `golangci-lint run ./...` is clean (gofmt + gosec — not covered by `go vet`)
+- [ ] `govulncheck ./...` is clean
+- [ ] Docs updated (`README.md`, `docs/`, `config/example.yaml` if config changed)
+- [ ] `CHANGELOG.md` updated under the right section
+- [ ] Any new metric/config key/flag is documented and uses a stable, low-cardinality name
+- [ ] Breaking changes to config or the metrics contract are called out above and in `CHANGELOG.md`

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,57 @@
+name: benchmarks
+
+# Report-only benchmark regression tracking. CI runners have variable
+# performance, so this does NOT hard-fail on a regression (that would be flaky);
+# it runs the Go benchmarks on the PR head and on the base, compares them with
+# benchstat, and posts the delta to the job summary so regressions are visible
+# in review. Run `make bench` locally and compare with benchstat for a
+# controlled measurement before trusting a number.
+on:
+  pull_request:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/benchmarks.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  benchstat:
+    name: benchmark comparison (report-only)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+          cache: true
+
+      - name: install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: benchmark PR head
+        run: go test -run='^$' -bench=. -benchmem -count=6 ./... | tee /tmp/new.txt
+
+      - name: benchmark base
+        run: |
+          git checkout --quiet "${{ github.event.pull_request.base.sha }}"
+          go test -run='^$' -bench=. -benchmem -count=6 ./... | tee /tmp/old.txt
+          git checkout --quiet -
+
+      - name: compare (base → PR)
+        run: |
+          {
+            echo '## Benchmark comparison (base → PR head)'
+            echo '`benchstat` over 6 runs each. CI runner variance is high — treat'
+            echo 'small deltas as noise; investigate a consistent >20% geomean change.'
+            echo
+            echo '```'
+            benchstat /tmp/old.txt /tmp/new.txt || echo "benchstat could not compare (no common benchmarks or a run failed)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
       - name: unit tests
         run: go test ./... -race -count=1 -timeout 120s -coverprofile=coverage.out
 
+      # Gate: total statement coverage must not regress below the floor. Set
+      # below the current level (~85%) with headroom for normal fluctuation;
+      # raise the floor as coverage improves. Prevents silent erosion.
+      - name: enforce coverage floor
+        run: |
+          min=83.0
+          pct=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
+          echo "total coverage: ${pct}% (floor: ${min}%)"
+          awk -v p="$pct" -v m="$min" 'BEGIN { exit (p+0 >= m+0) ? 0 : 1 }' || {
+            echo "::error::total coverage ${pct}% is below the required floor of ${min}%"
+            exit 1
+          }
+
       - name: upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,31 @@ jobs:
       - name: govulncheck
         run: govulncheck ./...
 
+  license-check:
+    name: license compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.4'
+          cache: true
+
+      - name: install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      # Fails the build if any dependency carries a forbidden or unidentifiable
+      # license. The project is AGPL-3.0, so copyleft (GPL/LGPL/MPL) deps are
+      # compatible and intentionally NOT disallowed; "forbidden" catches truly
+      # incompatible/proprietary licenses and "unknown" forces a human to
+      # classify anything go-licenses can't detect before it ships.
+      - name: check dependency licenses
+        run: |
+          go-licenses check ./... \
+            --disallowed_types=forbidden,unknown \
+            --ignore github.com/colinedwardwood/network-topology-exporter
+
   helm-lint:
     name: helm lint
     runs-on: ubuntu-latest
@@ -393,6 +418,41 @@ jobs:
             bin/topology-exporter-linux-amd64
             bin/topology-exporter-linux-arm64
 
+      # SBOM (SPDX) for the published image — the third leg of the supply-chain
+      # story alongside cosign signatures and SLSA provenance. Generated with
+      # syft (via anchore/sbom-action), attested to the registry as an in-toto
+      # SPDX predicate, signed as a blob, and attached to the release + the
+      # offline tarball.
+      - name: generate image SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build_push.outputs.digest }}
+          format: spdx-json
+          output-file: network-topology-exporter-${{ github.ref_name }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: attest image SBOM
+        env:
+          DIGEST: ${{ steps.build_push.outputs.digest }}
+          SBOM: network-topology-exporter-${{ github.ref_name }}.spdx.json
+        run: |
+          cosign attest --yes --type spdxjson --predicate "${SBOM}" \
+            "ghcr.io/${{ github.repository }}@${DIGEST}"
+          if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
+            cosign attest --yes --type spdxjson --predicate "${SBOM}" \
+              "docker.io/${{ github.repository }}@${DIGEST}"
+          fi
+
+      - name: sign SBOM (cosign keyless)
+        env:
+          SBOM: network-topology-exporter-${{ github.ref_name }}.spdx.json
+        run: |
+          cosign sign-blob --yes \
+            --output-signature "${SBOM}.sig" \
+            --output-certificate "${SBOM}.cert" \
+            "${SBOM}"
+
       # Offline install bundle for air-gapped / proxy-restricted shops that can
       # reach neither ghcr.io nor docker.io. Contains the static binaries plus
       # their cosign sigs/certs, the example config, the Helm chart, and the
@@ -411,6 +471,7 @@ jobs:
              bin/topology-exporter-linux-arm64.cert \
              "${staging}/bin/"
           cp config/example.yaml "${staging}/config/"
+          cp network-topology-exporter-${{ github.ref_name }}.spdx.json "${staging}/"
           cp -R deploy/helm/topology-exporter "${staging}/deploy/helm-chart"
           cp -R deploy/kustomize "${staging}/deploy/kustomize"
           tar -czf "${TARBALL}" -C offline "network-topology-exporter-${{ github.ref_name }}"
@@ -437,4 +498,7 @@ jobs:
             network-topology-exporter-${{ github.ref_name }}-offline.tar.gz
             network-topology-exporter-${{ github.ref_name }}-offline.tar.gz.sig
             network-topology-exporter-${{ github.ref_name }}-offline.tar.gz.cert
+            network-topology-exporter-${{ github.ref_name }}.spdx.json
+            network-topology-exporter-${{ github.ref_name }}.spdx.json.sig
+            network-topology-exporter-${{ github.ref_name }}.spdx.json.cert
           generate_release_notes: true

--- a/.github/workflows/k6-load.yml
+++ b/.github/workflows/k6-load.yml
@@ -1,0 +1,52 @@
+name: k6-load
+
+# Best-effort k6 load smoke for /metrics. A fresh exporter has little
+# cardinality, so this only proves the scrape surface serves cleanly under
+# concurrency — it does NOT block PRs (continue-on-error). Real capacity testing
+# runs against a large-topology instance; see tests/load/k6/README.md.
+on:
+  pull_request:
+    paths:
+      - "tests/load/k6/**"
+      - ".github/workflows/k6-load.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  k6-smoke:
+    name: k6 /metrics load smoke (best-effort)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+          cache: true
+
+      - name: build and start the exporter
+        run: |
+          go build -o /tmp/topology-exporter ./cmd/topology-exporter
+          /tmp/topology-exporter \
+            --config.file=config/example.yaml \
+            --web.listen-address=:9100 &
+          echo "waiting for readiness..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9100/readyz >/dev/null; then echo "ready"; break; fi
+            sleep 1
+          done
+
+      - name: install k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: run /metrics scrape load
+        uses: grafana/run-k6-action@v1
+        env:
+          TARGET: http://localhost:9100
+          VUS: "20"
+          DURATION: "20s"
+        with:
+          path: tests/load/k6/scrape_metrics.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,22 @@ v1.3.1 lands under this milestone instead, renamed to
   auto-discovers every `Fuzz*` target under `internal/discovery/` (16 today), so
   new harnesses are picked up with no edit. The upstream `google/oss-fuzz`
   application and PR are tracked as remaining steps on #84.
+- **Quality & supply-chain hardening.**
+  - **Goroutine/fd-leak detection** (`go.uber.org/goleak`) in `internal/app` and
+    `internal/discovery/snmp` — guards the session-pool eviction goroutine, the
+    pprof debug server, and the discovery-loop workers against leaks.
+  - **Total test coverage raised 80% → 85%** (`internal/app` 34%→60%,
+    `internal/tracing` 64%→91%) and a **CI coverage floor** (83%) so it can't
+    silently erode.
+  - **SBOM** (SPDX, via syft) generated for the released image, attested to the
+    registry and attached to the release + offline tarball — completing the
+    cosign + SLSA + SBOM supply-chain trio.
+  - **License-compliance CI gate** (`go-licenses`, forbidden/unknown disallowed)
+    so a future incompatible or unidentified transitive dependency fails CI.
+  - **Dependabot** (gomod / github-actions / docker), **CODEOWNERS**, and a **PR
+    template** modelled on Grafana OSS conventions.
+  - **Benchmark regression tracking** (report-only benchstat diff on PRs) and a
+    **k6 load test** for the `/metrics` scrape surface (`tests/load/k6/`).
 
 ### Discovery
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ lint: ## golangci-lint
 	@command -v golangci-lint >/dev/null || { echo "install: https://golangci-lint.run/usage/install/"; exit 1; }
 	golangci-lint run ./...
 
+.PHONY: bench
+bench: ## Run Go benchmarks (compare across commits with benchstat)
+	go test -run='^$$' -bench=. -benchmem -count=6 ./...
+
+.PHONY: licenses
+licenses: ## Check dependency licenses (forbidden/unknown fail)
+	@command -v go-licenses >/dev/null || go install github.com/google/go-licenses@latest
+	go-licenses check ./... --disallowed_types=forbidden,unknown --ignore github.com/colinedwardwood/network-topology-exporter
+
 .PHONY: fmt
 fmt: ## Format
 	gofmt -s -w .

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/app/cycle_warn_test.go
+++ b/internal/app/cycle_warn_test.go
@@ -1,0 +1,42 @@
+package app
+
+import "testing"
+
+// TestMaybeWarnLargeTopologyUpwardCrossing fires the warning only on the upward
+// crossing of the edge threshold, honours the cooldown, and threads the
+// returned state correctly across cycles.
+func TestMaybeWarnLargeTopologyUpwardCrossing(t *testing.T) {
+	log := slogDiscard()
+	above := LargeTopologyEdgeThreshold + 1
+	below := LargeTopologyEdgeThreshold
+
+	// Below threshold: no warning, state stays below.
+	nowAbove, last := MaybeWarnLargeTopology(log, below, 10, false, 1, -LargeTopologyWarnCooldownCycles)
+	if nowAbove {
+		t.Error("below threshold should report nowAbove=false")
+	}
+	if last != -LargeTopologyWarnCooldownCycles {
+		t.Errorf("lastWarnCycle = %d, want unchanged", last)
+	}
+
+	// Upward crossing past cooldown: warns, lastWarnCycle advances to cycle 5.
+	nowAbove, last = MaybeWarnLargeTopology(log, above, 10, false, 5, -LargeTopologyWarnCooldownCycles)
+	if !nowAbove {
+		t.Error("crossing should report nowAbove=true")
+	}
+	if last != 5 {
+		t.Errorf("lastWarnCycle = %d, want 5 (warned this cycle)", last)
+	}
+
+	// Already above (prevAbove true): no re-warn, lastWarnCycle unchanged.
+	_, last2 := MaybeWarnLargeTopology(log, above, 10, true, 6, 5)
+	if last2 != 5 {
+		t.Errorf("lastWarnCycle = %d, want 5 (no re-warn while still above)", last2)
+	}
+
+	// Upward crossing but within cooldown window: suppressed.
+	_, last3 := MaybeWarnLargeTopology(log, above, 10, false, 10, 5)
+	if last3 != 5 {
+		t.Errorf("lastWarnCycle = %d, want 5 (suppressed by cooldown)", last3)
+	}
+}

--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -1,0 +1,201 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+// TestDeduplicateOOS verifies duplicate (device, port, hint) neighbours are
+// collapsed to the first occurrence while insertion order is preserved.
+func TestDeduplicateOOS(t *testing.T) {
+	in := []discovery.OutOfScopeNeighbour{
+		{ReportingDevice: "a", ReportingPort: "1", NeighbourHint: "h1", Proto: "lldp"},
+		{ReportingDevice: "a", ReportingPort: "1", NeighbourHint: "h1", Proto: "cdp"}, // dup of first
+		{ReportingDevice: "a", ReportingPort: "2", NeighbourHint: "h1", Proto: "lldp"},
+	}
+	out := DeduplicateOOS(in)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0].Proto != "lldp" {
+		t.Errorf("first kept proto = %q, want lldp (first occurrence)", out[0].Proto)
+	}
+	if out[1].ReportingPort != "2" {
+		t.Errorf("second kept port = %q, want 2", out[1].ReportingPort)
+	}
+}
+
+// TestMergeOOSFirstSeen restores the original FirstSeen for known neighbours and
+// leaves the cycle's fresh timestamp for newly-seen ones.
+func TestMergeOOSFirstSeen(t *testing.T) {
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	fresh := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	prev := []discovery.OutOfScopeNeighbour{
+		{ReportingDevice: "a", ReportingPort: "1", NeighbourHint: "h", FirstSeen: old},
+	}
+	cur := []discovery.OutOfScopeNeighbour{
+		{ReportingDevice: "a", ReportingPort: "1", NeighbourHint: "h", FirstSeen: fresh}, // known
+		{ReportingDevice: "b", ReportingPort: "2", NeighbourHint: "x", FirstSeen: fresh}, // new
+	}
+	out := MergeOOSFirstSeen(cur, prev)
+	if !out[0].FirstSeen.Equal(old) {
+		t.Errorf("known neighbour FirstSeen = %v, want restored %v", out[0].FirstSeen, old)
+	}
+	if !out[1].FirstSeen.Equal(fresh) {
+		t.Errorf("new neighbour FirstSeen = %v, want fresh %v", out[1].FirstSeen, fresh)
+	}
+	// Ensure the input slice was not mutated.
+	if !cur[0].FirstSeen.Equal(fresh) {
+		t.Errorf("input slice mutated: cur[0].FirstSeen = %v", cur[0].FirstSeen)
+	}
+}
+
+// TestDeduplicateDevices keeps the first Device per ID in input order.
+func TestDeduplicateDevices(t *testing.T) {
+	in := []discovery.Device{
+		{ID: "sw-a", Vendor: "first"},
+		{ID: "sw-b"},
+		{ID: "sw-a", Vendor: "second"}, // dup ID
+	}
+	out := DeduplicateDevices(in)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0].Vendor != "first" {
+		t.Errorf("kept vendor = %q, want first occurrence", out[0].Vendor)
+	}
+}
+
+// TestCollectDegradedReasons gathers the unique reason set across degraded
+// edges, defaulting empty/missing reasons to "unknown" and ignoring
+// non-degraded edges.
+func TestCollectDegradedReasons(t *testing.T) {
+	edges := []discovery.Edge{
+		{Metadata: map[string]string{discovery.MetadataKeyDegraded: "true", discovery.MetadataKeyDegradedReason: "timeout, partial"}},
+		{Metadata: map[string]string{discovery.MetadataKeyDegraded: "true", discovery.MetadataKeyDegradedReason: "timeout"}}, // dup reason
+		{Metadata: map[string]string{discovery.MetadataKeyDegraded: "true"}},                                                 // empty reason -> unknown
+		{Metadata: map[string]string{discovery.MetadataKeyDegraded: "false"}},                                                // not degraded
+		{Metadata: nil}, // no metadata
+	}
+	got := CollectDegradedReasons(edges)
+	want := map[string]bool{"timeout": true, "partial": true, "unknown": true}
+	if len(got) != len(want) {
+		t.Fatalf("reasons = %v, want keys %v", got, want)
+	}
+	for _, r := range got {
+		if !want[r] {
+			t.Errorf("unexpected reason %q in %v", r, got)
+		}
+	}
+}
+
+// TestResolveEdgeDstDevicesIPResolution resolves an IP DstDevice to its sysName
+// and keeps an unresolved IP edge as-is.
+func TestResolveEdgeDstDevicesIPResolution(t *testing.T) {
+	ipToID := map[string]string{"10.0.0.2": "sw-b"}
+	edges := []discovery.Edge{
+		{SrcDevice: "sw-a", DstDevice: "10.0.0.2", DiscoveryProto: discovery.DiscoveryProtocolBGP},
+		{SrcDevice: "sw-a", DstDevice: "10.0.0.9", DiscoveryProto: discovery.DiscoveryProtocolBGP}, // unresolved IP kept
+	}
+	out := ResolveEdgeDstDevices(slogDiscard(), edges, ipToID, map[string]string{}, nil)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (unresolved IP edge is kept)", len(out))
+	}
+	if out[0].DstDevice != "sw-b" {
+		t.Errorf("resolved dst = %q, want sw-b", out[0].DstDevice)
+	}
+	if out[1].DstDevice != "10.0.0.9" {
+		t.Errorf("unresolved IP dst = %q, want 10.0.0.9 unchanged", out[1].DstDevice)
+	}
+}
+
+// TestResolveEdgeDstDevicesSuppressesUnresolvedFDBMAC drops an FDB edge whose
+// MAC peer cannot be resolved and increments the suppressed counter, while a
+// non-FDB MAC edge is retained.
+func TestResolveEdgeDstDevicesSuppressesUnresolvedFDBMAC(t *testing.T) {
+	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_suppressed_total"})
+	macToID := map[string]string{"aa:bb:cc:dd:ee:01": "sw-known"}
+	edges := []discovery.Edge{
+		{SrcDevice: "sw-a", DstDevice: "aa:bb:cc:dd:ee:01", DiscoveryProto: discovery.DiscoveryProtocolFDB},  // resolved
+		{SrcDevice: "sw-a", DstDevice: "aa:bb:cc:dd:ee:99", DiscoveryProto: discovery.DiscoveryProtocolFDB},  // unresolved FDB -> suppressed
+		{SrcDevice: "sw-a", DstDevice: "aa:bb:cc:dd:ee:88", DiscoveryProto: discovery.DiscoveryProtocolLLDP}, // unresolved non-FDB -> kept as MAC
+	}
+	out := ResolveEdgeDstDevices(slogDiscard(), edges, map[string]string{}, macToID, counter)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (one FDB MAC suppressed)", len(out))
+	}
+	if out[0].DstDevice != "sw-known" {
+		t.Errorf("resolved FDB dst = %q, want sw-known", out[0].DstDevice)
+	}
+	// The LLDP MAC edge is kept (normalised to canonical MAC form, unchanged value).
+	if out[1].DiscoveryProto != discovery.DiscoveryProtocolLLDP {
+		t.Errorf("second kept edge proto = %q, want lldp", out[1].DiscoveryProto)
+	}
+	if got := testutil.ToFloat64(counter); got != 1 {
+		t.Errorf("suppressed counter = %v, want 1", got)
+	}
+}
+
+// TestSynthesizeEdgesBackfillsFDBPort builds the LLDP chassis-MAC index, resolves
+// an FDB MAC peer to a sysName via that index, and backfills the FDB edge's
+// DstPort from the matching LLDP observation.
+func TestSynthesizeEdgesBackfillsFDBPort(t *testing.T) {
+	lldp := discovery.Edge{
+		SrcDevice:      "sw-a",
+		SrcPort:        "Gi0/1",
+		DstDevice:      "sw-b",
+		DstPort:        "Gi0/2",
+		DiscoveryProto: discovery.DiscoveryProtocolLLDP,
+		Metadata:       map[string]string{discovery.MetadataKeyPeerChassisMac: "aa:bb:cc:dd:ee:ff"},
+	}
+	fdb := discovery.Edge{
+		SrcDevice:      "sw-a",
+		SrcPort:        "Gi0/1",
+		DstDevice:      "aa:bb:cc:dd:ee:ff", // MAC -> resolves to sw-b via LLDP index
+		DiscoveryProto: discovery.DiscoveryProtocolFDB,
+	}
+	out := SynthesizeEdges(slogDiscard(), []discovery.Edge{lldp, fdb}, map[string]string{}, map[string]string{}, nil)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	var fdbOut *discovery.Edge
+	for i := range out {
+		if out[i].DiscoveryProto == discovery.DiscoveryProtocolFDB {
+			fdbOut = &out[i]
+		}
+	}
+	if fdbOut == nil {
+		t.Fatal("FDB edge not present in output")
+	}
+	if fdbOut.DstDevice != "sw-b" {
+		t.Errorf("FDB dst = %q, want resolved sw-b", fdbOut.DstDevice)
+	}
+	if fdbOut.DstPort != "Gi0/2" {
+		t.Errorf("FDB dst port = %q, want backfilled Gi0/2", fdbOut.DstPort)
+	}
+}
+
+// TestSynthesizeEdgesARPFallback resolves a MAC via the ARP table when no LLDP
+// chassis annotation provides the mapping.
+func TestSynthesizeEdgesARPFallback(t *testing.T) {
+	ipToID := map[string]string{"10.0.0.2": "sw-b"}
+	arpMACToIP := map[string]string{"aa:bb:cc:dd:ee:ff": "10.0.0.2"}
+	fdb := discovery.Edge{
+		SrcDevice:      "sw-a",
+		SrcPort:        "Gi0/1",
+		DstDevice:      "aa:bb:cc:dd:ee:ff",
+		DiscoveryProto: discovery.DiscoveryProtocolFDB,
+	}
+	out := SynthesizeEdges(slogDiscard(), []discovery.Edge{fdb}, ipToID, arpMACToIP, nil)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	if out[0].DstDevice != "sw-b" {
+		t.Errorf("ARP-resolved dst = %q, want sw-b", out[0].DstDevice)
+	}
+}

--- a/internal/app/leak_test.go
+++ b/internal/app/leak_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs the app package tests under goleak so a leaked goroutine fails
+// the suite. This package owns the discovery loop/cycle worker goroutines and
+// the opt-in pprof debug server (issue #69); goleak is the guard that a clean
+// shutdown of those paths leaves nothing running. No IgnoreFunction is
+// registered: every goroutine the package starts is expected to stop on its
+// own teardown, so any survivor is a real leak we want to catch.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/app/loop_test.go
+++ b/internal/app/loop_test.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/app/httpx"
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+)
+
+// TestNewLogger maps level strings to slog levels and never returns nil.
+func TestNewLogger(t *testing.T) {
+	for _, lvl := range []string{"debug", "info", "warn", "error", "bogus", ""} {
+		if NewLogger(lvl) == nil {
+			t.Errorf("NewLogger(%q) returned nil", lvl)
+		}
+	}
+}
+
+// TestWarnSnapshotFallback uses the direct slog path when no limiter is set, and
+// the rate-limited path when a limiter is configured. Neither must panic.
+func TestWarnSnapshotFallback(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Snapshot.Path = "/tmp/x.json"
+
+	// No limiter: direct slog.Warn path.
+	lc := LoopConfig{Logger: slogDiscard(), Cfg: cfg}
+	lc.WarnSnapshot(context.Background(), "site-a", "no limiter path")
+
+	// With limiter: rate-limited path keyed on site+path.
+	lc.WarnLimiter = loglimit.New(slogDiscard(), time.Hour)
+	lc.WarnSnapshot(context.Background(), "site-a", "limiter path")
+}
+
+// TestOtlpPushDropsWhenSemFull drops the push (and increments the dropped
+// counter) when the concurrency semaphore is already saturated.
+func TestOtlpPushDropsWhenSemFull(t *testing.T) {
+	m := metrics.New(false)
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // saturate
+	var ran atomic.Bool
+	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpSem: sem}
+	lc.OtlpPush(context.Background(), func(context.Context) error {
+		ran.Store(true)
+		return nil
+	}, "should not run")
+	if ran.Load() {
+		t.Error("push fn ran despite saturated semaphore")
+	}
+}
+
+// TestOtlpPushRunsAndCountsOK enqueues a push that succeeds and waits for it via
+// the WaitGroup, asserting the goroutine completed and the semaphore drained.
+func TestOtlpPushRunsAndCountsOK(t *testing.T) {
+	m := metrics.New(false)
+	sem := make(chan struct{}, 1)
+	var wg sync.WaitGroup
+	var ran atomic.Bool
+	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpSem: sem, OtlpWg: &wg}
+	lc.OtlpPush(context.Background(), func(context.Context) error {
+		ran.Store(true)
+		return nil
+	}, "push ok")
+	wg.Wait()
+	if !ran.Load() {
+		t.Error("push fn did not run")
+	}
+	// Semaphore must have drained so a follow-up push can proceed.
+	select {
+	case sem <- struct{}{}:
+		<-sem
+	default:
+		t.Error("semaphore not released after push completed")
+	}
+}
+
+// TestOtlpPushCountsError runs a failing push and waits for completion.
+func TestOtlpPushCountsError(t *testing.T) {
+	m := metrics.New(false)
+	var wg sync.WaitGroup
+	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpWg: &wg}
+	lc.OtlpPush(context.Background(), func(context.Context) error {
+		return errors.New("boom")
+	}, "push failed")
+	wg.Wait()
+}
+
+// TestRunDiscoveryLoopShutsDownCleanly drives the full loop against an
+// in-process SNMP agent for one cycle, writing a snapshot, then cancels the
+// context and asserts the loop returns (goleak in TestMain guards that the
+// snapshot-writer goroutine and any in-flight work shut down with no leak).
+func TestRunDiscoveryLoopShutsDownCleanly(t *testing.T) {
+	t.Setenv("TEST_COMM", "public")
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Discovery.Interval = time.Hour // one immediate cycle, then block on ticker
+	cfg.Discovery.CycleBudgetFraction = 1
+	cfg.Discovery.UnconfirmedLinkTTLCycles = 3
+	cfg.Discovery.Scope.CIDRAllowList = []string{"127.0.0.0/8"}
+	cfg.Snapshot.Path = filepath.Join(t.TempDir(), "snap.json")
+
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", net.ParseIP("127.0.0.2")))
+	ip, port := snmptest.ParseAddr(addr)
+	cfg.Targets = []config.TargetConfig{{Host: ip.String(), Port: int(port)}}
+
+	m := metrics.New(false)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var status atomic.Pointer[httpx.CycleStatus]
+	var ready atomic.Bool
+	lc := LoopConfig{
+		Cancel: cancel,
+		Logger: slogDiscard(),
+		Cfg:    cfg,
+		M:      m,
+		Status: &status,
+		Ready:  &ready,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		RunDiscoveryLoop(ctx, lc)
+	}()
+
+	// Wait until the first cycle has marked the loop ready, then cancel.
+	deadline := time.After(8 * time.Second)
+	for !ready.Load() {
+		select {
+		case <-deadline:
+			cancel()
+			<-done
+			t.Fatal("loop never became ready")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		t.Fatal("RunDiscoveryLoop did not return after context cancel")
+	}
+
+	if status.Load() == nil {
+		t.Error("cycle status was never stored")
+	}
+}

--- a/internal/app/probe_test.go
+++ b/internal/app/probe_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+)
+
+// TestProfileToParamsV2c builds v2c params from a profile whose community env is
+// set, and errors when the env is empty.
+func TestProfileToParamsV2c(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	t.Setenv("PT_COMM", "public")
+	p := config.CredentialProfile{Type: config.ProfileTypeSNMPv2c, CommunityEnv: "PT_COMM", Retries: 2, ContextName: "ctx"}
+	params, err := ProfileToParams(ip, 161, time.Second, p)
+	if err != nil {
+		t.Fatalf("ProfileToParams: %v", err)
+	}
+	if string(params.Community) != "public" {
+		t.Errorf("community = %q, want public", params.Community)
+	}
+	if params.Retries != 2 || params.ContextName != "ctx" {
+		t.Errorf("retries/context = %d/%q, want 2/ctx", params.Retries, params.ContextName)
+	}
+	if params.V3 {
+		t.Error("V3 should be false for v2c profile")
+	}
+
+	empty := config.CredentialProfile{Type: config.ProfileTypeSNMPv2c, CommunityEnv: "PT_COMM_UNSET"}
+	if _, err := ProfileToParams(ip, 161, time.Second, empty); err == nil {
+		t.Error("expected error for empty community env, got nil")
+	}
+}
+
+// TestProfileToParamsV3 builds v3 params and errors when a referenced auth/priv
+// env is empty.
+func TestProfileToParamsV3(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	t.Setenv("PT_USER", "snmpuser")
+	t.Setenv("PT_AUTH", "authpass")
+	t.Setenv("PT_PRIV", "privpass")
+	p := config.CredentialProfile{
+		Type:         config.ProfileTypeSNMPv3,
+		UsernameEnv:  "PT_USER",
+		AuthKeyEnv:   "PT_AUTH",
+		PrivKeyEnv:   "PT_PRIV",
+		AuthProtocol: "SHA",
+		PrivProtocol: "AES",
+	}
+	params, err := ProfileToParams(ip, 161, time.Second, p)
+	if err != nil {
+		t.Fatalf("ProfileToParams v3: %v", err)
+	}
+	if !params.V3 {
+		t.Error("V3 should be true")
+	}
+	if params.Username != "snmpuser" || string(params.AuthKey) != "authpass" || string(params.PrivKey) != "privpass" {
+		t.Errorf("v3 creds not populated: %+v", params)
+	}
+	if params.AuthProto != "SHA" || params.PrivProto != "AES" {
+		t.Errorf("auth/priv proto = %q/%q, want SHA/AES", params.AuthProto, params.PrivProto)
+	}
+}
+
+// TestProfileToParamsV3EmptyUsername errors when the username env is empty.
+func TestProfileToParamsV3EmptyUsername(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	p := config.CredentialProfile{Type: config.ProfileTypeSNMPv3, UsernameEnv: "PT_USER_UNSET"}
+	if _, err := ProfileToParams(ip, 161, time.Second, p); err == nil {
+		t.Error("expected error for empty username env, got nil")
+	}
+}
+
+// TestProfileToParamsUnknownType rejects an unknown profile type.
+func TestProfileToParamsUnknownType(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	if _, err := ProfileToParams(ip, 161, time.Second, config.CredentialProfile{Type: "bogus"}); err == nil {
+		t.Error("expected error for unknown profile type, got nil")
+	}
+}
+
+// TestCredentialCandidatesLegacyCommunity returns one community candidate from
+// modules.snmp.community_env when no profiles are configured, and none when the
+// env is unset (fail-closed).
+func TestCredentialCandidatesLegacyCommunity(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	t.Setenv("CC_COMM", "public")
+	cfg := testConfig(t, "CC_COMM")
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	cands := CredentialCandidates(cfg, resolver, ip, config.TargetConfig{}, slogDiscard())
+	if len(cands) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(cands))
+	}
+	if string(cands[0].Params.Community) != "public" {
+		t.Errorf("community = %q, want public", cands[0].Params.Community)
+	}
+	if cands[0].Params.Port != 161 {
+		t.Errorf("default port = %d, want 161", cands[0].Params.Port)
+	}
+
+	// Unset env -> fail closed with no candidates.
+	cfgUnset := testConfig(t, "CC_COMM_UNSET")
+	resolver2, err := credentials.New(cfgUnset.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	if cands := CredentialCandidates(cfgUnset, resolver2, ip, config.TargetConfig{}, slogDiscard()); len(cands) != 0 {
+		t.Errorf("candidates = %d, want 0 (fail closed)", len(cands))
+	}
+}

--- a/internal/app/rediscover_extra_test.go
+++ b/internal/app/rediscover_extra_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// TestAuthConfigured reflects the flag the constructor was given.
+func TestAuthConfigured(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+	if rd := newTestRediscoverer(t, cfg, m, nil, true); !rd.AuthConfigured() {
+		t.Error("AuthConfigured() = false, want true")
+	}
+	if rd := newTestRediscoverer(t, cfg, m, nil, false); rd.AuthConfigured() {
+		t.Error("AuthConfigured() = true, want false")
+	}
+}
+
+// TestRediscoverResultsBoxesTypedResults verifies the httpx adapter returns one
+// boxed result per target, preserving the typed outcome.
+func TestRediscoverResultsBoxesTypedResults(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+	rd := newTestRediscoverer(t, cfg, m, []string{"10.0.0.0/24"}, true)
+
+	out := rd.RediscoverResults(context.Background(), []string{"10.99.0.1", "not-an-ip"})
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want 2", len(out))
+	}
+	r0, ok := out[0].(RediscoverResult)
+	if !ok {
+		t.Fatalf("result[0] type = %T, want RediscoverResult", out[0])
+	}
+	if r0.Outcome != RediscoverOutOfScope {
+		t.Errorf("result[0] outcome = %q, want out_of_scope", r0.Outcome)
+	}
+	r1 := out[1].(RediscoverResult)
+	if r1.Outcome != RediscoverError {
+		t.Errorf("result[1] outcome = %q, want error", r1.Outcome)
+	}
+}
+
+// TestRediscoverContextCancelledIsTimeout marks an in-scope target as timeout
+// when the context is already cancelled before its walk begins.
+func TestRediscoverContextCancelledIsTimeout(t *testing.T) {
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+	rd := newTestRediscoverer(t, cfg, m, []string{"10.0.0.0/24"}, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel up front so the per-target select hits ctx.Done()
+	results := rd.Rediscover(ctx, []string{"10.0.0.5"})
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Outcome != RediscoverTimeout {
+		t.Errorf("outcome = %q, want timeout", results[0].Outcome)
+	}
+}

--- a/internal/discovery/snmp/leak_test.go
+++ b/internal/discovery/snmp/leak_test.go
@@ -1,0 +1,19 @@
+package snmp
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs the snmp package tests under goleak so a leaked goroutine or
+// socket fails the suite. The session pool (issue #83) runs a background
+// evictLoop goroutine and holds UDP sessions; goleak is the guard that a
+// Close()d pool stops its evictor and releases every session, and that the
+// pooled-session tests do not leak gosnmp sockets. No IgnoreFunction is
+// registered: every goroutine this package starts (the evictor, the in-process
+// snmptest agent's serve loop) is stopped deterministically before the suite
+// exits, so any survivor is a real leak we want to catch.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/tracing/endpoint_test.go
+++ b/internal/tracing/endpoint_test.go
@@ -1,0 +1,114 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+)
+
+// TestEndpointURL covers empty, plain-http (insecure), and https endpoints.
+func TestEndpointURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantOK       bool
+		wantInsecure bool
+	}{
+		{"empty", "", false, false},
+		{"http insecure", "http://collector:4318", true, true},
+		{"https secure", "https://collector:4318", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, insecure, ok := endpointURL(tt.endpoint)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if insecure != tt.wantInsecure {
+				t.Errorf("insecure = %v, want %v", insecure, tt.wantInsecure)
+			}
+			if ok && raw != tt.endpoint {
+				t.Errorf("rawURL = %q, want %q", raw, tt.endpoint)
+			}
+		})
+	}
+}
+
+// TestEndpointHostInsecure extracts host:port and the insecure flag for the gRPC
+// exporter, including the empty and bare-host fallbacks.
+func TestEndpointHostInsecure(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantHost     string
+		wantInsecure bool
+	}{
+		{"empty", "", "", false},
+		{"http authority", "http://collector:4317", "collector:4317", true},
+		{"https authority", "https://collector:4317", "collector:4317", false},
+		{"bare host no scheme", "collector:4317", "collector:4317", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, insecure := endpointHostInsecure(tt.endpoint)
+			if host != tt.wantHost {
+				t.Errorf("host = %q, want %q", host, tt.wantHost)
+			}
+			if insecure != tt.wantInsecure {
+				t.Errorf("insecure = %v, want %v", insecure, tt.wantInsecure)
+			}
+		})
+	}
+}
+
+// TestNewTraceExporterGRPC builds the gRPC exporter (it connects lazily, so no
+// live receiver is needed) for an insecure endpoint.
+func TestNewTraceExporterGRPC(t *testing.T) {
+	exp, err := newTraceExporter(context.Background(), Config{
+		Protocol: ProtocolGRPC,
+		Endpoint: "http://127.0.0.1:4317",
+	})
+	if err != nil {
+		t.Fatalf("newTraceExporter grpc: %v", err)
+	}
+	if exp == nil {
+		t.Fatal("nil exporter without error")
+	}
+	if err := exp.Shutdown(context.Background()); err != nil {
+		t.Errorf("exporter shutdown: %v", err)
+	}
+}
+
+// TestNewGRPCProviderAndShutdown exercises the gRPC branch of New end to end and
+// confirms Shutdown is clean.
+func TestNewGRPCProviderAndShutdown(t *testing.T) {
+	p, err := New(context.Background(), Config{
+		Endpoint:   "http://127.0.0.1:4317",
+		Protocol:   ProtocolGRPC,
+		SampleRate: 1.0,
+		InstanceID: "test-instance",
+	})
+	if err != nil {
+		t.Fatalf("New grpc: %v", err)
+	}
+	if err := p.Shutdown(context.Background()); err != nil {
+		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+// TestTracerReturnsScopedTracer confirms Tracer() returns a usable tracer from
+// the global provider (the no-op when none is installed).
+func TestTracerReturnsScopedTracer(t *testing.T) {
+	tr := Tracer()
+	if tr == nil {
+		t.Fatal("Tracer() returned nil")
+	}
+	// A span Start/End on the global (no-op) tracer must not panic.
+	_, span := tr.Start(context.Background(), "unit.smoke")
+	span.End()
+	// Sanity: the package scope tracer matches otel.Tracer(ScopeName).
+	if otel.Tracer(ScopeName) == nil {
+		t.Error("otel.Tracer(ScopeName) returned nil")
+	}
+}

--- a/tests/load/k6/README.md
+++ b/tests/load/k6/README.md
@@ -1,0 +1,47 @@
+# Load testing with k6
+
+[Grafana k6](https://k6.io/) load tests for the exporter's HTTP surface. The
+exporter's steady-state cost is Prometheus scraping `/metrics` and rendering the
+topology collector at the current graph's cardinality, so that is what these
+scripts exercise.
+
+## Scripts
+
+| Script | What it measures |
+|---|---|
+| `scrape_metrics.js` | Concurrent `/metrics` scrapes — p95/p99 render latency and error rate under VU load, the way a busy or federated Prometheus would scrape it. |
+
+## Run
+
+Against any running exporter:
+
+```bash
+k6 run tests/load/k6/scrape_metrics.js
+# tune load and target:
+TARGET=http://host:9100 VUS=50 DURATION=2m k6 run tests/load/k6/scrape_metrics.js
+```
+
+Thresholds (the test fails if breached): `<1%` failed scrapes, `/metrics` p95
+`< 500 ms`, p99 `< 1500 ms`. Adjust to match your Prometheus `scrape_timeout`.
+
+### Realistic cardinality
+
+A freshly started process renders an almost-empty `/metrics`. For a meaningful
+measurement, point `TARGET` at an instance that has discovered a large topology:
+
+- the `deploy/long-running-test/` lab (rotating multi-topology fixture), or
+- an instance started from a large snapshot (`snapshot.path`), or
+- a production/staging instance behind a management interface.
+
+### Streaming to Grafana Cloud k6
+
+```bash
+k6 cloud tests/load/k6/scrape_metrics.js
+```
+
+## CI
+
+`.github/workflows/k6-load.yml` runs `scrape_metrics.js` against a freshly built
+exporter as a **best-effort** smoke (it won't block PRs — a fresh instance has
+little cardinality, so it only proves `/metrics` serves cleanly under
+concurrency). Use the local/large-topology runs above for real capacity work.

--- a/tests/load/k6/scrape_metrics.js
+++ b/tests/load/k6/scrape_metrics.js
@@ -1,0 +1,46 @@
+// k6 load test for the exporter's HTTP scrape surface.
+//
+// The exporter's runtime load is dominated by Prometheus scraping /metrics —
+// rendering the topology collector under whatever cardinality the discovered
+// graph carries. This script hammers /metrics with concurrent virtual users
+// and asserts latency + error-rate thresholds, the same way a busy Prometheus
+// (or several federated scrapers) would.
+//
+// Run locally against any running exporter:
+//   k6 run tests/load/k6/scrape_metrics.js
+//   TARGET=http://host:9100 VUS=50 DURATION=2m k6 run tests/load/k6/scrape_metrics.js
+//
+// For a realistic high-cardinality measurement, point TARGET at an instance
+// that has discovered a large topology (e.g. the deploy/long-running-test lab,
+// or an instance started from a large snapshot) rather than a fresh process.
+//
+// k6 is a Grafana product; results stream to Grafana Cloud k6 with `k6 cloud`.
+import http from "k6/http";
+import { check } from "k6";
+
+const TARGET = __ENV.TARGET || "http://localhost:9100";
+
+export const options = {
+  scenarios: {
+    scrape: {
+      executor: "constant-vus",
+      vus: Number(__ENV.VUS || 20),
+      duration: __ENV.DURATION || "30s",
+    },
+  },
+  thresholds: {
+    // Fewer than 1% of scrapes may fail.
+    http_req_failed: ["rate<0.01"],
+    // Scrape latency budget — align with your Prometheus scrape_timeout.
+    http_req_duration: ["p(95)<500", "p(99)<1500"],
+  },
+};
+
+export default function () {
+  const res = http.get(`${TARGET}/metrics`);
+  check(res, {
+    "status is 200": (r) => r.status === 200,
+    "exposes topology metrics": (r) =>
+      typeof r.body === "string" && r.body.includes("network_topology_"),
+  });
+}


### PR DESCRIPTION
Closes the production-readiness gaps surfaced in the quality review. Eight items, all verified locally (`go test ./... -race`, `golangci-lint`, `govulncheck`, all workflow YAML).

| Item | What |
|---|---|
| **goleak** (#1) | `go.uber.org/goleak` `TestMain` in `internal/app` + `internal/discovery/snmp` — guards the #83 pool eviction goroutine, #69 debug server, and loop workers. No real leak found (confirms the existing `Close`/`Shutdown` paths are correct). |
| **Coverage** (#3) | 80% → **85.3%** (`internal/app` 34→60, `internal/tracing` 64→91). |
| **Coverage gate** (#2) | build-test fails below an **83%** floor — no more silent erosion. |
| **SBOM** (#4) | SPDX SBOM (syft) for the released image, attested to the registry + attached to release/tarball. Completes cosign + SLSA + SBOM. |
| **License gate** (#6) | `go-licenses check` (forbidden/unknown disallowed; AGPL-compatible copyleft allowed) — verified passing on the current dep set. |
| **Dependabot** (#5) | gomod / github-actions / docker, grouped weekly. |
| **CODEOWNERS + PR template** (#8) | Grafana-OSS-style path routing + review checklist (incl. "run golangci-lint, not just go vet"). |
| **Benchmarks + k6** (#7) | report-only benchstat diff on PRs (runner variance → not a hard gate); k6 `/metrics` load test (`tests/load/k6/`) + best-effort CI smoke via Grafana's k6 actions. |

Notes:
- The benchmark and k6 CI jobs are intentionally **report-only / best-effort** (`continue-on-error`) — CI runner perf variance makes a hard perf gate flaky.
- New dep: `go.uber.org/goleak` only.

## Test plan
- [x] `go build`/`vet` clean, `go test ./... -race` (25 pkgs) pass
- [x] `golangci-lint run ./...` 0 issues, `govulncheck ./...` clean
- [x] coverage gate simulated locally: 85.3% ≥ 83% floor
- [x] `go-licenses check` passes; all 5 workflow YAMLs parse