### PR TITLE
Juniper lab: data-plane capture + factory-default fallback (doc/script accuracy)

### DIFF
--- a/lab/juniper-jnxbgp/README.md
+++ b/lab/juniper-jnxbgp/README.md
@@ -50,30 +50,45 @@ sudo containerlab deploy -t topology.clab.yml
 vJunos boots slowly — give it **~5 minutes**. (`docker logs clab-juniper-jnxbgp-r1`
 shows boot progress.)
 
+### 2a. If r1 boots unconfigured (factory default)
+On some vJunos-router builds (observed on **25.4R1.12**) vrnetlab does **not**
+consume the containerlab config drive — r1 comes up at factory default (you'll
+see "Auto Image Upgrade: ... NO VALID CONFIG" in `docker logs`, and the
+`admin`/`admin@123` login is rejected). If so, configure it once at the serial
+console:
+```bash
+sudo docker exec -it clab-juniper-jnxbgp-r1 telnet localhost 5000   # login: root  (no password)
+```
+Then in the Junos CLI (`cli` → `configure`), set a root password
+(`set system root-authentication plain-text-password`, prompts) and paste the
+`set` lines from [`configs/r1.conf`](configs/r1.conf) (ge-0/0/0 = the only
+`up/up` data port; confirm with `show interfaces terse | match ge-`), then
+`commit`. This is a one-time, in-memory config — it does the same thing the
+config drive would have.
+
 ### 3. Confirm both BGP sessions are Established
-The FRR side is the easy check (no Junos login needed) — both peers should leave
+Check from the FRR peer (no Junos login needed) — both peers should leave
 `Active` and show an uptime:
 ```bash
 docker exec clab-juniper-jnxbgp-p1 vtysh -c "show bgp summary"
 # expect 192.0.2.1 (v4) and 2001:db8:1::1 (v6) Established
 ```
-To check from Junos, SSH into the VM (vrnetlab default `admin` / `admin@123`;
-containerlab `exec` runs in the *container*, not the Junos CLI, so use SSH):
-```bash
-ssh admin@172.20.20.21 "show bgp summary"
-```
-If a peer is stuck in `Active`, give it another minute (vJunos is slow to
-settle) and confirm the link subnet is `192.0.2.0/30` — **not** `10.0.0.0/24`,
-which collides with vJunos's internal `fxp0` management network. The capture
-only needs the sessions Established — no routes.
+If stuck in `Active`, give it a minute (vJunos is slow) and confirm the link
+subnet is `192.0.2.0/30` — **not** `10.0.0.0/24`, which collides with vJunos's
+internal `fxp0` management network. The capture only needs the sessions
+Established — no routes.
 
 ### 4. Capture
 ```bash
 ./capture.sh
 ```
-Writes `captures/r1_juniper_jnxBgpM2PeerTable.txt` (plus the system group, the
-RFC 4273 fallback table, and the route table for context). Private lab
-addresses, so no redaction needed.
+`capture.sh` runs `snmpwalk` **from the FRR peer (p1) against r1's data-plane
+address `192.0.2.1`** — not the lab management IP. vrnetlab fronts `fxp0` with a
+NAT that does not forward UDP 161, so SNMP to the management IP times out; the
+data-plane path is also how a real exporter would reach the device. It writes
+`captures/r1_juniper_jnxBgpM2PeerTable.txt` (plus the system group, the RFC 4273
+fallback table, and the route table for context). Documentation-range addresses,
+so no redaction needed.
 
 ### 5. Hand it back
 Commit `captures/r1_juniper_jnxBgpM2PeerTable.txt` (and siblings) — that's the

--- a/lab/juniper-jnxbgp/capture.sh
+++ b/lab/juniper-jnxbgp/capture.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env bash
 #
-# capture.sh — drive snmpwalk against the juniper-jnxbgp vJunos-router lab and
-# save raw output per OID root under ./captures/, named to match the fixture
-# convention (r1_juniper_<label>.txt) so the jnxBgpM2PeerTable capture lands
-# exactly where issue #56 expects it.
+# capture.sh — capture jnxBgpM2PeerTable (+ context OIDs) from the vJunos-router
+# in the juniper-jnxbgp lab and save them under ./captures/ as the #56 fixture,
+# named r1_juniper_<label>.txt (numeric -On -Oe form, paste-ready for tests).
 #
