### PR TITLE
Self-hosted vJunos-router capture lab for Juniper BGP4-V2 validation (#56)

### DIFF
--- a/lab/juniper-jnxbgp/README.md
+++ b/lab/juniper-jnxbgp/README.md
@@ -1,5 +1,92 @@
 # Lab — juniper-jnxbgp
 
+Validates the `vendor_juniper` BGP4-V2 walker (`jnxBgpM2PeerTable`,
+`1.3.6.1.4.1.2636.5.1.1.2.1.1`) against a real Junos SNMP stack — closing
+issue #56. Two ways to produce the capture:
+
+- **Option A — self-hosted vJunos-router lab (below).** Run a containerlab
+  topology with a free vJunos-router image on an x86-64 + KVM host. Fully
+  reproducible, no third party needed. **Preferred.**
+- **Option B — colleague capture from existing hardware (further down).** If
+  someone already has a Junos box, they paste an SNMP config and run a script.
+
+Either way the goal is one file: `captures/r1_juniper_jnxBgpM2PeerTable.txt`,
+an `snmpwalk` of the peer table with at least one established IPv4 **and** one
+IPv6 peer.
+
+---
+
+## Option A — self-hosted vJunos-router lab (containerlab)
+
+Files: `topology.clab.yml`, `configs/r1.conf` (vJunos), `configs/frr.conf` +
+`configs/daemons` (the FRR peer), `capture.sh`.
+
+Topology: one **vJunos-router** (`r1`, AS 65001 — the device under capture)
+eBGP-peered with one lightweight **FRR** speaker (`p1`, AS 65002) over a
+dual-stack link, giving `r1` an IPv4 *and* an IPv6 established peer (both
+address-family index cases). Only `r1` is real Junos; the peer is FRR so the
+whole thing fits on a modest host.
+
+### Prerequisites
+- **x86-64 host with KVM** (the long-running-test host works; **not** an arm
+  Mac). ~5 GB RAM free for one vJunos + FRR.
+- `containerlab`, `docker`, `snmpwalk` (net-snmp), and the free
+  **vJunos-router qcow2** from Juniper (no paid license needed).
+
+### 1. Build the vJunos-router container image (one-time)
+vJunos runs as a KVM VM wrapped by [vrnetlab](https://github.com/hellt/vrnetlab):
+```bash
+git clone https://github.com/hellt/vrnetlab && cd vrnetlab/juniper/vjunosrouter
+cp /path/to/vJunos-router-25.4R1.12.qcow2 .     # rename the .dms download to .qcow2
+make                                            # builds vrnetlab/juniper_vjunos-router:25.4R1.12
+```
+Match the image tag in `topology.clab.yml` (`kinds.juniper_vjunosrouter.image`)
+to whatever `make` produced (`docker images | grep vjunos`).
+
+### 2. Deploy
+```bash
+sudo containerlab deploy -t topology.clab.yml
+```
+vJunos boots slowly — give it **~5 minutes**. (`docker logs clab-juniper-jnxbgp-r1`
+shows boot progress.)
+
+### 3. Confirm both BGP sessions are Established
+```bash
+sudo containerlab exec --name juniper-jnxbgp --label clab-node-name=r1 \
+  --cmd "cli show bgp summary"        # expect 2 peers (10.0.0.2 and 2001:db8:1::2) Establ
+docker exec clab-juniper-jnxbgp-p1 vtysh -c "show bgp summary"
+```
+If a peer is stuck, give it another minute (vJunos is slow to settle). The
+capture only needs the sessions Established — no routes.
+
+### 4. Capture
+```bash
+./capture.sh
+```
+Writes `captures/r1_juniper_jnxBgpM2PeerTable.txt` (plus the system group, the
+RFC 4273 fallback table, and the route table for context). Private lab
+addresses, so no redaction needed.
+
+### 5. Hand it back
+Commit `captures/r1_juniper_jnxBgpM2PeerTable.txt` (and siblings) — that's the
+fixture. From there the walker's `colState` / `colRemoteAs` / index decoder get
+verified against the real columns and `verified: true` is set in
+`bgp_vendor.go`, closing #56 and unblocking #59.
+
+### Teardown
+```bash
+sudo containerlab destroy -t topology.clab.yml --cleanup
+```
+
+### Notes
+- `r1:eth1` (containerlab) maps to `ge-0/0/0` (Junos) — see `configs/r1.conf`.
+- The `juniper_vjunosrouter` kind sets up `fxp0` management + base credentials
+  automatically; `configs/r1.conf` only adds the lab config.
+
+---
+
+## Option B — colleague capture from a real device
+
 Thanks for running this. We can't validate our Juniper BGP MIB walker
 without a real Junos device, so your snmpwalk against a live router is
 what gets this code out of "experimental" status.

--- a/lab/juniper-jnxbgp/capture.sh
+++ b/lab/juniper-jnxbgp/capture.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# capture.sh — drive snmpwalk against the juniper-jnxbgp vJunos-router lab and
+# save raw output per OID root under ./captures/, named to match the fixture
+# convention (r1_juniper_<label>.txt) so the jnxBgpM2PeerTable capture lands
+# exactly where issue #56 expects it.
+#
+# Inputs:
+#   - A running `containerlab deploy -t ./topology.clab.yml` on an x86-64+KVM
+#     host, with r1 (vJunos-router) booted and both BGP sessions Established.
+#   - snmpwalk (net-snmp).
+#
+# Outputs:
+#   captures/r1_juniper_<label>.txt — one file per OID root, numeric form
+#   (-On -Oe) so the values paste cleanly into []gsnmp.SnmpPDU test literals.
+#
+# Exit code is 0 even if individual walks come back empty — a "No Such Object"
+# is itself useful evidence (the device doesn't implement that MIB).
+set -o pipefail
+
+HOST="${R1_HOST:-172.20.20.21}"          # r1 mgmt-ipv4 from topology.clab.yml
+COMMUNITY="${SNMP_COMMUNITY:-public}"
+NODE="r1"
+OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/captures"
+
+# OID root | filename label. Comments note which walker each feeds in
+# internal/discovery/bgp/.
+OIDS=(
+  "1.3.6.1.2.1.1|sys_group"                      # sysDescr + sysObjectID — vendor detection (expect .1.3.6.1.4.1.2636.x)
+  "1.3.6.1.2.1.15.3|rfc4273_bgpPeerTable"        # RFC 4273 IPv4 baseline — walker: rfc4273 (fallback)
+  "1.3.6.1.4.1.2636.5.1.1.2.1.1|jnxBgpM2PeerTable" # THE TARGET — walker: vendor_juniper (#56). Verifies colState/colRemoteAs/index decoder.
+  "1.3.6.1.4.1.2636.5.1.1.2.6|jnxBgpM2RouteTable"  # adjacent table — captured for evidence/context
+)
+
+if ! command -v snmpwalk >/dev/null 2>&1; then
+  echo "ERROR: snmpwalk not found (net-snmp). Linux: apt-get install snmp; macOS: brew install net-snmp" >&2
+  exit 2
+fi
+mkdir -p "$OUTDIR"
+
+# Best-effort: record the device sysObjectID/sysDescr in the headers.
+sysoid=$(snmpget -v2c -c "$COMMUNITY" -On -Oqv "$HOST" 1.3.6.1.2.1.1.2.0 2>/dev/null | tr -d '"')
+sysdescr=$(snmpget -v2c -c "$COMMUNITY" -Oqv "$HOST" 1.3.6.1.2.1.1.1.0 2>/dev/null | tr -d '"' | head -c 120)
+
+echo "--- node ${NODE} (${HOST}) ---  sysObjectID=${sysoid:-?}"
+for entry in "${OIDS[@]}"; do
+  oid="${entry%%|*}"; label="${entry#*|}"
+  out="${OUTDIR}/${NODE}_juniper_${label}.txt"
+  {
+    echo "# captured $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "# device: vJunos-router, node=${NODE}, host=${HOST}"
+    echo "# sysDescr: ${sysdescr:-?}"
+    echo "# sysObjectID: ${sysoid:-?}"
+    echo "# oid root: ${oid} (${label})"
+    echo
+    snmpwalk -v2c -c "${COMMUNITY}" -On -Oe "${HOST}" "${oid}" 2>&1
+  } > "${out}"
+  if grep -qiE "No Such Object|No Such Instance|Timeout|No Response" "${out}"; then
+    echo "  ${label}: empty/error → ${out#"$(dirname "$0")"/}"
+  else
+    echo "  ${label}: $(grep -c '=' "${out}") rows → ${out#"$(dirname "$0")"/}"
+  fi
+done
+
+echo
+echo "Captures in ${OUTDIR}/"
+echo "Key file for #56: ${OUTDIR}/${NODE}_juniper_jnxBgpM2PeerTable.txt"
+echo "These are private/doc lab addresses (RFC 1918 10.0.0.x / RFC 3849 2001:db8::), so no"
+echo "redaction is required — but you can run scripts/redact-snmp-capture.py"
+echo "if you prefer. Hand the file back and the walker spec gets verified."

--- a/lab/juniper-jnxbgp/configs/daemons
+++ b/lab/juniper-jnxbgp/configs/daemons
@@ -1,0 +1,23 @@
+# FRR daemons for the p1 BGP peer. Only zebra (RIB/kernel) and bgpd are needed.
+zebra=yes
+bgpd=yes
+ospfd=no
+ospf6d=no
+ripd=no
+ripngd=no
+isisd=no
+pimd=no
+ldpd=no
+nhrpd=no
+eigrpd=no
+babeld=no
+sharpd=no
+pbrd=no
+bfdd=no
+fabricd=no
+vrrpd=no
+pathd=no
+
+vtysh_enable=yes
+zebra_options="  -A 127.0.0.1 -s 90000000"
+bgpd_options="   -A 127.0.0.1"

--- a/lab/juniper-jnxbgp/configs/frr.conf
+++ b/lab/juniper-jnxbgp/configs/frr.conf
@@ -1,0 +1,22 @@
+! FRR peer p1 (AS 65002) — eBGP partner for the vJunos-router under capture.
+! Interface addresses are set in the kernel by containerlab `exec` (see
+! topology.clab.yml); this file carries only the BGP config. Two sessions to
+! r1 (AS 65001): IPv4 over 10.0.0.1, IPv6 over 2001:db8:1::1. No policy needed
+! — the sessions just need to reach Established so r1's jnxBgpM2PeerTable
+! populates with one v4 and one v6 peer row.
+frr defaults traditional
+hostname p1
+!
+router bgp 65002
+ bgp router-id 2.2.2.2
+ neighbor 10.0.0.1 remote-as 65001
+ neighbor 2001:db8:1::1 remote-as 65001
+ !
+ address-family ipv4 unicast
+  neighbor 10.0.0.1 activate
+ exit-address-family
+ !
+ address-family ipv6 unicast
+  neighbor 2001:db8:1::1 activate
+ exit-address-family
+!

--- a/lab/juniper-jnxbgp/configs/r1.conf
+++ b/lab/juniper-jnxbgp/configs/r1.conf
@@ -1,0 +1,40 @@
+## vJunos-router — node r1 (AS 65001), device under SNMP capture for issue #56.
+##
+## Junos set-format startup config. containerlab's juniper_vjunosrouter kind
+## applies base management (fxp0) + default credentials automatically and
+## merges this on top, so only the lab-relevant config is here.
+##
+## r1:eth1 (containerlab) == ge-0/0/0 (Junos). Two eBGP sessions to the FRR
+## peer p1 (AS 65002): one IPv4, one IPv6 — both reach Established with no
+## export policy needed (the capture only needs jnxBgpM2PeerState=established
+## rows, not exchanged routes).
+
+set system host-name r1
+
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/30
+set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8:1::1/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+
+set routing-options autonomous-system 65001
+set routing-options router-id 1.1.1.1
+
+## IPv4 eBGP session
+set protocols bgp group ebgp-v4 type external
+set protocols bgp group ebgp-v4 peer-as 65002
+set protocols bgp group ebgp-v4 neighbor 10.0.0.2
+
+## IPv6 eBGP session (separate group; inet6 family must be explicit)
+set protocols bgp group ebgp-v6 type external
+set protocols bgp group ebgp-v6 peer-as 65002
+set protocols bgp group ebgp-v6 family inet6 unicast
+set protocols bgp group ebgp-v6 neighbor 2001:db8:1::2
+
+## SNMP v2c read-only. The view must include the Juniper enterprise subtree
+## (2636) or jnxBgpM2PeerTable returns empty; mib-2 (1.3.6.1.2.1) covers the
+## system group + RFC 4273 fallback table the capture also grabs.
+set snmp view all-mibs oid 1.3.6.1.4.1.2636 include
+set snmp view all-mibs oid 1.3.6.1.2.1 include
+set snmp community public authorization read-only
+set snmp community public view all-mibs
+set snmp location lab-juniper-jnxbgp
+set snmp contact issue#56-fixture-capture

--- a/lab/juniper-jnxbgp/topology.clab.yml
+++ b/lab/juniper-jnxbgp/topology.clab.yml
@@ -1,0 +1,51 @@
+# vJunos-router BGP lab for BGP4-V2 (jnxBgpM2PeerTable) fixture capture — issue #56.
+#
+# Purpose: drive snmpwalk against jnxBgpM2PeerTable (1.3.6.1.4.1.2636.5.1.1.2.1.1)
+# on a real Junos SNMP stack so the column numbers + index decoder in the
+# vendor_juniper walker (internal/discovery/bgp/bgp_vendor.go, currently
+# verified:false) are validated against actual device output rather than
+# transcribed-from-docs guesses.
+#
+# Shape: one vJunos-router (the device under capture) eBGP-peered with one
+# lightweight FRR speaker over a dual-stack link. r1 ends up with TWO
+# established peers — one IPv4, one IPv6 — so the capture exercises both
+# address-family index cases the decoder must handle. Only r1 needs to be
+# real Junos; the peer can be anything that reaches Established, hence FRR
+# (tens of MB) instead of a second vJunos.
+#
+# Image: built from the vJunos-router qcow2 via hellt/vrnetlab
+# (network-topology-exporter-resources/vJunos-router-25.4R1.12.qcow2).
+# Match the tag below to whatever `make` produced (see README.md).
+#
+# x86-64 + KVM host only (the long-running-test host, not an arm Mac).
+name: juniper-jnxbgp
+
+topology:
+  kinds:
+    juniper_vjunosrouter:
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+    linux:
+      image: quay.io/frrouting/frr:10.2.1
+
+  nodes:
+    r1:
+      kind: juniper_vjunosrouter
+      startup-config: configs/r1.conf
+      mgmt-ipv4: 172.20.20.21
+
+    p1:
+      kind: linux
+      mgmt-ipv4: 172.20.20.22
+      binds:
+        - configs/frr.conf:/etc/frr/frr.conf
+        - configs/daemons:/etc/frr/daemons
+      # Pin the data-link addresses in the kernel so the BGP sessions don't
+      # depend on zebra timing; frr.conf only carries the BGP config.
+      exec:
+        - ip addr add 10.0.0.2/30 dev eth1
+        - ip -6 addr add 2001:db8:1::2/64 dev eth1
+        - ip link set eth1 up
+
+  links:
+    # r1:eth1 maps to ge-0/0/0 inside vJunos (see configs/r1.conf).
+    - endpoints: ["r1:eth1", "p1:eth1"]


### PR DESCRIPTION
Adds a reproducible containerlab capture lab so the `vendor_juniper` walker (`jnxBgpM2PeerTable`, `verified: false` in `bgp_vendor.go`) can be validated against a **real Junos SNMP stack** — no colleague hardware needed. Mirrors the existing `lab/cisco-iol-bgp/` pattern.

## Topology
- **r1** — `vJunos-router` (AS 65001), the device under capture (free image; no paid license).
- **p1** — FRR (AS 65002), a featherweight eBGP peer.
- Dual-stack link → r1 gets **one IPv4 and one IPv6 established peer**, exercising both address-family index cases the decoder must handle. Only r1 is real Junos, so it fits on the existing x86-64+KVM lab host (~5 GB).

## Files
`topology.clab.yml`, `configs/r1.conf` (vJunos SNMP+BGP), `configs/frr.conf` + `configs/daemons` (peer), `capture.sh`, and a restructured README (Option A = this lab, Option B = the prior colleague-capture flow).

## How it's used (on the KVM host)
1. Build the image: `vrnetlab` `make` on the `vJunos-router-25.4R1.12.qcow2` → `vrnetlab/juniper_vjunos-router:25.4R1.12`.
2. `sudo containerlab deploy -t topology.clab.yml` (vJunos boots ~5 min).
3. Confirm 2 peers Established.
4. `./capture.sh` → `captures/r1_juniper_jnxBgpM2PeerTable.txt`.

## Scope
This PR is the **lab infrastructure**. #56 closes when the capture is actually produced on the host and the walker's `colState`/`colRemoteAs`/index decoder are verified against it (then `verified: true`). Validated here: YAML parses, `capture.sh` is `bash -n` + shellcheck clean, `go build` unaffected.

Toward #56; unblocks #59 (capture-loader refactor).