### PR TITLE
Ops hardening: liveness-on-wedge + background-goroutine panic recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ v1.3.1 lands under this milestone instead, renamed to
 
 ### Security & correctness (post-merge hardening)
 
+- **Liveness now detects a wedged discovery loop.** `/healthz` returns **503**
+  once no cycle has completed within `discovery.interval ×
+  discovery.liveness_max_stale_cycles` (new field, default `3`, `0` disables),
+  so Kubernetes restarts a deadlocked loop instead of leaving it "live" forever.
+  A watchdog re-asserts `network_topology_graph_stale=1` on a running stall and
+  clears it on recovery. Both are inert for `federation.role: hub` (no local
+  discovery loop) and when the field is `0`.
+- **Background goroutines now recover from panics.** The discovery loop,
+  snapshot writers, OTLP push, stale watchdog, hub serve/eviction/snapshot
+  writer, and FDB per-VLAN walkers each recover, log a stack trace, and count
+  the event via the new `network_topology_panics_total{site}` metric instead of
+  crashing the process — previously a single panic anywhere (e.g. in hub
+  reconcile) took down aggregation for every spoke. Any non-zero value indicates
+  a bug; alert on increase.
+
 - **`/admin/rediscover` auth gate now requires real client authentication.** The
   endpoint previously enabled itself whenever `listen.web_config_file` was set —
   but a TLS-only web-config encrypts without authenticating the caller, so any

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -48,6 +48,18 @@ discovery:
   # network_topology_cycle_budget_skips_total.
   cycle_budget_fraction: 0.8
 
+  # Liveness staleness gate (default 3). /healthz is the Kubernetes liveness
+  # target. When the most recent discovery cycle is older than
+  # interval × liveness_max_stale_cycles, /healthz returns 503 so Kubernetes
+  # restarts a process whose discovery loop has wedged (deadlocked) — a wedged
+  # loop can no longer update its own last-cycle timestamp, so without this the
+  # pod would stay "live" forever and never recover. The same staleness signal
+  # also re-asserts network_topology_graph_stale=1 while the loop is stalled.
+  # 0 disables the gate (/healthz always 200 once up — prior behaviour). The
+  # gate is always inert in pure-hub mode (federation.role: hub), which runs no
+  # local discovery loop and so has no cycle timestamp to age out.
+  liveness_max_stale_cycles: 3
+
   # Per-module timeout within a device's total timeout_per_device budget.
   # Prevents one slow protocol walk from consuming the whole device budget.
   # 0 = no additional cap (default); must be < timeout_per_device when set.

--- a/deploy/helm/topology-exporter/values.yaml
+++ b/deploy/helm/topology-exporter/values.yaml
@@ -66,6 +66,12 @@ resources:
   limits:
     memory: 256Mi
 
+# /healthz returns 503 once the discovery loop has gone stale (no completed
+# cycle within discovery.interval × discovery.liveness_max_stale_cycles), so a
+# wedged loop is restarted by Kubernetes. Set discovery.liveness_max_stale_cycles
+# in the exporter config (default 3) and size failureThreshold × periodSeconds so
+# a transiently slow cycle does not cause a needless restart. The gate is inert
+# for federation.role: hub (no local discovery loop).
 livenessProbe:
   httpGet:
     path: /healthz

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             - name: metrics
               containerPort: 9100
               protocol: TCP
+          # /healthz returns 503 once the discovery loop has gone stale (no
+          # completed cycle within discovery.interval ×
+          # discovery.liveness_max_stale_cycles, default 3 cycles), so a wedged
+          # loop is restarted. Inert for federation.role: hub (no local loop).
           livenessProbe:
             httpGet:
               path: /healthz

