### PR TITLE
Fix nightly-fuzz false-positive regression alerts (closes #107)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -23,19 +23,46 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
-      # 10 minutes per target across 16 fuzz harnesses. Coverage-guided
+      # 10 minutes per target across the fuzz harnesses. Coverage-guided
       # engine reaches deeper paths than the per-PR short pass.
+      #
+      # Two correctness points learned from a false-positive regression alert
+      # (#107):
+      #   1. -timeout MUST exceed -fuzztime. With the default 10m test timeout
+      #      and -fuzztime=10m the test deadline races the fuzz deadline and the
+      #      run dies with a benign "context deadline exceeded" — no crash. We
+      #      give the timeout generous headroom.
+      #   2. Only a GENUINE crasher must fail the build. Go writes a minimised
+      #      crashing input ("Failing input written to testdata/fuzz/...") on a
+      #      real find; a fuzztime-deadline artifact does not. We fail (and let
+      #      the next step file an issue) only when a crasher was actually found,
+      #      so a clean deep run can never page as a security regression again.
       - name: deep fuzz parsers
         id: fuzz
         run: |
-          set -e
+          set -uo pipefail
+          crash=0
           for pkg in bgp fdb ospf mpls lldp snmp; do
             FUZZ_TARGETS=$(go test -list 'Fuzz.*' "./internal/discovery/$pkg" | grep '^Fuzz')
             for t in $FUZZ_TARGETS; do
               echo "▼ $pkg.$t"
-              go test -run=NONE -fuzz="^$t\$" -fuzztime=10m "./internal/discovery/$pkg"
+              if out=$(go test -run=NONE -fuzz="^$t\$" -fuzztime=10m -timeout=15m "./internal/discovery/$pkg" 2>&1); then
+                printf '%s\n' "$out"
+                continue
+              fi
+              printf '%s\n' "$out"
+              if printf '%s\n' "$out" | grep -qE 'Failing input written|^[[:space:]]*panic:'; then
+                echo "::error::fuzz crash found in $pkg.$t — crasher written to testdata/fuzz/"
+                crash=1
+              elif printf '%s\n' "$out" | grep -q 'context deadline exceeded'; then
+                echo "::warning::$pkg.$t reached the fuzztime deadline with no crasher (benign); continuing"
+              else
+                echo "::error::$pkg.$t fuzz run failed for a non-crash reason (build/setup); investigate"
+                crash=1
+              fi
             done
           done
+          exit "$crash"
 
       - name: upload fuzz corpus on failure
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ v1.3.1 lands under this milestone instead, renamed to
 
 ### Security & correctness (post-merge hardening)
 
+- **Nightly fuzz no longer false-alarms (#107).** The `fuzz-nightly` workflow ran
+  `-fuzztime=10m` with the default 10m test timeout, so the test deadline raced
+  the fuzz deadline and a clean run died with a benign `context deadline
+  exceeded` — auto-filing a HIGH "regression detected" issue with no actual
+  crash. Fixed: `-timeout=15m` gives headroom over `-fuzztime`, and the step now
+  fails (and files an issue) only when Go actually writes a crashing input, so a
+  benign fuzztime deadline can never page as a security regression again.
 - **SNMP transport goroutines now recover from panics.** The raw `go func()`
   bodies in `internal/discovery/snmp` that call gosnmp `BulkWalkAll`/`WalkAll`/
   `Get` previously ran with no `recover()` on their stack, so a panic decoding a


### PR DESCRIPTION
## What #107 actually was
The `fuzz-nightly` run [27002929874](https://github.com/colinedwardwood/network-topology-exporter/actions/runs/27002929874) auto-filed #107 as a HIGH "regression detected". Triage:
- The failing target was **`FuzzPDUBytes`** (`internal/discovery/snmp`), **not** the `FuzzReadInetAddrAt` seed the artifact happened to contain.
- It ran the **full 600.00s / 22.8M execs with ZERO crashers** (no "Failing input written") and failed only with **`context deadline exceeded`**.
- That's a benign fuzztime/test-timeout race — **not a code crash.** Confirmed: the artifact's input (`[]byte("0"), int(-14)`) is the already-fixed negative-`pos` case and passes on current code.

## Root cause
`fuzz-nightly.yml` ran `go test -fuzz=… -fuzztime=10m` with **no `-timeout`**, so the default 10m test deadline collided with the 10m fuzz deadline. Whichever target was still running at the mark died with `context deadline exceeded` and tripped `if: failure()` → auto-filed a HIGH issue. Pure noise that erodes trust in the nightly signal.

## Fix
1. **`-timeout=15m`** — headroom over `-fuzztime=10m` so the test deadline never races the fuzz deadline.
2. **Crash-vs-deadline discrimination** — the step now fails (and lets the issue-filer run) **only when Go writes an actual crashing input** (`Failing input written` / `panic:`). A benign `context deadline exceeded` is logged as a warning and the run continues. Verified the classifier against the real deadline-artifact, real-crasher, and build-error signatures.

Net: a clean deep fuzz run can never again page as a security regression; a genuine crasher still fails hard, uploads the corpus, and files an issue.

The per-PR `fuzz-short` job (`-fuzztime=30s`, default 10m timeout) is unaffected — 30s ≪ 10m, no collision.

## Test plan
- [x] YAML parses
- [x] classifier verified on all three failure signatures (benign deadline → continue; real crash → fail; build error → fail)