### PR TITLE
Fix long-running-lab mutator: idempotent, self-healing link reconciliation

### DIFF
--- a/deploy/long-running-test/README.md
+++ b/deploy/long-running-test/README.md
@@ -31,6 +31,15 @@ Nodes that don't participate in the current topology (`spine2` in
 `topo-1/2/3`; `leaf4` in `topo-4`) stay running with no data-plane
 links — the exporter sees the device but reports zero edges.
 
+Each mutation is **idempotent and self-healing**: rather than trusting that
+the previously-applied topology's links still exist, the mutator verifies and
+(re)creates *every* desired link on each pass (with retries, repairing a
+half-broken veth pair). A `containerlab tools veth create` that fails
+transiently — or a veth lost out-of-band — is recreated on the next apply
+instead of leaving a permanent missing edge (e.g. a star missing one spoke).
+Re-applying the current topology (restart the `long-running-mutator`
+container) is therefore a valid recovery for a partial topology.
+
 The mutator emits JSON events on stdout that Alloy ships to Loki:
 `mutator_starting`, `mutation_start`, `link_added`, `link_removed`,
 `link_add_failed`, `link_remove_failed`, `mutation_success`,

--- a/deploy/long-running-test/mutate.sh
+++ b/deploy/long-running-test/mutate.sh
@@ -69,6 +69,41 @@ parse_links() {
     awk -F'|' '{ a=$1; b=$2; if (a < b) print a"|"b; else print b"|"a }' | sort -u
 }
 