-# Inputs:
-#   - A running `containerlab deploy -t ./topology.clab.yml` on an x86-64+KVM
-#     host, with r1 (vJunos-router) booted and both BGP sessions Established.
-#   - snmpwalk (net-snmp).
+# WHY THE CAPTURE RUNS FROM THE FRR PEER, NOT THE HOST:
+#   vrnetlab fronts vJunos's fxp0 management interface with a container-level
+#   NAT that does not forward UDP 161, so SNMP to the lab management IP just
+#   times out. A real exporter queries a device over the network it is attached
+#   to — so we do the same: snmpwalk runs from the directly-attached FRR peer
+#   (p1) against r1's data-plane address (ge-0/0/0, 192.0.2.1), where Junos
+#   snmpd answers in the default routing instance.
 #
-# Outputs:
-#   captures/r1_juniper_<label>.txt — one file per OID root, numeric form
-#   (-On -Oe) so the values paste cleanly into []gsnmp.SnmpPDU test literals.
+# Prereqs (run on the lab host; needs docker):
+#   - `containerlab deploy -t topology.clab.yml` is up.
+#   - r1 is CONFIGURED. NB: on some vJunos-router builds the containerlab config
+#     drive is not consumed and r1 boots to factory default — see README.md
+#     "If r1 boots unconfigured" for the one-time console config.
+#   - both eBGP sessions are Established (check: docker exec p1 vtysh -c "show bgp summary").
 #
 # Exit code is 0 even if individual walks come back empty — a "No Such Object"
 # is itself useful evidence (the device doesn't implement that MIB).
 set -o pipefail
 
-HOST="${R1_HOST:-172.20.20.21}"          # r1 mgmt-ipv4 from topology.clab.yml
+PEER="${PEER_CONTAINER:-clab-juniper-jnxbgp-p1}"   # directly-attached SNMP client (FRR)
+TARGET="${R1_DATA_IP:-192.0.2.1}"                  # r1 ge-0/0/0 (data plane)
 COMMUNITY="${SNMP_COMMUNITY:-public}"
 NODE="r1"
 OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/captures"
@@ -26,45 +32,47 @@ OUTDIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/captures"
 # OID root | filename label. Comments note which walker each feeds in
 # internal/discovery/bgp/.
 OIDS=(
-  "1.3.6.1.2.1.1|sys_group"                      # sysDescr + sysObjectID — vendor detection (expect .1.3.6.1.4.1.2636.x)
-  "1.3.6.1.2.1.15.3|rfc4273_bgpPeerTable"        # RFC 4273 IPv4 baseline — walker: rfc4273 (fallback)
+  "1.3.6.1.2.1.1|sys_group"                        # sysDescr + sysObjectID — vendor detection (expect .1.3.6.1.4.1.2636.x)
+  "1.3.6.1.2.1.15.3|rfc4273_bgpPeerTable"          # RFC 4273 IPv4 baseline — walker: rfc4273 (fallback)
   "1.3.6.1.4.1.2636.5.1.1.2.1.1|jnxBgpM2PeerTable" # THE TARGET — walker: vendor_juniper (#56). Verifies colState/colRemoteAs/index decoder.
-  "1.3.6.1.4.1.2636.5.1.1.2.6|jnxBgpM2RouteTable"  # adjacent table — captured for evidence/context
+  "1.3.6.1.4.1.2636.5.1.1.2.6|jnxBgpM2RouteTable"  # adjacent table — captured for context
 )
 
-if ! command -v snmpwalk >/dev/null 2>&1; then
-  echo "ERROR: snmpwalk not found (net-snmp). Linux: apt-get install snmp; macOS: brew install net-snmp" >&2
+# Ensure net-snmp tools are present in the (alpine) FRR peer container.
+docker exec "$PEER" sh -c 'command -v snmpwalk >/dev/null 2>&1 || apk add --no-cache net-snmp-tools >/dev/null 2>&1' 2>/dev/null
+if ! docker exec "$PEER" sh -c 'command -v snmpwalk >/dev/null 2>&1'; then
+  echo "ERROR: snmpwalk unavailable in ${PEER} (is the lab deployed? is ${PEER} the right container?)" >&2
   exit 2
 fi
 mkdir -p "$OUTDIR"
 
