### PR TITLE
Fix juniper-jnxbgp lab: BGP link collided with vrnetlab vJunos mgmt subnet + SNMP mgmt-instance

### DIFF
--- a/lab/juniper-jnxbgp/README.md
+++ b/lab/juniper-jnxbgp/README.md
@@ -51,13 +51,21 @@ vJunos boots slowly — give it **~5 minutes**. (`docker logs clab-juniper-jnxbg
 shows boot progress.)
 
 ### 3. Confirm both BGP sessions are Established
+The FRR side is the easy check (no Junos login needed) — both peers should leave
+`Active` and show an uptime:
 ```bash
-sudo containerlab exec --name juniper-jnxbgp --label clab-node-name=r1 \
-  --cmd "cli show bgp summary"        # expect 2 peers (10.0.0.2 and 2001:db8:1::2) Establ
 docker exec clab-juniper-jnxbgp-p1 vtysh -c "show bgp summary"
+# expect 192.0.2.1 (v4) and 2001:db8:1::1 (v6) Established
 ```
-If a peer is stuck, give it another minute (vJunos is slow to settle). The
-capture only needs the sessions Established — no routes.
+To check from Junos, SSH into the VM (vrnetlab default `admin` / `admin@123`;
+containerlab `exec` runs in the *container*, not the Junos CLI, so use SSH):
+```bash
+ssh admin@172.20.20.21 "show bgp summary"
+```
+If a peer is stuck in `Active`, give it another minute (vJunos is slow to
+settle) and confirm the link subnet is `192.0.2.0/30` — **not** `10.0.0.0/24`,
+which collides with vJunos's internal `fxp0` management network. The capture
+only needs the sessions Established — no routes.
 
 ### 4. Capture
 ```bash

--- a/lab/juniper-jnxbgp/capture.sh
+++ b/lab/juniper-jnxbgp/capture.sh
@@ -65,6 +65,6 @@ done
 echo
 echo "Captures in ${OUTDIR}/"
 echo "Key file for #56: ${OUTDIR}/${NODE}_juniper_jnxBgpM2PeerTable.txt"
-echo "These are private/doc lab addresses (RFC 1918 10.0.0.x / RFC 3849 2001:db8::), so no"
+echo "These are documentation lab addresses (RFC 5737 192.0.2.x / RFC 3849 2001:db8::), so no"
 echo "redaction is required — but you can run scripts/redact-snmp-capture.py"
 echo "if you prefer. Hand the file back and the walker spec gets verified."

--- a/lab/juniper-jnxbgp/configs/frr.conf
+++ b/lab/juniper-jnxbgp/configs/frr.conf
@@ -1,7 +1,7 @@
 ! FRR peer p1 (AS 65002) — eBGP partner for the vJunos-router under capture.
 ! Interface addresses are set in the kernel by containerlab `exec` (see
 ! topology.clab.yml); this file carries only the BGP config. Two sessions to
-! r1 (AS 65001): IPv4 over 10.0.0.1, IPv6 over 2001:db8:1::1. No policy needed
+! r1 (AS 65001): IPv4 over 192.0.2.1, IPv6 over 2001:db8:1::1. No policy needed
 ! — the sessions just need to reach Established so r1's jnxBgpM2PeerTable
 ! populates with one v4 and one v6 peer row.
 frr defaults traditional
@@ -9,11 +9,11 @@ hostname p1
 !
 router bgp 65002
  bgp router-id 2.2.2.2
- neighbor 10.0.0.1 remote-as 65001
+ neighbor 192.0.2.1 remote-as 65001
  neighbor 2001:db8:1::1 remote-as 65001
  !
  address-family ipv4 unicast
-  neighbor 10.0.0.1 activate
+  neighbor 192.0.2.1 activate
  exit-address-family
  !
  address-family ipv6 unicast

--- a/lab/juniper-jnxbgp/configs/r1.conf
+++ b/lab/juniper-jnxbgp/configs/r1.conf
@@ -11,7 +11,7 @@
 
 set system host-name r1
 
-set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/30
+set interfaces ge-0/0/0 unit 0 family inet address 192.0.2.1/30
 set interfaces ge-0/0/0 unit 0 family inet6 address 2001:db8:1::1/64
 set interfaces lo0 unit 0 family inet address 1.1.1.1/32
 
@@ -21,7 +21,7 @@ set routing-options router-id 1.1.1.1
 ## IPv4 eBGP session
 set protocols bgp group ebgp-v4 type external
 set protocols bgp group ebgp-v4 peer-as 65002
-set protocols bgp group ebgp-v4 neighbor 10.0.0.2
+set protocols bgp group ebgp-v4 neighbor 192.0.2.2
 
 ## IPv6 eBGP session (separate group; inet6 family must be explicit)
 set protocols bgp group ebgp-v6 type external
@@ -38,3 +38,7 @@ set snmp community public authorization read-only
 set snmp community public view all-mibs
 set snmp location lab-juniper-jnxbgp
 set snmp contact issue#56-fixture-capture
+## vJunos puts fxp0 in the dedicated `mgmt_junos` management instance
+## (`management-instance` in the base config), so SNMP queries arriving on the
+## management IP are only answered when SNMP is permitted over that instance.
+set snmp routing-instance-access

--- a/lab/juniper-jnxbgp/topology.clab.yml
+++ b/lab/juniper-jnxbgp/topology.clab.yml
@@ -41,8 +41,11 @@ topology:
         - configs/daemons:/etc/frr/daemons
       # Pin the data-link addresses in the kernel so the BGP sessions don't
       # depend on zebra timing; frr.conf only carries the BGP config.
+      # NB: the BGP link uses 192.0.2.0/30 (RFC 5737), NOT 10.0.0.0/24 — that
+      # subnet is vrnetlab's internal vJunos management network (fxp0=10.0.0.15)
+      # and overlapping it breaks the data-plane sessions.
       exec:
-        - ip addr add 10.0.0.2/30 dev eth1
+        - ip addr add 192.0.2.2/30 dev eth1
         - ip -6 addr add 2001:db8:1::2/64 dev eth1
         - ip link set eth1 up
 


### PR DESCRIPTION
Found by actually running the lab on the KVM host. Two bugs:

1. **Subnet collision.** The BGP data link used `10.0.0.0/30`, but that overlaps vrnetlab's internal vJunos management network (`fxp0 = 10.0.0.15/24`, internal gateway `10.0.0.2`). r1's `ge-0/0/0` address conflicted with mgmt, so both eBGP sessions stuck in `Active`. Moved the IPv4 link to **RFC 5737 `192.0.2.0/30`** (r1 `.1`, FRR `.2`); IPv6 (`2001:db8:1::/64`) was fine.
2. **SNMP unreachable.** vJunos base config sets `management-instance` (fxp0 in `mgmt_junos`), so SNMP on the mgmt IP timed out. Added **`set snmp routing-instance-access`** so snmpd answers over the management instance.

Also fixed the README verify step (containerlab `exec` runs in the *container*, not the Junos CLI — use `ssh admin@<mgmt>` or check the FRR side).

Validated: clab YAML parses, `capture.sh` shellcheck-clean. Currently being verified live on the lab host (redeploy + capture).