### PR TITLE
test(bgp): load BGP4-V2 captures directly instead of transcribed PDUs (#59)

### DIFF
--- a/internal/discovery/bgp/bgp_outcome_test.go
+++ b/internal/discovery/bgp/bgp_outcome_test.go
@@ -192,7 +192,7 @@ func TestWalkerOutcomeRFC4273Edges(t *testing.T) {
 func TestWalkerOutcomeVendorCiscoEdges(t *testing.T) {
 	t.Parallel()
 	fake := &fakeWalkerMetrics{}
-	addr := snmptest.Start(t, "public", buildCiscoCbgpPeer2RealPDUs())
+	addr := snmptest.Start(t, "public", snmptest.LoadCapture(t, ciscoCapture))
 	ip, port := snmptest.ParseAddr(addr)
 
 	p := snmputil.Params{
@@ -222,7 +222,7 @@ func TestWalkerOutcomeVendorCiscoEdges(t *testing.T) {
 func TestWalkerOutcomeVendorAristaEdges(t *testing.T) {
 	t.Parallel()
 	fake := &fakeWalkerMetrics{}
-	addr := snmptest.Start(t, "public", buildAristaBgp4v2RealPDUs())
+	addr := snmptest.Start(t, "public", snmptest.LoadCapture(t, aristaCapture))
 	ip, port := snmptest.ParseAddr(addr)
 
 	p := snmputil.Params{

--- a/internal/discovery/bgp/bgp_v2_test.go
+++ b/internal/discovery/bgp/bgp_v2_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
 )
 
+// Real-device capture files (snmpwalk -On -Oe), loaded directly by the vendor
+// walker integration tests via snmptest.LoadCapture so the tests run against
+// the exact bytes the device emitted rather than transcribed PDU slices (#59).
+// Paths are relative to this package directory (internal/discovery/bgp).
+const (
+	ciscoCapture   = "../../../lab/cisco-iol-bgp/captures/r1_cisco_cbgpPeer2Table.txt"
+	aristaCapture  = "../../../lab/arista-ceos-bgp/captures/r1_arista_bgp4v2.txt"
+	juniperCapture = "../../../lab/juniper-jnxbgp/captures/r1_juniper_jnxBgpM2PeerTable.txt"
+)
+
 // --- index decoder tests -----------------------------------------------
 
 // TestDecodeCiscoCbgpPeer2Index covers the index format used by Cisco's
@@ -127,7 +137,7 @@ func TestDecodeJuniperJnxBgpM2Index(t *testing.T) {
 // that mirrors real cbgpPeer2Table output (column numbers from the
 // real-device captures: state=3, remoteAs=11, peer IP in the index).
 func TestWalkVendorCisco(t *testing.T) {
-	addr := snmptest.Start(t, "public", buildCiscoCbgpPeer2RealPDUs())
+	addr := snmptest.Start(t, "public", snmptest.LoadCapture(t, ciscoCapture))
 	ip, port := snmptest.ParseAddr(addr)
 
 	p := snmputil.Params{
@@ -158,7 +168,7 @@ func TestWalkVendorCisco(t *testing.T) {
 // enterprise-MIB column numbers from real cEOS captures (state=13,
 // remoteAs=10, peer IP in index after peerInstance).
 func TestWalkVendorArista(t *testing.T) {
-	addr := snmptest.Start(t, "public", buildAristaBgp4v2RealPDUs())
+	addr := snmptest.Start(t, "public", snmptest.LoadCapture(t, aristaCapture))
 	ip, port := snmptest.ParseAddr(addr)
 
 	p := snmputil.Params{
@@ -191,7 +201,7 @@ func TestWalkVendorArista(t *testing.T) {
 func TestWalkUseV2MIBDisabledOnlyHitsRFC4273(t *testing.T) {
 	// Serve both: the vendor table has an IPv4 peer; RFC 4273 has the
 	// same peer. With kill-switch off, only the RFC 4273 path fires.
-	pdus := append(buildCiscoCbgpPeer2RealPDUs(), buildBgpAgentPDUs()...)
+	pdus := append(snmptest.LoadCapture(t, ciscoCapture), buildBgpAgentPDUs()...)
 	addr := snmptest.Start(t, "public", pdus)
 	ip, port := snmptest.ParseAddr(addr)
 
@@ -398,32 +408,42 @@ func TestPackageConstantsStable(t *testing.T) {
 	}
 }
 
-// --- synthesizers --------------------------------------------------------
+// TestWalkVendorJuniper end-to-ends the Juniper walker against the real
+// jnxBgpM2PeerTable captured from a vJunos-router (JUNOS 25.4R1.12, #56). The
+// capture has two established eBGP peers — 192.0.2.2 (IPv4) and 2001:db8:1::2
+// (IPv6) — both with remote AS 65002 (state col 2, remoteAs col 13).
+func TestWalkVendorJuniper(t *testing.T) {
+	addr := snmptest.Start(t, "public", snmptest.LoadCapture(t, juniperCapture))
+	ip, port := snmptest.ParseAddr(addr)
 
-// buildCiscoCbgpPeer2RealPDUs returns a PDU set that mirrors the real
-// cbgpPeer2Table output captured from cisco_iol L2-17.12.1. The minimum
-// columns needed for the walker are state (col 3) and remoteAs (col 11);
-// peer IP is in the index suffix. See
-// lab/cisco-iol-bgp/captures/r1_cisco_cbgpPeer2Table.txt for the full
-// real-device output this is modelled on.
-func buildCiscoCbgpPeer2RealPDUs() []gsnmp.SnmpPDU {
-	const base = ".1.3.6.1.4.1.9.9.187.1.2.5.1."
-	// Index: <addrType=1=ipv4>.<addrLen=4>.<addrBytes=10.0.0.2>
-	const idx = "1.4.10.0.0.2"
-	return []gsnmp.SnmpPDU{
-		{Name: base + "3." + idx, Type: gsnmp.Integer, Value: bgpStateEstablished},
-		{Name: base + "11." + idx, Type: gsnmp.Gauge32, Value: uint(65001)},
+	p := snmputil.Params{
+		IP:          ip,
+		Port:        port,
+		Community:   []byte("public"),
+		Timeout:     3 * time.Second,
+		UseBGPV2MIB: true,
+		Vendor:      "juniper",
 	}
-}
 
-// buildAristaBgp4v2RealPDUs mirrors Arista cEOS 4.36's enterprise BGP4V2
-// MIB. See lab/arista-ceos-bgp/captures/r1_arista_bgp4v2.txt.
-func buildAristaBgp4v2RealPDUs() []gsnmp.SnmpPDU {
-	const base = ".1.3.6.1.4.1.30065.4.1.1.2.1."
-	// Index: <peerInst=1>.<addrType=1=ipv4>.<addrLen=4>.<addrBytes=10.0.0.2>
-	const idx = "1.1.4.10.0.0.2"
-	return []gsnmp.SnmpPDU{
-		{Name: base + "13." + idx, Type: gsnmp.Integer, Value: bgpStateEstablished},
-		{Name: base + "10." + idx, Type: gsnmp.Gauge32, Value: uint(65001)},
+	edges, _, err := Walk(context.Background(), p, "rtr-juniper", nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 edges from Juniper vendor walker (one per peer), got %d: %+v", len(edges), edges)
+	}
+	got := map[string]string{}
+	for _, e := range edges {
+		got[e.DstDevice] = e.Metadata[metaKeyRemoteAs]
+	}
+	for _, peer := range []string{"192.0.2.2", "2001:db8:1::2"} {
+		as, ok := got[peer]
+		if !ok {
+			t.Errorf("no edge to peer %s; got %+v", peer, got)
+			continue
+		}
+		if as != "65002" {
+			t.Errorf("peer %s RemoteAs = %q, want 65002 (from col 13)", peer, as)
+		}
 	}
 }

--- a/internal/snmptest/capture.go
+++ b/internal/snmptest/capture.go
@@ -1,0 +1,257 @@
+package snmptest
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	gsnmp "github.com/gosnmp/gosnmp"
+)
+
+// LoadCapture reads an snmpwalk capture file (numeric OIDs and numeric enums,
+// i.e. `snmpwalk -On -Oe`, the format emitted by lab/*/capture.sh) and returns
+// the PDUs it describes, ready to hand to Start. Comment lines (`#`) and blank
+// lines are skipped. It fails the test on any parse error, mirroring Start's
+// fail-fast helper style.
+//
+// Loading captures directly — instead of transcribing them into hand-built PDU
+// slices — means the vendor walker tests run against the exact bytes a real
+// device emitted, so a capture refresh that drifts from the walker's column
+// assumptions is caught rather than silently ignored (issue #59).
+func LoadCapture(t *testing.T, path string) []gsnmp.SnmpPDU {
+	t.Helper()
+	f, err := os.Open(path) //nolint:gosec // G304: a test helper that opens a caller-supplied capture path is the whole point.
+	if err != nil {
+		t.Fatalf("snmptest.LoadCapture: open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	pdus, err := parseCapture(f)
+	if err != nil {
+		t.Fatalf("snmptest.LoadCapture: parse %s: %v", path, err)
+	}
+	return pdus
+}
+
+// parseCapture is the testable core of LoadCapture: it turns the capture text
+// into PDUs or returns an error. Kept separate so the parser can be unit-tested
+// against in-memory input without touching the filesystem.
+func parseCapture(r io.Reader) ([]gsnmp.SnmpPDU, error) {
+	var pdus []gsnmp.SnmpPDU
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		eq := strings.Index(line, " = ")
+		if eq < 0 {
+			// A line with no ' = ' is a wrapped continuation of the previous
+			// Hex-STRING value (snmpwalk folds long octet strings across lines).
+			if appended, err := appendHexContinuation(pdus, trimmed); err != nil {
+				return nil, fmt.Errorf("line %d: %w", lineNo, err)
+			} else if appended {
+				continue
+			}
+			return nil, fmt.Errorf("line %d: no ' = ' separator: %q", lineNo, line)
+		}
+		oid := strings.TrimSpace(line[:eq])
+		rest := strings.TrimSpace(line[eq+3:])
+		pdu, err := parseValue(oid, rest)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		pdus = append(pdus, pdu)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return pdus, nil
+}
+
+// appendHexContinuation folds a wrapped hex line into the preceding Hex-STRING
+// PDU. Returns false (not an error) when the line isn't a plausible hex
+// continuation, so the caller can report it as a malformed line instead.
+func appendHexContinuation(pdus []gsnmp.SnmpPDU, line string) (bool, error) {
+	n := len(pdus)
+	if n == 0 || pdus[n-1].Type != gsnmp.OctetString || !looksHex(line) {
+		return false, nil
+	}
+	b, err := parseHexBytes(line)
+	if err != nil {
+		return false, fmt.Errorf("continuation hex: %w", err)
+	}
+	prev, _ := pdus[n-1].Value.([]byte)
+	merged := make([]byte, 0, len(prev)+len(b))
+	merged = append(merged, prev...)
+	merged = append(merged, b...)
+	pdus[n-1].Value = merged
+	return true, nil
+}
+
+// parseValue turns "<TYPE>: <value>" (or a bare quoted string) into a PDU.
+func parseValue(oid, rest string) (gsnmp.SnmpPDU, error) {
+	pdu := gsnmp.SnmpPDU{Name: oid}
+
+	if colon := strings.Index(rest, ":"); colon > 0 {
+		typ := rest[:colon]
+		val := strings.TrimSpace(rest[colon+1:])
+		// A bare token before the colon (no spaces, type-shaped) is an SNMP
+		// type keyword: parse it if known, but reject an unknown one so that
+		// capture-format drift surfaces rather than being silently swallowed
+		// into an OctetString. A quoted or space-containing left side (e.g.
+		// the value itself happens to contain a colon) is not a type prefix.
+		if looksLikeTypeToken(typ) {
+			if !isTypeToken(typ) {
+				return pdu, fmt.Errorf("unsupported SNMP type %q", typ)
+			}
+			return typedValue(pdu, typ, val)
+		}
+	}
+
+	// No type prefix — a bare string value such as `""` (an empty OctetString,
+	// common for unset columns) or a quoted literal.
+	pdu.Type = gsnmp.OctetString
+	pdu.Value = []byte(strings.Trim(rest, `"`))
+	return pdu, nil
+}
+
+func typedValue(pdu gsnmp.SnmpPDU, typ, val string) (gsnmp.SnmpPDU, error) {
+	switch typ {
+	case "INTEGER":
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return pdu, fmt.Errorf("INTEGER %q: %w", val, err)
+		}
+		pdu.Type, pdu.Value = gsnmp.Integer, n
+	case "Gauge32", "Gauge", "Unsigned32":
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return pdu, fmt.Errorf("%s %q: %w", typ, val, err)
+		}
+		pdu.Type, pdu.Value = gsnmp.Gauge32, uint(n)
+	case "Counter32", "Counter":
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return pdu, fmt.Errorf("%s %q: %w", typ, val, err)
+		}
+		pdu.Type, pdu.Value = gsnmp.Counter32, uint(n)
+	case "Counter64":
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return pdu, fmt.Errorf("Counter64 %q: %w", val, err)
+		}
+		pdu.Type, pdu.Value = gsnmp.Counter64, n
+	case "Timeticks", "Timeticks32":
+		// snmpwalk prints `(12345) 0:02:03.45`; the ticks are the first integer.
+		n, ok := firstUint(val)
+		if !ok {
+			return pdu, fmt.Errorf("timeticks %q: no numeric ticks", val)
+		}
+		if n > math.MaxUint32 {
+			return pdu, fmt.Errorf("timeticks %q: exceeds 32 bits", val)
+		}
+		pdu.Type, pdu.Value = gsnmp.TimeTicks, uint32(n)
+	case "IpAddress":
+		pdu.Type, pdu.Value = gsnmp.IPAddress, val
+	case "Hex-STRING":
+		b, err := parseHexBytes(val)
+		if err != nil {
+			return pdu, fmt.Errorf("Hex-STRING %q: %w", val, err)
+		}
+		pdu.Type, pdu.Value = gsnmp.OctetString, b
+	case "STRING":
+		pdu.Type, pdu.Value = gsnmp.OctetString, []byte(strings.Trim(val, `"`))
+	case "OID":
+		pdu.Type, pdu.Value = gsnmp.ObjectIdentifier, val
+	default:
+		return pdu, fmt.Errorf("unsupported SNMP type %q", typ)
+	}
+	return pdu, nil
+}
+
+// isTypeToken reports whether s is a recognised snmpwalk type keyword. Type
+// keywords are a single token of letters, digits and hyphens (e.g. Hex-STRING),
+// which lets parseValue tell `STRING: "x"` (typed) from a bare `"x"` value.
+func isTypeToken(s string) bool {
+	switch s {
+	case "INTEGER", "Gauge32", "Gauge", "Unsigned32", "Counter32", "Counter",
+		"Counter64", "Timeticks", "Timeticks32", "IpAddress", "Hex-STRING",
+		"STRING", "OID":
+		return true
+	}
+	return false
+}
+
+// looksLikeTypeToken reports whether s has the shape of an snmpwalk type
+// keyword: a leading letter followed by letters, digits or hyphens, with no
+// spaces (e.g. INTEGER, Gauge32, Hex-STRING).
+func looksLikeTypeToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z':
+		case i > 0 && ((c >= '0' && c <= '9') || c == '-'):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// parseHexBytes decodes space-separated hex pairs ("0A 00 00 01") into bytes.
+func parseHexBytes(s string) ([]byte, error) {
+	s = strings.ReplaceAll(s, " ", "")
+	if s == "" {
+		return []byte{}, nil
+	}
+	return hex.DecodeString(s)
+}
+
+// looksHex reports whether s is composed solely of hex digits and spaces, used
+// to recognise a wrapped Hex-STRING continuation line.
+func looksHex(s string) bool {
+	seen := false
+	for _, c := range s {
+		switch {
+		case c == ' ':
+		case (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'):
+			seen = true
+		default:
+			return false
+		}
+	}
+	return seen
+}
+
+// firstUint returns the first run of decimal digits in s as a uint64.
+func firstUint(s string) (uint64, bool) {
+	start := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			if start < 0 {
+				start = i
+			}
+		} else if start >= 0 {
+			n, err := strconv.ParseUint(s[start:i], 10, 64)
+			return n, err == nil
+		}
+	}
+	if start >= 0 {
+		n, err := strconv.ParseUint(s[start:], 10, 64)
+		return n, err == nil
+	}
+	return 0, false
+}

--- a/internal/snmptest/capture_test.go
+++ b/internal/snmptest/capture_test.go
@@ -1,0 +1,108 @@
+package snmptest
+
+import (
+	"strings"
+	"testing"
+
+	gsnmp "github.com/gosnmp/gosnmp"
+)
+
+// TestParseCaptureTypes covers each SNMP type token the lab capture files emit
+// (INTEGER, Gauge32, Counter32, Counter64, Timeticks, IpAddress, Hex-STRING,
+// STRING) plus the bare empty-string form, asserting both the gosnmp type tag
+// and the decoded Go value.
+func TestParseCaptureTypes(t *testing.T) {
+	in := strings.Join([]string{
+		"# a comment line — ignored",
+		"# device: fake",
+		"",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.3.1.4.10.0.0.2 = INTEGER: 6",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.11.1.4.10.0.0.2 = Gauge32: 65001",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.13.1.4.10.0.0.2 = Counter32: 7",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.30.1.4.10.0.0.2 = Counter64: 123456789012",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.31.1.4.10.0.0.2 = Timeticks: (133) 0:00:01.33",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.9.1.4.10.0.0.2 = IpAddress: 1.1.1.1",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.6.1.4.10.0.0.2 = Hex-STRING: 0A 00 00 01 ",
+		".1.3.6.1.4.1.30065.4.1.1.2.1.14.1.1.4.10.0.0.2 = STRING: \"ibgp-r2\"",
+		".1.3.6.1.4.1.9.9.187.1.2.5.1.28.1.4.10.0.0.2 = \"\"",
+	}, "\n")
+
+	pdus, err := parseCapture(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseCapture: %v", err)
+	}
+	if len(pdus) != 9 {
+		t.Fatalf("got %d PDUs, want 9 (comments/blanks skipped)", len(pdus))
+	}
+
+	check := func(i int, wantName string, wantType gsnmp.Asn1BER, wantVal any) {
+		t.Helper()
+		if pdus[i].Name != wantName {
+			t.Errorf("[%d] Name = %q, want %q", i, pdus[i].Name, wantName)
+		}
+		if pdus[i].Type != wantType {
+			t.Errorf("[%d] Type = %v, want %v", i, pdus[i].Type, wantType)
+		}
+		switch want := wantVal.(type) {
+		case []byte:
+			got, ok := pdus[i].Value.([]byte)
+			if !ok || string(got) != string(want) {
+				t.Errorf("[%d] Value = %v (%T), want %v", i, pdus[i].Value, pdus[i].Value, want)
+			}
+		default:
+			if pdus[i].Value != wantVal {
+				t.Errorf("[%d] Value = %v (%T), want %v (%T)", i, pdus[i].Value, pdus[i].Value, wantVal, wantVal)
+			}
+		}
+	}
+
+	check(0, ".1.3.6.1.4.1.9.9.187.1.2.5.1.3.1.4.10.0.0.2", gsnmp.Integer, 6)
+	check(1, ".1.3.6.1.4.1.9.9.187.1.2.5.1.11.1.4.10.0.0.2", gsnmp.Gauge32, uint(65001))
+	check(2, ".1.3.6.1.4.1.9.9.187.1.2.5.1.13.1.4.10.0.0.2", gsnmp.Counter32, uint(7))
+	check(3, ".1.3.6.1.4.1.9.9.187.1.2.5.1.30.1.4.10.0.0.2", gsnmp.Counter64, uint64(123456789012))
+	check(4, ".1.3.6.1.4.1.9.9.187.1.2.5.1.31.1.4.10.0.0.2", gsnmp.TimeTicks, uint32(133))
+	check(5, ".1.3.6.1.4.1.9.9.187.1.2.5.1.9.1.4.10.0.0.2", gsnmp.IPAddress, "1.1.1.1")
+	check(6, ".1.3.6.1.4.1.9.9.187.1.2.5.1.6.1.4.10.0.0.2", gsnmp.OctetString, []byte{0x0a, 0, 0, 1})
+	check(7, ".1.3.6.1.4.1.30065.4.1.1.2.1.14.1.1.4.10.0.0.2", gsnmp.OctetString, []byte("ibgp-r2"))
+	check(8, ".1.3.6.1.4.1.9.9.187.1.2.5.1.28.1.4.10.0.0.2", gsnmp.OctetString, []byte{})
+}
+
+// TestParseCaptureHexContinuation folds a wrapped Hex-STRING line (snmpwalk
+// breaks long octet strings across lines) into the preceding PDU.
+func TestParseCaptureHexContinuation(t *testing.T) {
+	in := ".1.3.6.1.2.1.1.6 = Hex-STRING: 00 11 22 33\n44 55 66 77\n"
+	pdus, err := parseCapture(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseCapture: %v", err)
+	}
+	if len(pdus) != 1 {
+		t.Fatalf("got %d PDUs, want 1 (continuation merged)", len(pdus))
+	}
+	got, _ := pdus[0].Value.([]byte)
+	want := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77}
+	if string(got) != string(want) {
+		t.Errorf("Value = % x, want % x", got, want)
+	}
+}
+
+// TestParseCaptureErrors covers the malformed inputs the parser must reject so
+// that capture-format drift surfaces as a test failure rather than silent data
+// loss.
+func TestParseCaptureErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"unknown type", ".1.3.6.1 = WeirdType: 5"},
+		{"non-numeric integer", ".1.3.6.1 = INTEGER: notanumber"},
+		{"odd hex", ".1.3.6.1 = Hex-STRING: 0A0"},
+		{"no separator and no prior hex", "garbage line with no equals"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := parseCapture(strings.NewReader(c.in)); err == nil {
+				t.Errorf("parseCapture(%q) succeeded, want error", c.in)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #59. Replaces the hand-transcribed `gosnmp.SnmpPDU` slices in the BGP4-V2 vendor-walker tests with direct loads of the real lab capture files, eliminating the capture-vs-walker drift gap (carved out of #1).

- **`snmptest.LoadCapture(t, path)`** (+ testable `parseCapture`): parses `snmpwalk -On -Oe` output — the format `lab/*/capture.sh` emits — into PDUs. Handles `INTEGER`, `Gauge32`, `Counter32`, `Counter64`, `Timeticks`, `IpAddress`, `Hex-STRING`, `STRING`, the bare empty-string (`""`) case, and wrapped Hex-STRING continuation lines. **Rejects unknown type tokens** so future capture-format drift fails loudly.
- **Cisco + Arista** walker tests (`bgp_v2_test.go`, `bgp_outcome_test.go`) now load `lab/cisco-iol-bgp/captures/r1_cisco_cbgpPeer2Table.txt` and `lab/arista-ceos-bgp/captures/r1_arista_bgp4v2.txt`. The transcribed builders are removed.
- **New `TestWalkVendorJuniper`** — first end-to-end test of the Juniper walker against the real `jnxBgpM2PeerTable` capture (#56): two established eBGP peers (IPv4 `192.0.2.2` + IPv6 `2001:db8:1::2`, AS 65002).

### Scope notes
- **Nokia (#57)** intentionally not wired — no real fixture yet (vSIM is unlicensed/blocked).
- **IOS-XE (#58)** needs no separate fixture — closed via cross-confirmation that it reuses the Cisco `cbgpPeer2Table`.
- Tests still run with **no network and no SNMP daemon**; the in-process `snmptest` agent serves the loaded PDUs.

## Test Plan
- [x] `go test ./...` — exit 0, no failures
- [x] `golangci-lint run` — 0 issues (gofmt/gosec/staticcheck/gocritic)
- [x] New parser unit tests cover every type, hex continuation, and 4 error cases
- [x] `TestWalkVendorCisco/Arista/Juniper` pass against the real capture files