-# Best-effort: record the device sysObjectID/sysDescr in the headers.
-sysoid=$(snmpget -v2c -c "$COMMUNITY" -On -Oqv "$HOST" 1.3.6.1.2.1.1.2.0 2>/dev/null | tr -d '"')
-sysdescr=$(snmpget -v2c -c "$COMMUNITY" -Oqv "$HOST" 1.3.6.1.2.1.1.1.0 2>/dev/null | tr -d '"' | head -c 120)
+snmpq() { docker exec "$PEER" "$@"; }
 
-echo "--- node ${NODE} (${HOST}) ---  sysObjectID=${sysoid:-?}"
+sysoid=$(snmpq snmpget -v2c -c "$COMMUNITY" -On -Oqv -t4 -r2 "$TARGET" 1.3.6.1.2.1.1.2.0 2>/dev/null | tr -d '"\r')
+sysdescr=$(snmpq snmpget -v2c -c "$COMMUNITY" -Oqv -t4 -r2 "$TARGET" 1.3.6.1.2.1.1.1.0 2>/dev/null | tr -d '"\r' | head -c 120)
+
+echo "--- ${NODE} via ${PEER} -> ${TARGET} (data plane) ---  sysObjectID=${sysoid:-?}"
 for entry in "${OIDS[@]}"; do
   oid="${entry%%|*}"; label="${entry#*|}"
   out="${OUTDIR}/${NODE}_juniper_${label}.txt"
   {
     echo "# captured $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    echo "# device: vJunos-router, node=${NODE}, host=${HOST}"
+    echo "# device: vJunos-router, node=${NODE}, queried via peer ${PEER} -> ${TARGET} (data plane)"
     echo "# sysDescr: ${sysdescr:-?}"
     echo "# sysObjectID: ${sysoid:-?}"
     echo "# oid root: ${oid} (${label})"
     echo
-    snmpwalk -v2c -c "${COMMUNITY}" -On -Oe "${HOST}" "${oid}" 2>&1
+    snmpq snmpwalk -v2c -c "${COMMUNITY}" -On -Oe -t4 -r2 "${TARGET}" "${oid}" 2>&1 | tr -d '\r'
   } > "${out}"
   if grep -qiE "No Such Object|No Such Instance|Timeout|No Response" "${out}"; then
-    echo "  ${label}: empty/error → ${out#"$(dirname "$0")"/}"
+    echo "  ${label}: empty/error -> ${out#"$(dirname "$0")"/}"
   else
-    echo "  ${label}: $(grep -c '=' "${out}") rows → ${out#"$(dirname "$0")"/}"
+    echo "  ${label}: $(grep -c '=' "${out}") rows -> ${out#"$(dirname "$0")"/}"
   fi
 done
 
 echo
 echo "Captures in ${OUTDIR}/"
 echo "Key file for #56: ${OUTDIR}/${NODE}_juniper_jnxBgpM2PeerTable.txt"
-echo "These are documentation lab addresses (RFC 5737 192.0.2.x / RFC 3849 2001:db8::), so no"
-echo "redaction is required — but you can run scripts/redact-snmp-capture.py"
-echo "if you prefer. Hand the file back and the walker spec gets verified."
+echo "Addresses are documentation ranges (RFC 5737 192.0.2.x / RFC 3849 2001:db8::),"
+echo "so no redaction is needed; scripts/redact-snmp-capture.py is available if you want it."


### PR DESCRIPTION
Makes the `lab/juniper-jnxbgp/` docs + `capture.sh` match how the lab actually ran when closing #56:

- **`capture.sh`** now snmpwalks from the FRR peer (p1) against r1's data-plane IP `192.0.2.1`, not the management IP — vrnetlab's mgmt NAT doesn't forward UDP 161 (and the data plane is how a real exporter would query the device anyway).
- **README** gains a *"2a. If r1 boots unconfigured"* fallback: on vJunos-router 25.4R1.12 vrnetlab didn't consume the config drive (factory-default/ZTP), so the node is configured once at the serial console.

Docs/lab tooling only — no exporter code change.