+# True if interface $2 exists inside base node $1 (e.g. node_iface_exists leaf1 eth1).
+node_iface_exists() {
+  docker exec "clab-$LAB_NAME-$1" ip link show "$2" >/dev/null 2>&1
+}
+
+# Ensure one veth link exists, creating it if absent. Idempotent and
+# self-healing: this is the core reliability guarantee. A veth create that
+# fails transiently, or a veth lost out-of-band, must never leave a desired
+# link permanently missing (a partial topology with no alertable signal).
+# Endpoints are "node:iface" strings. Returns 0 if present/created, 1 if not.
+ensure_link() {
+  local a="$1" z="$2"
+  local an="${a%%:*}" ai="${a#*:}" zn="${z%%:*}" zi="${z#*:}"
+  local a_ok=1 z_ok=1
+  node_iface_exists "$an" "$ai" || a_ok=0
+  node_iface_exists "$zn" "$zi" || z_ok=0
+  if [ "$a_ok" = 1 ] && [ "$z_ok" = 1 ]; then
+    return 0   # both ends present — link already up
+  fi
+  # Half-broken pair (one end survived a partial create/teardown): remove the
+  # dangling end so veth create can succeed cleanly.
+  [ "$a_ok" = 1 ] && docker exec "clab-$LAB_NAME-$an" ip link del "$ai" >/dev/null 2>&1
+  [ "$z_ok" = 1 ] && docker exec "clab-$LAB_NAME-$zn" ip link del "$zi" >/dev/null 2>&1
+  local attempt
+  for attempt in 1 2 3; do
+    if containerlab tools veth create \
+         --a-endpoint "clab-$LAB_NAME-$a" \
+         --b-endpoint "clab-$LAB_NAME-$z" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
 # Apply one mutation. $1 is the target topology filename (basename).
 apply_topology() {
   local topo="$1"
@@ -88,19 +123,17 @@ apply_topology() {
   local cur_file=""
   [ -n "$prev" ] && cur_file="$TOPODIR/$prev"
 
-  local cur des add del keep
+  local cur des del
   cur=$(parse_links "$cur_file")
   des=$(parse_links "$file")
-  add=$(comm -13 <(printf '%s\n' "$cur") <(printf '%s\n' "$des"))
+  # Links the previous topology had that the target does not want.
   del=$(comm -23 <(printf '%s\n' "$cur") <(printf '%s\n' "$des"))
-  keep=$(comm -12 <(printf '%s\n' "$cur") <(printf '%s\n' "$des"))
 
-  local n_add n_del n_keep
-  n_add=$(printf '%s' "$add" | grep -c .)
+  local n_del n_des
   n_del=$(printf '%s' "$del" | grep -c .)
-  n_keep=$(printf '%s' "$keep" | grep -c .)
+  n_des=$(printf '%s' "$des" | grep -c .)
 
-  # Delete first so freed eth slots are available for reuse on add.
+  # Delete unwanted links first so freed eth slots are available for reuse.
   while IFS= read -r link; do
     [ -z "$link" ] && continue
     local left right node iface
@@ -113,26 +146,39 @@ apply_topology() {
     fi
   done <<< "$del"
 
-  local add_failures=0
+  # Ensure EVERY desired link exists — not just the diff 'add' set. This is the
+  # self-healing fix: a link that previously failed to attach or was lost
+  # out-of-band used to sit in the 'keep' set and was never recreated, leaving a
+  # permanent partial topology (e.g. a star missing one spoke) with no alertable
+  # signal. We now verify each desired link and (re)create any that are missing,
+  # with retries, every pass — so a transient veth failure self-corrects on the
+  # next apply (and a same-topology re-apply is a valid recovery).
+  local ensure_failures=0 n_created=0
   while IFS= read -r link; do
     [ -z "$link" ] && continue
     local a z
     a="${link%%|*}"; z="${link#*|}"
-    if containerlab tools veth create --a-endpoint "clab-$LAB_NAME-$a" --b-endpoint "clab-$LAB_NAME-$z" >/dev/null 2>&1; then
+    if node_iface_exists "${a%%:*}" "${a#*:}" && node_iface_exists "${z%%:*}" "${z#*:}"; then
+      continue   # both ends already present
+    fi
+    if ensure_link "$a" "$z"; then
       emit link_added "a=$a" "z=$z"
+      n_created=$((n_created + 1))
     else
       emit link_add_failed "a=$a" "z=$z"
-      add_failures=$((add_failures + 1))
+      ensure_failures=$((ensure_failures + 1))
     fi
-  done <<< "$add"
+  done <<< "$des"
 
   local dt=$(( $(date +%s) - t0 ))
-  if [ "$add_failures" -eq 0 ]; then
-    # Record success in the state file so the next mutation diffs from here.
+  if [ "$ensure_failures" -eq 0 ]; then
+    # Record success so the next mutation diffs removals from here. Because we
+    # ensure all desired links every pass, re-applying the same topology now
+    # also self-corrects any missing link.
     printf '%s\n' "$topo" > "$STATE_FILE"
-    emit mutation_success "topo=$topo" "prev=$prev" "duration_s=!$dt" "links_added=!$n_add" "links_removed=!$n_del" "links_kept=!$n_keep"
+    emit mutation_success "topo=$topo" "prev=$prev" "duration_s=!$dt" "links_desired=!$n_des" "links_created=!$n_created" "links_removed=!$n_del"
   else
-    emit mutation_failed "topo=$topo" "phase=apply" "duration_s=!$dt" "add_failures=!$add_failures"
+    emit mutation_failed "topo=$topo" "phase=apply" "duration_s=!$dt" "ensure_failures=!$ensure_failures" "links_created=!$n_created"
     return 1
   fi
 }


### PR DESCRIPTION
## Symptom
The Grafana Cloud long-running lab's **star** topology rendered with `leaf1` disconnected (3 of 4 spokes present; `spine1↔leaf1` missing). The other topologies/links were fine.

## Root cause (not the exporter, not the dashboard)
The exporter image is unchanged and the dashboard correctly drew the 3 real edges — the **`spine1↔leaf1` edge genuinely didn't exist** because the link was never created. `mutate.sh` reconciled links by *name*: it diffed the target topology against the last-applied topology and created only the `add` set, assuming every `keep` link already existed. So a single transient `containerlab tools veth create` failure (or a veth lost out-of-band) left that link **permanently missing** — and because it sat in `keep`, even re-applying the same topology never recreated it. (The same flaw would empty the whole topology after a base `containerlab deploy --reconfigure`, which wipes all veths while `.last-topo` still names a topology.)

## Fix
`apply_topology` now **ensures every desired link exists on each pass** instead of trusting the diff:
- new `ensure_link` helper: checks both endpoint interfaces; if a link is missing it (re)creates it with **3 retries**, and repairs a **half-broken** veth pair by clearing the surviving end first;
- healthy links are left untouched (no churn);
- removal of unwanted links stays diff-based.

Net: a transient veth failure self-corrects on the next apply, and **restarting the mutator is now a valid recovery** for a partial topology.

Validated with a mock harness (docker/containerlab stubbed) across present / both-missing / half-broken endpoints and the exact live partial-star scenario — only the missing `leaf1↔spine1` link is recreated, the 3 healthy links untouched. `bash -n` clean. Emit event names unchanged (Loki queries unaffected).

## Recovery for the running lab (operator action — I can't reach your host)
Least-disruptive (no full rebuild):
```bash
cd deploy/long-running-test
rsync -avz --exclude deploy.sh --exclude 'id_ed25519*' --exclude .env . ansible@<lab-host>:/home/ansible/long-running-test/
ssh ansible@<lab-host> 'docker restart long-running-mutator'
```
The mutator re-applies the current hour's topology with the new ensure logic, recreating the missing spoke; the edge returns in Grafana within ~1 discovery cycle. (Or run `./deploy.sh` for a full refresh.)