--- a/docs/operator/troubleshooting.md
+++ b/docs/operator/troubleshooting.md
@@ -199,6 +199,28 @@ Other categories of disagreement (port-name encoding differences, direction asym
 
 5. Verify `cidr_allow_list` is non-empty and covers at least one reachable device.
 
+### graph_stale flips back to 1 on a *running* exporter
+
+If `network_topology_graph_stale` was `0` and then returns to `1` while the
+process keeps running, the discovery loop has **wedged** mid-run: it completed
+at least one cycle but has not completed another within
+`discovery.interval × discovery.liveness_max_stale_cycles` (default 3). A
+watchdog re-asserts the gauge so the `TopologyGraphStale` alert fires for the
+running-wedge case, not only at cold start.
+
+In the same window, `/healthz` (the Kubernetes liveness target) returns **503**
+with `{"status":"stale", ...}`, so Kubernetes restarts the pod and recovers a
+deadlocked loop on its own. Confirm with:
+
+```
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:9100/healthz
+curl -s http://localhost:9100/healthz | jq .
+```
+
+To tune or disable the gate, set `discovery.liveness_max_stale_cycles` (0
+disables it — `/healthz` then stays 200 once up). The gate and watchdog are
+always inert for `federation.role: hub`, which runs no local discovery loop.
+
 ---
 
 ## 8. Snapshot issues

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -247,6 +247,12 @@ func Run(ctx context.Context, args []string) int {
 		workerDone.Add(1)
 		go func() {
 			defer workerDone.Done()
+			// Recover a panic in our hub serve/accept body so one bad push
+			// path cannot crash the whole aggregator and lose every spoke's
+			// graph. One-shot: on recovery the goroutine exits (the deferred
+			// workerDone.Done fires) and shutdown proceeds; the process keeps
+			// serving the last-published metrics.
+			defer recoverGoroutine("hub_serve", logger, m)
 			if err := hub.Serve(ctx); err != nil && ctx.Err() == nil {
 				logger.Error("hub federation server error", "error", err)
 				cancel()
@@ -313,6 +319,11 @@ func Run(ctx context.Context, args []string) int {
 			workerDone.Add(1)
 			go func() {
 				defer workerDone.Done()
+				// Recover a panic in the watchdog so a bug in the staleness
+				// gate cannot crash the process. One-shot: on recovery the
+				// watchdog exits, leaving the /healthz gate to fall back to
+				// the cycle-timestamp check the handler already performs.
+				defer recoverGoroutine("stale_watchdog", logger, m)
 				RunStaleWatchdog(ctx, &status, m, cfg.Discovery.Interval, livenessMaxStale, time.Now)
 			}()
 		}
@@ -320,6 +331,13 @@ func Run(ctx context.Context, args []string) int {
 		workerDone.Add(1)
 		go func() {
 			defer workerDone.Done()
+			// Recover a panic in the discovery scheduler so one wedged
+			// cycle cannot crash the process. Per-cycle work is already
+			// panic-isolated at two finer layers — the per-device probe
+			// recover in cycle.go and the per-cycle recover added inside
+			// RunDiscoveryLoop — so reaching here means the scheduler shell
+			// itself panicked; recover, exit, and let shutdown drain.
+			defer recoverGoroutine("discovery_loop", logger, m)
 			RunDiscoveryLoop(ctx, LoopConfig{
 				Cancel:        cancel,
 				Logger:        logger,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -116,13 +116,21 @@ func Run(ctx context.Context, args []string) int {
 	// Hub mode replaces this with hub.IsReady before registering the mux handler.
 	isReadyFn := ready.Load
 
+	// Liveness staleness gate (ops hardening): /healthz returns 503 once the
+	// most recent discovery cycle is older than interval × liveness_max_stale_cycles
+	// so Kubernetes restarts a process whose discovery loop has wedged. A maxStale
+	// of 0 disables the gate (handler always 200 — prior behaviour). The same
+	// value gates the watchdog goroutine below. See livenessMaxStale for the
+	// hub-exclusion rule.
+	livenessMaxStale := livenessMaxStale(cfg)
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", httpx.InstrumentMetricsHandler(
 		promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{Registry: m.Registry()}),
 		m.MetricsRenderDuration,
 		m.MetricsPayloadBytes,
 	))
-	mux.HandleFunc("/healthz", httpx.NewHealthzHandler(&status))
+	mux.HandleFunc("/healthz", httpx.NewHealthzHandler(&status, livenessMaxStale, time.Now))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			http.NotFound(w, r)
@@ -296,6 +304,19 @@ func Run(ctx context.Context, args []string) int {
 		rediscoverer := NewRediscoverer(cfg, m, logger, adminResolver, allowedNets, &cycleMu, WebConfigHasClientAuth(cfg.Listen.WebConfigFile))
 		mux.HandleFunc("/admin/rediscover", httpx.NewRediscoverHandler(rediscoverer))
 
+		// Graph-stale watchdog (ops hardening): re-assert GraphStale=1 when this
+		// running loop wedges. Only started when a local discovery loop runs (the
+		// default branch already excludes hub) AND the liveness gate is enabled
+		// (livenessMaxStale > 0). Joined via workerDone so graceful shutdown waits
+		// for it; it returns on ctx cancellation (no goroutine leak — goleak).
+		if livenessMaxStale > 0 {
+			workerDone.Add(1)
+			go func() {
+				defer workerDone.Done()
+				RunStaleWatchdog(ctx, &status, m, cfg.Discovery.Interval, livenessMaxStale, time.Now)
+			}()
+		}
+
 		workerDone.Add(1)
 		go func() {
 			defer workerDone.Done()
@@ -396,6 +417,30 @@ func Run(ctx context.Context, args []string) int {
 	}
 	logger.Info("clean shutdown complete")
 	return 0
+}
+
+// livenessMaxStale returns the /healthz liveness staleness threshold for this
+// config: discovery.interval × discovery.liveness_max_stale_cycles. It returns
+// 0 (gate disabled) in two cases:
+//
+//   - liveness_max_stale_cycles == 0 — the operator disabled the gate; or
+//   - federation.role == "hub" — a pure hub runs NO local discovery loop, so it
+//     never updates the cycle timestamp and would otherwise falsely trip the
+//     gate. This is the single hub-exclusion point shared by the /healthz gate
+//     and the graph-stale watchdog: a 0 result means neither is engaged.
+//
+// A 0 return therefore preserves today's behaviour (/healthz always 200 once up
+// and no watchdog goroutine), which is exactly what hub mode and an explicit
+// opt-out both want.
+func livenessMaxStale(cfg *config.Config) time.Duration {
+	if cfg.Federation.Role == "hub" {
+		return 0
+	}
+	cycles := cfg.Discovery.LivenessMaxStaleCyclesValue()
+	if cycles <= 0 {
+		return 0
+	}
+	return cfg.Discovery.Interval * time.Duration(cycles)
 }
 
 // NewLogger returns a slog.Logger configured to emit JSON to stderr at the

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -263,6 +263,14 @@ func RunCycle(
 			params.UseBGPV2MIB = !cfg.Modules.BGP.DisableV2MIB
 			params.WalkerMetrics = walkerMetrics
 			params.WarnLimiter = warnLimiter
+			// Nil-tolerant panic-reporter seam (ops hardening): the FDB module
+			// spawns one goroutine per VLAN and recovers a panic locally so one
+			// bad VLAN can't crash discovery; this closure lets it bump
+			// network_topology_panics_total{site} without the discovery package
+			// importing the prometheus client (mirrors the WalkerMetrics seam).
+			params.PanicReporter = func(site string) {
+				m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
+			}
 			// Issue #83: opt-in per-target SNMP session pool. When pool is nil
 			// (the default), params.Pool stays nil and snmpwalk.Acquire uses the
 			// fresh open+close path — byte-identical to pre-#83 behaviour. When a

--- a/internal/app/httpx/httpx.go
+++ b/internal/app/httpx/httpx.go
@@ -120,19 +120,54 @@ func NewReadyzHandler(isReady func() bool) http.HandlerFunc {
 	}
 }
 
-// NewHealthzHandler returns an HTTP handler for /healthz. It reports the
-// timestamp of the most recent discovery cycle and that cycle's device
-// error count. Until the first cycle completes (status pointer is nil)
-// it reports `{"status":"ok","last_cycle_at":null,"device_errors":null}`
-// so a fresh process is healthy from the orchestrator's perspective
-// while readiness gating still keeps traffic away (see NewReadyzHandler).
-func NewHealthzHandler(status *atomic.Pointer[CycleStatus]) http.HandlerFunc {
+// IsStale reports whether a cycle that last completed at `last` is older than
+// `threshold` as of `now`. A non-positive threshold disables the check and
+// always reports false (not stale). This is the single staleness predicate
+// shared by the /healthz liveness gate (NewHealthzHandler) and the graph-stale
+// watchdog (app.runStaleWatchdog), kept as a tiny pure function so it can be
+// unit-tested in isolation.
+func IsStale(now, last time.Time, threshold time.Duration) bool {
+	if threshold <= 0 {
+		return false
+	}
+	return now.Sub(last) > threshold
+}
+
+// NewHealthzHandler returns an HTTP handler for /healthz, the Kubernetes
+// liveness target. It reports the timestamp of the most recent discovery
+// cycle and that cycle's device error count.
+//
+// Liveness gate: when maxStale > 0 and the most recent cycle is older than
+// maxStale (now - LastCycleAt > maxStale), the handler returns 503 so the
+// orchestrator restarts a process whose discovery loop has wedged. maxStale
+// is discovery.interval × liveness_max_stale_cycles; a value of 0 disables
+// the gate (the handler is then always 200 — today's behaviour). The gate is
+// also disabled for pure-hub mode, which runs no local discovery loop and so
+// never updates LastCycleAt (the call site passes maxStale == 0 there).
+//
+// Until the first cycle completes (status pointer is nil) the handler reports
+// `{"status":"ok","last_cycle_at":null,"device_errors":null}` with 200 so a
+// fresh process stays live while readiness gating keeps traffic away (see
+// NewReadyzHandler) — the gate never trips before the first cycle.
+//
+// now defaults to time.Now when nil; it is injectable so tests can drive the
+// staleness boundary deterministically.
+func NewHealthzHandler(status *atomic.Pointer[CycleStatus], maxStale time.Duration, now func() time.Time) http.HandlerFunc {
+	if now == nil {
+		now = time.Now
+	}
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		s := status.Load()
 		if s == nil {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":"ok","last_cycle_at":null,"device_errors":null}` + "\n"))
+			return
+		}
+		if IsStale(now(), s.LastCycleAt, maxStale) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprintf(w, `{"status":"stale","last_cycle_at":%q,"device_errors":%d,"stale_threshold_seconds":%d}`+"\n",
+				s.LastCycleAt.UTC().Format(time.RFC3339), s.DeviceErrors, int64(maxStale.Seconds()))
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/app/httpx/httpx_test.go
+++ b/internal/app/httpx/httpx_test.go
@@ -15,7 +15,7 @@ import (
 func TestHealthzHandlerNilStatus(t *testing.T) {
 	var status atomic.Pointer[CycleStatus]
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", NewHealthzHandler(&status))
+	mux.HandleFunc("/healthz", NewHealthzHandler(&status, 0, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -38,7 +38,7 @@ func TestHealthzHandlerPopulatedStatus(t *testing.T) {
 	now := time.Now()
 	status.Store(&CycleStatus{LastCycleAt: now, DeviceErrors: 2})
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", NewHealthzHandler(&status))
+	mux.HandleFunc("/healthz", NewHealthzHandler(&status, 0, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -53,6 +53,86 @@ func TestHealthzHandlerPopulatedStatus(t *testing.T) {
 	}
 	if m["device_errors"] != float64(2) {
 		t.Errorf("device_errors = %v, want 2", m["device_errors"])
+	}
+}
+
+// TestHealthzHandlerLivenessGate drives the liveness staleness gate across its
+// boundary cases with an injected clock: a fresh cycle stays 200, a cycle older
+// than maxStale returns 503 with a stale body, a disabled gate (maxStale == 0)
+// is always 200 even for an ancient cycle, and a nil status (no cycle yet)
+// stays 200 regardless of the gate. Every case asserts the body parses as JSON.
+func TestHealthzHandlerLivenessGate(t *testing.T) {
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	const maxStale = 3 * time.Minute
+
+	cases := []struct {
+		name     string
+		setLast  bool          // store a CycleStatus with LastCycleAt = base - age
+		age      time.Duration // how stale the stored cycle is, relative to base
+		maxStale time.Duration
+		wantCode int
+		wantStat string
+	}{
+		{name: "fresh cycle within window", setLast: true, age: 1 * time.Minute, maxStale: maxStale, wantCode: http.StatusOK, wantStat: "ok"},
+		{name: "cycle exactly at threshold is not stale", setLast: true, age: maxStale, maxStale: maxStale, wantCode: http.StatusOK, wantStat: "ok"},
+		{name: "cycle older than maxStale is stale", setLast: true, age: maxStale + time.Second, maxStale: maxStale, wantCode: http.StatusServiceUnavailable, wantStat: "stale"},
+		{name: "disabled gate always ok even when ancient", setLast: true, age: 24 * time.Hour, maxStale: 0, wantCode: http.StatusOK, wantStat: "ok"},
+		{name: "no cycle yet stays ok with gate enabled", setLast: false, maxStale: maxStale, wantCode: http.StatusOK, wantStat: "ok"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var status atomic.Pointer[CycleStatus]
+			if tc.setLast {
+				status.Store(&CycleStatus{LastCycleAt: base.Add(-tc.age), DeviceErrors: 1})
+			}
+			now := func() time.Time { return base }
+			h := NewHealthzHandler(&status, tc.maxStale, now)
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			var m map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+				t.Fatalf("response is not valid JSON: %v", err)
+			}
+			if m["status"] != tc.wantStat {
+				t.Errorf("status field = %q, want %q", m["status"], tc.wantStat)
+			}
+			if tc.wantCode == http.StatusServiceUnavailable {
+				if m["stale_threshold_seconds"] != float64(int64(tc.maxStale.Seconds())) {
+					t.Errorf("stale_threshold_seconds = %v, want %v", m["stale_threshold_seconds"], tc.maxStale.Seconds())
+				}
+			}
+		})
+	}
+}
+
+// TestIsStale covers the shared staleness predicate directly, including the
+// disabled (non-positive threshold) short-circuit and the strict ">" boundary.
+func TestIsStale(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		last      time.Time
+		threshold time.Duration
+		want      bool
+	}{
+		{"disabled threshold zero", now.Add(-time.Hour), 0, false},
+		{"disabled threshold negative", now.Add(-time.Hour), -time.Minute, false},
+		{"within window", now.Add(-time.Minute), 2 * time.Minute, false},
+		{"exactly at threshold", now.Add(-2 * time.Minute), 2 * time.Minute, false},
+		{"past threshold", now.Add(-3 * time.Minute), 2 * time.Minute, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsStale(now, tc.last, tc.threshold); got != tc.want {
+				t.Errorf("IsStale = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -128,6 +128,45 @@ func (lc LoopConfig) OtlpPush(ctx context.Context, fn func(context.Context) erro
 	}()
 }
 
+// RunStaleWatchdog re-asserts the network_topology_graph_stale gauge when a
+// running discovery loop wedges. The wedged loop cannot set its own gauge (it
+// is stuck inside a cycle), so this independent goroutine ticks roughly every
+// `interval` and, once at least one cycle has completed (status != nil), sets
+// the gauge to 1 when the last cycle is older than maxStale and back to 0 when
+// a fresh cycle has landed inside the window. It deliberately does nothing
+// before the first cycle so it never fights the cold-start GraphStale=1 /
+// first-success GraphStale=0 logic in RunDiscoveryLoop.
+//
+// The watchdog is only started when a local discovery loop runs (hub mode is
+// excluded by the caller) and when the gate is enabled (maxStale > 0). It stops
+// the ticker and returns on context cancellation so graceful shutdown joins it
+// cleanly and goleak stays green. `now` defaults to time.Now when nil.
+func RunStaleWatchdog(ctx context.Context, status *atomic.Pointer[httpx.CycleStatus], m *metrics.Metrics, interval, maxStale time.Duration, now func() time.Time) {
+	if now == nil {
+		now = time.Now
+	}
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			s := status.Load()
+			if s == nil {
+				// No cycle has completed yet; leave the cold-start gauge state
+				// owned by RunDiscoveryLoop untouched.
+				continue
+			}
+			if httpx.IsStale(now(), s.LastCycleAt, maxStale) {
+				m.GraphStale.Set(1)
+			} else {
+				m.GraphStale.Set(0)
+			}
+		}
+	}
+}
+
 // RunDiscoveryLoop is the main discovery scheduler. It loads the LD-13
 // snapshot on startup, starts the credential resolver, and then runs
 // periodic cycles. Each cycle probes all configured targets concurrently

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -108,6 +108,12 @@ func (lc LoopConfig) OtlpPush(ctx context.Context, fn func(context.Context) erro
 		lc.OtlpWg.Add(1)
 	}
 	go func() { //nolint:gosec // G118: OTLP push must survive the originating cycle's context — the push is a side-effect of a completed cycle and should reach the collector even if the cycle's deadline already expired
+		// Recover a panic in the push body so a bug in the OTLP exporter
+		// cannot crash the process. Registered first so it runs LAST in the
+		// defer chain — after the semaphore release and OtlpWg.Done below —
+		// keeping the concurrency cap and shutdown drain correct on panic.
+		// One-shot: the push goroutine exits on recovery.
+		defer recoverGoroutine("otlp_push", lc.Logger, lc.M)
 		if lc.OtlpWg != nil {
 			defer lc.OtlpWg.Done()
 		}
@@ -230,6 +236,12 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 		snapWg.Add(1)
 		go func() {
 			defer snapWg.Done()
+			// Recover a panic in the snapshot writer so a bug in the write
+			// path cannot crash the process (and, in spoke mode, take the
+			// live discovery loop with it). One-shot: on recovery the writer
+			// exits; the loop's enqueue path then trips queue_full and counts
+			// the dropped snapshots, so the failure stays observable.
+			defer recoverGoroutine("snapshot_writer", lc.Logger, lc.M)
 			var writeDone chan error // non-nil while a write goroutine is in flight
 			for f := range snapshotCh {
 				lc.M.SnapshotQueueDepth.Set(float64(len(snapshotCh)))
@@ -258,7 +270,15 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 					}
 				}
 				writeDone = make(chan error, 1)
-				go func(f snapshot.File, done chan error) { done <- snapshot.Write(lc.Cfg.Snapshot.Path, f) }(f, writeDone)
+				go func(f snapshot.File, done chan error) {
+					// Recover a panic in snapshot.Write so it cannot crash the
+					// process; the buffered done channel still receives nothing
+					// on panic, so the parent's timeout branch handles it as a
+					// stalled write. The deferred recover runs before the
+					// goroutine unwinds, so the counter is bumped here too.
+					defer recoverGoroutine("snapshot_writer", lc.Logger, lc.M)
+					done <- snapshot.Write(lc.Cfg.Snapshot.Path, f)
+				}(f, writeDone)
 				select {
 				case err := <-writeDone:
 					writeDone = nil
@@ -287,6 +307,13 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 	prevAboveThreshold := false
 	lastWarnCycle := -LargeTopologyWarnCooldownCycles
 	cycle := func() {
+		// Per-cycle panic recovery (ops hardening): the discovery loop is
+		// long-lived, so a panic in one cycle's reconcile/diff/publish path
+		// must NOT kill the scheduler — recover here, count it under
+		// discovery_loop, and let the next tick run a fresh cycle. The
+		// per-device probe recover in cycle.go covers panics inside a single
+		// target's walk; this covers everything else in a cycle.
+		defer recoverGoroutine("discovery_loop", lc.Logger, lc.M)
 		cycleNum++
 		lc.M.GoRoutines.Set(float64(runtime.NumGoroutine()))
 		start := time.Now()

--- a/internal/app/recover.go
+++ b/internal/app/recover.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"log/slog"
+	"runtime/debug"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// recoverGoroutine is the shared panic-recovery body for the exporter's
+// long-lived background goroutines. Without it, a panic in any one of them
+// crashes the whole process — and in hub mode that destroys the aggregated
+// graph for every spoke. Used as the first deferred call at the top of a
+// goroutine body:
+//
+//	go func() {
+//		defer recoverGoroutine("snapshot_writer", logger, m)
+//		// ... goroutine work ...
+//	}()
+//
+// On a panic it mirrors the per-device recover block in cycle.go: it logs the
+// panic value plus the stack trace at Error level, increments the
+// network_topology_panics_total{site} counter so the bug is never hidden
+// silently, and then returns cleanly (it does NOT re-panic), so the goroutine
+// dies gracefully rather than taking the process down with it.
+//
+// site must be one of the closed, low-cardinality strings documented on
+// metrics.Metrics.PanicsRecoveredTotal (discovery_loop, snapshot_writer,
+// otlp_push, hub_serve, hub_rebuild, fdb_vlan_walk, stale_watchdog, ...).
+//
+// Both logger and m are tolerated as nil (logger falls back to slog.Default;
+// a nil m skips the counter) so the helper is safe to use from goroutines
+// started before those are fully wired and from tests.
+func recoverGoroutine(site string, logger *slog.Logger, m *metrics.Metrics) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Error("background goroutine panicked; recovered",
+		"site", site,
+		"panic", r,
+		"stack", string(debug.Stack()),
+	)
+	if m != nil {
+		m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
+	}
+}

--- a/internal/app/recover_test.go
+++ b/internal/app/recover_test.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// runRecovered calls fn inside a function whose only deferred call is
+// recoverGoroutine, so the test can observe that a panic in fn is recovered
+// (the helper returns normally) rather than propagating up the stack.
+func runRecovered(site string, m *metrics.Metrics, fn func()) {
+	defer recoverGoroutine(site, nil, m)
+	fn()
+}
+
+// TestRecoverGoroutine_RecoversAndCounts verifies the core contract: a wrapped
+// function that panics does NOT propagate the panic, and the
+// network_topology_panics_total{site} counter is incremented by 1.
+func TestRecoverGoroutine_RecoversAndCounts(t *testing.T) {
+	m := metrics.New(false)
+
+	// If recoverGoroutine re-panicked, the test goroutine would crash; reaching
+	// the assertion below proves the panic was swallowed.
+	runRecovered("snapshot_writer", m, func() {
+		panic("boom")
+	})
+
+	got := testutil.ToFloat64(m.PanicsRecoveredTotal.WithLabelValues("snapshot_writer"))
+	if got != 1 {
+		t.Fatalf("PanicsRecoveredTotal{site=snapshot_writer} = %v, want 1", got)
+	}
+	// A different site must not have been touched.
+	if other := testutil.ToFloat64(m.PanicsRecoveredTotal.WithLabelValues("otlp_push")); other != 0 {
+		t.Fatalf("PanicsRecoveredTotal{site=otlp_push} = %v, want 0", other)
+	}
+}
+
+// TestRecoverGoroutine_NoPanic verifies the happy path is a no-op: a function
+// that does not panic leaves the counter at zero.
+func TestRecoverGoroutine_NoPanic(t *testing.T) {
+	m := metrics.New(false)
+	ran := false
+	runRecovered("otlp_push", m, func() { ran = true })
+	if !ran {
+		t.Fatal("wrapped function did not run")
+	}
+	if got := testutil.ToFloat64(m.PanicsRecoveredTotal.WithLabelValues("otlp_push")); got != 0 {
+		t.Fatalf("PanicsRecoveredTotal{site=otlp_push} = %v, want 0 on no-panic path", got)
+	}
+}
+
+// TestRecoverGoroutine_NilMetrics verifies the helper tolerates a nil *Metrics
+// (used by goroutines started before metrics are wired, and by tests): it must
+// recover the panic without itself panicking on the nil counter.
+func TestRecoverGoroutine_NilMetrics(t *testing.T) {
+	// Must not panic even though m is nil.
+	runRecovered("hub_serve", nil, func() { panic("boom") })
+}

--- a/internal/app/watchdog_test.go
+++ b/internal/app/watchdog_test.go
@@ -1,0 +1,141 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/app/httpx"
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// TestLivenessMaxStale asserts the hub-exclusion and disable rules that gate
+// both the /healthz liveness check and the watchdog goroutine: a standalone
+// loop gets interval × cycles; a pure hub gets 0 (no local loop to wedge); an
+// explicit 0 cycle count disables the gate regardless of role.
+func TestLivenessMaxStale(t *testing.T) {
+	cycles := func(n int) *int { return &n }
+
+	cases := []struct {
+		name     string
+		role     string
+		interval time.Duration
+		cycles   *int
+		want     time.Duration
+	}{
+		{"standalone default", "standalone", 60 * time.Second, cycles(3), 3 * time.Minute},
+		{"spoke custom", "spoke", 30 * time.Second, cycles(5), 150 * time.Second},
+		{"hub excluded even with cycles set", "hub", 60 * time.Second, cycles(3), 0},
+		{"explicit zero disables", "standalone", 60 * time.Second, cycles(0), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Federation.Role = tc.role
+			cfg.Discovery.Interval = tc.interval
+			cfg.Discovery.LivenessMaxStaleCycles = tc.cycles
+			if got := livenessMaxStale(cfg); got != tc.want {
+				t.Errorf("livenessMaxStale = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunStaleWatchdogFlipsGauge drives the watchdog with a fast tick and a
+// controllable clock, asserting that GraphStale flips to 1 when the last cycle
+// ages past maxStale and back to 0 once a fresh cycle lands inside the window.
+// It also confirms the goroutine exits on context cancellation (the package
+// goleak TestMain catches a leak if it does not).
+func TestRunStaleWatchdogFlipsGauge(t *testing.T) {
+	m := metrics.New(false)
+	var status atomic.Pointer[httpx.CycleStatus]
+
+	// clock is the watchdog's notion of "now"; advance it to age the last cycle.
+	var clockMu sync.Mutex
+	clock := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	now := func() time.Time {
+		clockMu.Lock()
+		defer clockMu.Unlock()
+		return clock
+	}
+	advance := func(d time.Duration) {
+		clockMu.Lock()
+		clock = clock.Add(d)
+		clockMu.Unlock()
+	}
+
+	const maxStale = 3 * time.Minute
+
+	// First cycle has just completed (fresh).
+	status.Store(&httpx.CycleStatus{LastCycleAt: now()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Tick fast so the test does not wait on real interval-length sleeps.
+		RunStaleWatchdog(ctx, &status, m, 5*time.Millisecond, maxStale, now)
+	}()
+
+	waitFor := func(want float64) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if testutil.ToFloat64(m.GraphStale) == want {
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		t.Fatalf("GraphStale = %v, want %v", testutil.ToFloat64(m.GraphStale), want)
+	}
+
+	// Age the clock past the window: the watchdog must re-assert stale.
+	advance(maxStale + time.Minute)
+	waitFor(1)
+
+	// A fresh cycle lands: the watchdog must clear stale.
+	status.Store(&httpx.CycleStatus{LastCycleAt: now()})
+	waitFor(0)
+
+	// Cancellation must stop the goroutine cleanly.
+	cancel()
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not exit on context cancellation")
+	}
+}
+
+// TestRunStaleWatchdogIgnoresNilStatus verifies the watchdog leaves the gauge
+// untouched before the first cycle (status == nil), so it never fights the
+// cold-start GraphStale=1 owned by RunDiscoveryLoop.
+func TestRunStaleWatchdogIgnoresNilStatus(t *testing.T) {
+	m := metrics.New(false)
+	m.GraphStale.Set(1) // cold-start state owned by the loop
+	var status atomic.Pointer[httpx.CycleStatus]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		RunStaleWatchdog(ctx, &status, m, 2*time.Millisecond, time.Minute, time.Now)
+	}()
+
+	// Give the watchdog several ticks with a nil status.
+	time.Sleep(30 * time.Millisecond)
+	if got := testutil.ToFloat64(m.GraphStale); got != 1 {
+		t.Errorf("GraphStale = %v, want 1 (watchdog must not touch the gauge before first cycle)", got)
+	}
+	cancel()
+	wg.Wait()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,6 +242,30 @@ type DiscoveryConfig struct {
 	// (the per-module on/off toggles live under modules.snmp). Currently this is
 	// just the opt-in session pool (issue #83).
 	SNMP DiscoverySNMPConfig `yaml:"snmp"`
+
+	// LivenessMaxStaleCycles gates the /healthz liveness probe on discovery
+	// staleness. When the most recent cycle is older than
+	// interval × liveness_max_stale_cycles, /healthz returns 503 so Kubernetes
+	// restarts a process whose discovery loop has wedged (a deadlocked loop can
+	// no longer update its own last-cycle timestamp). Default 3. A value of 0
+	// disables the gate, restoring the prior behaviour where /healthz is always
+	// 200 once the process is up. The gate is inert in pure-hub mode regardless
+	// of this value, since a hub runs no local discovery loop.
+	//
+	// A pointer so the loader can distinguish "unset" (nil → default 3) from an
+	// explicit 0 (disable the gate). After applyDefaults this is always non-nil;
+	// read it via LivenessMaxStaleCyclesValue. Must be >= 0.
+	LivenessMaxStaleCycles *int `yaml:"liveness_max_stale_cycles"`
+}
+
+// LivenessMaxStaleCyclesValue returns the resolved liveness-gate cycle count.
+// applyDefaults guarantees the field is non-nil, but this accessor is nil-safe
+// (returns 0 → gate disabled) so callers never dereference a nil pointer.
+func (d DiscoveryConfig) LivenessMaxStaleCyclesValue() int {
+	if d.LivenessMaxStaleCycles == nil {
+		return 0
+	}
+	return *d.LivenessMaxStaleCycles
 }
 
 // DiscoverySNMPConfig groups discovery-wide SNMP transport options.
@@ -443,6 +467,14 @@ func (c *Config) applyDefaults() {
 	if c.Discovery.CycleBudgetFraction == 0 {
 		c.Discovery.CycleBudgetFraction = 0.8
 	}
+	// Liveness staleness gate defaults to 3 cycles. The field is a pointer so an
+	// unset value (nil) gets the default 3, while an explicit 0 in YAML is
+	// preserved as "disable the gate" — the two are otherwise indistinguishable
+	// for a plain int. See DiscoveryConfig.LivenessMaxStaleCycles.
+	if c.Discovery.LivenessMaxStaleCycles == nil {
+		def := 3
+		c.Discovery.LivenessMaxStaleCycles = &def
+	}
 	// Session-pool idle TTL defaults to 5 × interval (issue #83). Computed after
 	// the interval default above so a fully-defaulted config still gets a sane
 	// non-zero TTL. Only meaningful when the pool is enabled, but harmless to set
@@ -538,6 +570,9 @@ func (c *Config) validate() error {
 	}
 	if c.Discovery.Interval <= 0 {
 		return errors.New("discovery.interval must be > 0")
+	}
+	if c.Discovery.LivenessMaxStaleCyclesValue() < 0 {
+		return errors.New("discovery.liveness_max_stale_cycles must be >= 0 (0 = liveness staleness gate disabled)")
 	}
 	if c.Discovery.TimeoutPerDevice <= 0 {
 		return errors.New("discovery.timeout_per_device must be > 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,57 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	}
 }
 
+// LivenessMaxStaleCycles defaults to 3 when unset (the liveness staleness gate
+// is on by default), an explicit 0 is preserved as "disable the gate", and a
+// negative value is rejected.
+func TestLivenessMaxStaleCycles(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return path
+	}
+
+	t.Run("unset defaults to 3", func(t *testing.T) {
+		c, err := Load(write(t, "targets: []\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if got := c.Discovery.LivenessMaxStaleCyclesValue(); got != 3 {
+			t.Errorf("LivenessMaxStaleCycles default = %d, want 3", got)
+		}
+	})
+
+	t.Run("explicit zero disables", func(t *testing.T) {
+		c, err := Load(write(t, "discovery:\n  liveness_max_stale_cycles: 0\ntargets: []\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if got := c.Discovery.LivenessMaxStaleCyclesValue(); got != 0 {
+			t.Errorf("explicit 0 = %d, want 0 (gate disabled)", got)
+		}
+	})
+
+	t.Run("explicit positive round-trips", func(t *testing.T) {
+		c, err := Load(write(t, "discovery:\n  liveness_max_stale_cycles: 5\ntargets: []\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if got := c.Discovery.LivenessMaxStaleCyclesValue(); got != 5 {
+			t.Errorf("LivenessMaxStaleCycles = %d, want 5", got)
+		}
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		if _, err := Load(write(t, "discovery:\n  liveness_max_stale_cycles: -1\ntargets: []\n")); err == nil {
+			t.Fatal("expected validation error for liveness_max_stale_cycles: -1")
+		}
+	})
+}
+
 // Issue #69: debug_listen_addr defaults to empty (pprof endpoint OFF).
 func TestDebugListenAddrDefaultsOff(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/discovery/fdb/fdb.go
+++ b/internal/discovery/fdb/fdb.go
@@ -76,6 +76,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -475,6 +476,28 @@ func walkVlanCommunityFdbs(ctx context.Context, pp *snmputil.Params, client *gsn
 		wg.Add(1)
 		go func(idx, vlan int) {
 			defer wg.Done()
+
+			// Recover a panic in this per-VLAN walk so one bad VLAN cannot
+			// crash the whole discovery process (and, in spoke/standalone
+			// mode, take the discovery loop down with it). The recover is
+			// local because the panicking unit IS this goroutine; on recovery
+			// we log the stack, report it under site "fdb_vlan_walk" through
+			// the nil-tolerant PanicReporter seam (keeps this package free of
+			// any prometheus/app import), and leave results[idx] zero so the
+			// merge below simply skips this VLAN. Mirrors the per-device probe
+			// recover in internal/app/cycle.go. Registered first so it runs
+			// last in the defer chain, after the semaphore release and session
+			// close below.
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("fdb: per-VLAN walk panicked; recovered",
+						"device", p.IP, "vlan", vlan, "panic", r,
+						"stack", string(debug.Stack()))
+					if p.PanicReporter != nil {
+						p.PanicReporter("fdb_vlan_walk")
+					}
+				}
+			}()
 
 			// Acquire semaphore slot; respect context cancellation while waiting.
 			select {

--- a/internal/discovery/fdb/fdb_panic_test.go
+++ b/internal/discovery/fdb/fdb_panic_test.go
@@ -1,0 +1,86 @@
+package fdb
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gsnmp "github.com/gosnmp/gosnmp"
+
+	snmputil "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+)
+
+// vlanPanicAgent starts a multi-community SNMP test agent whose VLAN table
+// advertises VLAN 10, so walkVlanCommunityFdbs opens a per-VLAN session and
+// reaches the walkFdbTableIntoFn seam inside its per-VLAN goroutine. The
+// returned Params point at the agent. Mirrors TestWalkVlanCommunityFdbDiscovery.
+func vlanPanicAgent(t *testing.T) snmputil.Params {
+	t.Helper()
+	vlanTablePDUs := []gsnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.17.7.1.4.2.1.3.0.10", Type: gsnmp.Integer, Value: 10},
+		{Name: ".1.3.6.1.2.1.17.1.4.1.2.1", Type: gsnmp.Integer, Value: 2},
+		{Name: ".1.3.6.1.2.1.31.1.1.1.1.2", Type: gsnmp.OctetString, Value: []byte("GigabitEthernet0/2")},
+	}
+	communities := map[string][]gsnmp.SnmpPDU{
+		"public":    vlanTablePDUs,
+		"public@10": {}, // session opens; the panicking seam fires before any PDU matters
+	}
+	addr := snmptest.StartMultiCommunity(t, communities)
+	ip, port := snmptest.ParseAddr(addr)
+	return snmputil.Params{
+		IP:        ip,
+		Port:      port,
+		Community: []byte("public"),
+		Timeout:   3 * time.Second,
+	}
+}
+
+// TestVLANWalkPanicRecovered verifies that a panic inside one per-VLAN walk
+// goroutine does NOT crash the process: Walk still returns (no re-panic) and
+// the injected PanicReporter is invoked once with site "fdb_vlan_walk".
+func TestVLANWalkPanicRecovered(t *testing.T) {
+	orig := walkFdbTableIntoFn
+	t.Cleanup(func() { walkFdbTableIntoFn = orig })
+	walkFdbTableIntoFn = func(_ context.Context, _ *gsnmp.GoSNMP, _ map[string]*fdbEntry) (bool, error) {
+		panic("boom in per-VLAN walk")
+	}
+
+	var reported atomic.Int64
+	var gotSite atomic.Value
+	p := vlanPanicAgent(t)
+	p.PanicReporter = func(site string) {
+		reported.Add(1)
+		gotSite.Store(site)
+	}
+
+	// If the per-VLAN goroutine panic were not recovered, the test process
+	// would crash here; reaching the assertions proves it was contained.
+	_, _, err := Walk(context.Background(), p, "sw-01", nil)
+	if err != nil {
+		t.Fatalf("Walk returned error after recovered per-VLAN panic: %v", err)
+	}
+	if got := reported.Load(); got != 1 {
+		t.Fatalf("PanicReporter called %d times, want 1", got)
+	}
+	if site, _ := gotSite.Load().(string); site != "fdb_vlan_walk" {
+		t.Fatalf("PanicReporter site = %q, want %q", site, "fdb_vlan_walk")
+	}
+}
+
+// TestVLANWalkPanicNilReporter verifies the nil-tolerant seam: with no
+// PanicReporter wired, a per-VLAN panic is still recovered (Walk returns)
+// and nothing panics on the nil reporter.
+func TestVLANWalkPanicNilReporter(t *testing.T) {
+	orig := walkFdbTableIntoFn
+	t.Cleanup(func() { walkFdbTableIntoFn = orig })
+	walkFdbTableIntoFn = func(_ context.Context, _ *gsnmp.GoSNMP, _ map[string]*fdbEntry) (bool, error) {
+		panic("boom in per-VLAN walk")
+	}
+
+	p := vlanPanicAgent(t) // PanicReporter left nil
+	if _, _, err := Walk(context.Background(), p, "sw-01", nil); err != nil {
+		t.Fatalf("Walk returned error with nil PanicReporter: %v", err)
+	}
+}

--- a/internal/discovery/snmp/snmp.go
+++ b/internal/discovery/snmp/snmp.go
@@ -151,6 +151,19 @@ type Params struct {
 	// case. See WarnLimiter interface above.
 	WarnLimiter WarnLimiter
 
+	// PanicReporter is the nil-tolerant observer a walker calls when it
+	// recovers a panic in one of its own background goroutines (the FDB
+	// per-VLAN walkers spawn one goroutine per VLAN). It mirrors the
+	// WalkerMetrics/WarnLimiter injection seam: the discovery layer must not
+	// import the prometheus client or internal/app, so the production wiring
+	// in internal/app passes a closure that bumps
+	// network_topology_panics_total{site}. site is one of the closed,
+	// low-cardinality strings documented on metrics.PanicsRecoveredTotal
+	// (FDB uses "fdb_vlan_walk"). May be nil — callers MUST nil-check before
+	// calling (the recover still happens; only the counter bump is skipped),
+	// so a one-off walk without metrics wiring does not panic.
+	PanicReporter func(site string)
+
 	// CredentialProfile is the name of the credential profile that won the
 	// system-group walk for this target (set in cycle.go from the profileName
 	// WalkSystemWithCredentials returns). It is part of the session-pool key

--- a/internal/federation/hub.go
+++ b/internal/federation/hub.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -86,6 +87,36 @@ func NewHub(cfg config.FederationConfig, m *metrics.Metrics, logger *slog.Logger
 		h.snapshotCh = make(chan discovery.Graph, 1)
 	}
 	return h
+}
+
+// recoverGoroutine is the hub's panic-recovery body for its long-lived
+// background goroutines (eviction loop, snapshot writer). Without it, a panic
+// in any of them crashes the whole aggregator and destroys the combined graph
+// for every spoke. It mirrors the per-device recover block in
+// internal/app/cycle.go: it logs the panic value plus stack trace at Error
+// level, increments network_topology_panics_total{site} so the bug is never
+// hidden silently, and returns cleanly (does NOT re-panic) so the goroutine
+// dies gracefully. The hub already holds its own *metrics.Metrics handle
+// (h.m), so no injection seam is needed here — unlike the discovery modules,
+// the federation package legitimately depends on internal/metrics. h.m is
+// tolerated as nil (skips the counter) so tests can construct a bare Hub.
+//
+// Used as the first deferred call at the top of a goroutine body, e.g.
+// `defer h.recoverGoroutine("hub_rebuild")`. site must be one of the closed,
+// low-cardinality strings documented on metrics.PanicsRecoveredTotal.
+func (h *Hub) recoverGoroutine(site string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	h.logger.Error("hub background goroutine panicked; recovered",
+		"site", site,
+		"panic", r,
+		"stack", string(debug.Stack()),
+	)
+	if h.m != nil {
+		h.m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
+	}
 }
 
 // RestoreGraph populates hub metrics from a snapshot loaded at startup so the
@@ -890,7 +921,15 @@ func (h *Hub) runEviction(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			h.evictSilentSpokes()
+			// Per-tick recovery: evictSilentSpokes rebuilds and republishes
+			// the combined graph, so a panic there (site hub_rebuild) must not
+			// kill the eviction loop. Recover, count it, and let the next tick
+			// try again. Wrapped in a closure so the deferred recover scopes to
+			// one tick rather than the whole goroutine.
+			func() {
+				defer h.recoverGoroutine("hub_rebuild")
+				h.evictSilentSpokes()
+			}()
 		}
 	}
 }
@@ -1033,6 +1072,11 @@ func (h *Hub) writeSnapshot(g discovery.Graph) {
 // hub. It drains h.snapshotCh one graph at a time, so an NFS stall cannot
 // accumulate goroutines across spoke pushes.
 func (h *Hub) runSnapshotWriter(ctx context.Context) {
+	// Recover a panic in the snapshot writer so a bug in the write path
+	// cannot crash the aggregator. One-shot: on recovery the writer exits;
+	// subsequent writeSnapshotAsync calls then trip queue_full and count the
+	// dropped snapshots, so the failure stays observable.
+	defer h.recoverGoroutine("hub_snapshot_writer")
 	var writeDone chan struct{} // non-nil while a write goroutine is in flight
 	for {
 		select {
@@ -1053,8 +1097,13 @@ func (h *Hub) runSnapshotWriter(ctx context.Context) {
 			}
 			writeDone = make(chan struct{}, 1)
 			go func(g discovery.Graph, done chan struct{}) {
+				// Recover a panic in writeSnapshot so it cannot crash the
+				// process; close(done) still runs via defer so the parent's
+				// select unblocks on the success branch rather than timing
+				// out. Registered first so it runs after the close.
+				defer h.recoverGoroutine("hub_snapshot_writer")
+				defer close(done)
 				h.writeSnapshot(g)
-				close(done)
 			}(g, writeDone)
 			select {
 			case <-writeDone:

--- a/internal/federation/hub_panic_test.go
+++ b/internal/federation/hub_panic_test.go
@@ -1,0 +1,41 @@
+package federation
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// recoverInGoroutineBody runs fn under the hub's recoverGoroutine the same way
+// a real hub goroutine does, so the test can confirm a panic is swallowed
+// rather than propagated.
+func (h *Hub) recoverInGoroutineBody(site string, fn func()) {
+	defer h.recoverGoroutine(site)
+	fn()
+}
+
+// TestHubRecoverGoroutine_RecoversAndCounts verifies the hub's recover helper
+// swallows a panic and increments network_topology_panics_total{site}.
+func TestHubRecoverGoroutine_RecoversAndCounts(t *testing.T) {
+	h := newTestHub(nil)
+
+	// If recoverGoroutine re-panicked, the test would crash; reaching the
+	// assertion proves it was contained.
+	h.recoverInGoroutineBody("hub_rebuild", func() { panic("boom") })
+
+	got := testutil.ToFloat64(h.m.PanicsRecoveredTotal.WithLabelValues("hub_rebuild"))
+	if got != 1 {
+		t.Fatalf("PanicsRecoveredTotal{site=hub_rebuild} = %v, want 1", got)
+	}
+}
+
+// TestHubRecoverGoroutine_NilMetrics verifies the helper tolerates a nil
+// *metrics.Metrics handle (h.m): it must recover the panic without itself
+// panicking on the nil counter. logger is set to a real logger so the Error
+// log line does not hit a nil receiver.
+func TestHubRecoverGoroutine_NilMetrics(t *testing.T) {
+	h := &Hub{logger: slog.Default()} // h.m left nil
+	// Must not panic.
+	h.recoverInGoroutineBody("hub_snapshot_writer", func() { panic("boom") })
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -209,6 +209,15 @@ type Metrics struct {
 	//     skipped (BGP still falls through to the observable RFC 4273 path).
 	// No device, IP, or sysObjectID is ever a label value here.
 	SystemWalkAnomalyTotal *prometheus.CounterVec
+
+	// PanicsRecoveredTotal counts panics recovered in long-lived background
+	// goroutines, partitioned by a low-cardinality `site` label (a closed set
+	// of short stable strings: discovery_loop, snapshot_writer, otlp_push,
+	// hub_serve, hub_rebuild, hub_eviction, hub_snapshot_writer, fdb_vlan_walk,
+	// stale_watchdog). Each recovered panic logs the stack at Error level and
+	// bumps this counter so the bug is never hidden silently. Any non-zero
+	// value indicates a bug — alert on increase.
+	PanicsRecoveredTotal *prometheus.CounterVec
 }
 
 // New builds and registers the exporter's metric set. emitBoundaryObs should
@@ -380,6 +389,10 @@ func New(emitBoundaryObs bool) *Metrics {
 			Name: "network_topology_system_walk_anomaly_total",
 			Help: "SNMP system-group walk outcomes that silently degrade downstream behaviour. reason ∈ {empty_sysname, unknown_vendor}.",
 		}, []string{"reason"}),
+		PanicsRecoveredTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "network_topology_panics_total",
+			Help: "Panics recovered in background goroutines, by site. Any non-zero value indicates a bug — alert on increase.",
+		}, []string{"site"}),
 		MetricsPayloadBytes: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name: "network_topology_metrics_payload_bytes",
 			Help: "Response body size of one /metrics scrape in bytes. Tracks growth as the topology scales.",
@@ -432,6 +445,7 @@ func New(emitBoundaryObs bool) *Metrics {
 		m.BGPWalkerOutcomeTotal,
 		m.WalkerOutcomeTotal,
 		m.SystemWalkAnomalyTotal,
+		m.PanicsRecoveredTotal,
 	)
 
 	return m


### PR DESCRIPTION
The two **HIGH**-severity code gaps surfaced by the deep-audit (the MED/LOW were filed as #120/#121/#122).

## Liveness detects a wedged discovery loop
`/healthz` (the k8s liveness target) previously returned 200 forever once the first cycle completed — a deadlocked loop was never restarted. Now it returns **503** when `now - last_cycle_at > discovery.interval × discovery.liveness_max_stale_cycles` (new field, default **3**, **0 disables**). A small watchdog re-asserts `network_topology_graph_stale=1` on a running stall and clears it on recovery (the wedged loop can't re-assert its own gauge).
- **Inert for pure-hub mode** (no local discovery loop) and when the field is 0 — behaviour then identical to before.
- `*int` config field distinguishes unset (→ default 3) from an explicit 0.
- Watchdog joins the worker WaitGroup and exits on context cancel — goleak-clean.

## Background goroutines recover from panics
Only the per-target probe worker recovered before; a panic in the discovery loop, snapshot writers, OTLP push, hub reconcile/eviction, or an FDB per-VLAN walker **crashed the whole process** — in hub mode dropping aggregation for all spokes. Each now recovers, logs a stack trace, and increments `network_topology_panics_total{site}` (closed site label set).
- `internal/app` uses a `recoverGoroutine(site, logger, m)` helper; the hub uses its own metrics handle; FDB uses a new nil-tolerant `PanicReporter` seam on `snmputil.Params` (no bad imports into `internal/discovery`/`internal/federation`).
- One-shot goroutines recover-then-exit; long-lived loops recover per-iteration and continue.
- `http.Server.Serve` loops left untouched (net/http handles request panics).

## Test plan
- [x] `go build`/`vet` clean; `go test ./... -race` (25 pkgs) pass incl. both goleak TestMains
- [x] `golangci-lint run ./...` 0 issues; `govulncheck ./...` clean
- [x] coverage 85.2% (above the 83% floor)
- [x] recover helper, watchdog, FDB-panic, and hub-recover unit tests added