### PR TITLE
security/CI hardening: CodeQL, scheduled govulncheck, SHA-pinned actions, egress NetworkPolicy (#120 #121 #122 #124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.12
 
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.17.0
 
@@ -190,12 +190,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: docker build (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: false
@@ -315,11 +315,11 @@ jobs:
         with:
           go-version: '1.26.4'
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -328,13 +328,13 @@ jobs:
       # Gated on DOCKERHUB_ENABLED: skipped (not failed) when the secret is absent.
       - name: log in to Docker Hub
         if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       # Build the metadata-action images list: GHCR always, Docker Hub appended
       # only when the mirror is enabled. Emitting a multiline value via a heredoc
@@ -354,7 +354,7 @@ jobs:
 
       - name: docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ steps.imgs.outputs.images }}
           tags: |
@@ -364,7 +364,7 @@ jobs:
 
       - name: build and push
         id: build_push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
@@ -437,7 +437,7 @@ jobs:
       # SPDX predicate, signed as a blob, and attached to the release + the
       # offline tarball.
       - name: generate image SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ghcr.io/${{ github.repository }}@${{ steps.build_push.outputs.digest }}
           format: spdx-json
@@ -499,7 +499,7 @@ jobs:
             "${TARBALL}"
 
       - name: create github release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             bin/topology-exporter-linux-amd64

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# CodeQL semantic static analysis for Go (#120). Complements the existing
+# supply-chain controls (gosec via golangci-lint, govulncheck, gosec/OSS-Fuzz)
+# by adding dataflow-based analysis with results uploaded to the repository's
+# Security → Code scanning tab. Runs on PRs, on push to main, and weekly so a
+# newly published query surfaces issues even without a code change.
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '24 5 * * 1' # Mondays 05:24 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze (go)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for codeql-action to upload SARIF to the Security tab.
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/k6-load.yml
+++ b/.github/workflows/k6-load.yml
@@ -40,10 +40,10 @@ jobs:
           done
 
       - name: install k6
-        uses: grafana/setup-k6-action@v1
+        uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
 
       - name: run /metrics scrape load
-        uses: grafana/run-k6-action@v1
+        uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         env:
           TARGET: http://localhost:9100
           VUS: "20"

--- a/.github/workflows/kustomize-smoke.yml
+++ b/.github/workflows/kustomize-smoke.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           wait: 120s
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,34 @@
+# Scheduled vulnerability scan (#121). The govulncheck job in ci.yml runs only
+# on push/PR, so a CVE disclosed against an unchanged dependency during a quiet
+# period would not surface until the next commit. This runs govulncheck against
+# main on a weekly schedule (and on demand) so advisories are caught regardless
+# of commit activity.
+name: security-scan
+
+on:
+  schedule:
+    - cron: '17 6 * * 1' # Mondays 06:17 UTC (offset from codeql)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck (scheduled)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      # Fails the scheduled run (red workflow + notification) when a new advisory
+      # affects the module's actually-reachable code.
+      - name: govulncheck
+        run: govulncheck ./...

--- a/deploy/helm/topology-exporter/templates/networkpolicy.yaml
+++ b/deploy/helm/topology-exporter/templates/networkpolicy.yaml
@@ -11,6 +11,9 @@ spec:
       {{- include "topology-exporter.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
   ingress:
     # Allow Prometheus scraping on the metrics port from anywhere.
     - ports:
@@ -30,4 +33,58 @@ spec:
         - port: {{ .Values.service.hubPort | default 9101 }}
           protocol: TCP
     {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  {{- $eg := .Values.networkPolicy.egress }}
+  egress:
+    {{- if $eg.allowDNS }}
+    # DNS resolution (kube-dns / CoreDNS).
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+    {{- if $eg.snmp.cidrs }}
+    # SNMP polling targets (discovery scope).
+    - to:
+        {{- range $eg.snmp.cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range $eg.snmp.ports }}
+        - port: {{ . }}
+          protocol: UDP
+        {{- end }}
+    {{- end }}
+    {{- if $eg.otlp.cidrs }}
+    # OTLP traces/metrics collector.
+    - to:
+        {{- range $eg.otlp.cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range $eg.otlp.ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- if $eg.hub.cidrs }}
+    # Hub federation peers (spoke → hub push).
+    - to:
+        {{- range $eg.hub.cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range $eg.hub.ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- with $eg.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/topology-exporter/values.schema.json
+++ b/deploy/helm/topology-exporter/values.schema.json
@@ -512,10 +512,44 @@
     "networkPolicy": {
       "type": "object",
       "additionalProperties": false,
-      "description": "NetworkPolicy that restricts ingress to the hub federation port.",
+      "description": "NetworkPolicy that restricts ingress to the hub federation port, with optional egress lockdown.",
       "properties": {
         "enabled": { "type": "boolean" },
-        "spokeSelector": { "type": "object" }
+        "spokeSelector": { "type": "object" },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Opt-in egress restriction. When enabled, only the listed destinations are reachable.",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowDNS": { "type": "boolean" },
+            "snmp": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cidrs": { "type": "array", "items": { "type": "string" } },
+                "ports": { "type": "array", "items": { "type": "integer" } }
+              }
+            },
+            "otlp": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cidrs": { "type": "array", "items": { "type": "string" } },
+                "ports": { "type": "array", "items": { "type": "integer" } }
+              }
+            },
+            "hub": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cidrs": { "type": "array", "items": { "type": "string" } },
+                "ports": { "type": "array", "items": { "type": "integer" } }
+              }
+            },
+            "extraRules": { "type": "array", "items": { "type": "object" } }
+          }
+        }
       }
     }
   }

--- a/deploy/helm/topology-exporter/values.yaml
+++ b/deploy/helm/topology-exporter/values.yaml
@@ -59,6 +59,11 @@ prometheusRule:
   # Discovery cycle slower than this threshold triggers the p99 alert.
   cycleThresholdSeconds: 60
 
+# A CPU limit is intentionally omitted. Discovery is bursty (periodic cycles),
+# and a CPU limit would invite CFS throttling that stretches cycle latency for
+# no real benefit on a small workload. The request sets the scheduler floor;
+# memory keeps a hard limit to bound blast radius. Add a cpu limit here only if
+# a namespace ResourceQuota / LimitRange forces one. (#122)
 resources:
   requests:
     cpu: 50m
@@ -166,6 +171,32 @@ networkPolicy:
   # Labels that spoke pods must carry to be allowed ingress on the hub port.
   # Example: topology-exporter/role: spoke
   spokeSelector: {}
+  # Opt-in egress restriction. Default (disabled) keeps the policy Ingress-only.
+  # When enabled, policyTypes gains Egress and ONLY the rules below are allowed —
+  # all other outbound traffic is denied. A credential-bearing whole-network SNMP
+  # scanner has no business reaching arbitrary destinations, so locking egress
+  # limits the blast radius if the pod is compromised. You MUST enumerate every
+  # destination the exporter legitimately needs, or it will break.
+  egress:
+    enabled: false
+    # DNS resolution (kube-dns / CoreDNS). Almost always required. Allows
+    # UDP+TCP 53 egress (to any destination, since the DNS service IP varies).
+    allowDNS: true
+    # SNMP polling targets — typically your discovery scope
+    # (config.discovery.scope.cidr_allow_list).
+    snmp:
+      cidrs: [] # e.g. ["10.0.0.0/8"]
+      ports: [161]
+    # OTLP traces/metrics collector endpoint.
+    otlp:
+      cidrs: [] # e.g. ["10.96.0.10/32"]
+      ports: [4317]
+    # Hub federation peers (spoke → hub push). Hub-side acceptance is ingress.
+    hub:
+      cidrs: [] # e.g. ["10.0.0.0/8"]
+      ports: [9101]
+    # Escape hatch: extra raw NetworkPolicy egress entries, rendered verbatim.
+    extraRules: []
 
 nodeSelector: {}
 tolerations: []

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -23,7 +23,27 @@ deploy/kustomize/
     standalone/               # config.federation.role: standalone
     hub/                      # config.federation.role: hub
     spoke/                    # config.federation.role: spoke
+  components/
+    egress-networkpolicy/     # opt-in: lock down egress (DNS/SNMP/OTLP/hub)
 ```
+
+## Hardening: opt-in egress NetworkPolicy
+
+The base NetworkPolicy is **Ingress-only** — a compromised credential-bearing
+SNMP scanner would have unrestricted outbound (lateral) reach. The
+`components/egress-networkpolicy` component adds `Egress` to `policyTypes` with
+allow-rules for DNS, SNMP polling, the OTLP collector, and hub federation.
+Enable it from an overlay:
+
+```yaml
+# in overlays/<mode>/kustomization.yaml
+components:
+  - ../../components/egress-networkpolicy
+```
+
+With Egress enabled, **only the listed destinations are reachable** — edit the
+example CIDRs/ports in the component's patch to your environment first, or the
+exporter will lose connectivity. (Helm users set `networkPolicy.egress.*`.)
 
 ## Federation modes
 

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -56,6 +56,9 @@ spec:
               port: metrics
             initialDelaySeconds: 5
             periodSeconds: 10
+          # CPU limit intentionally omitted: discovery is bursty and a cpu limit
+          # would invite CFS throttling that stretches cycle latency. Memory keeps
+          # a hard limit to bound blast radius. Mirrors deploy/helm values.yaml. (#122)
           resources:
             requests:
               cpu: 50m

--- a/deploy/kustomize/components/egress-networkpolicy/kustomization.yaml
+++ b/deploy/kustomize/components/egress-networkpolicy/kustomization.yaml
@@ -1,0 +1,22 @@
+# Opt-in egress NetworkPolicy component (#122).
+#
+# Including this component adds `Egress` to the base NetworkPolicy's policyTypes
+# and a set of allow-rules, so a compromised credential-bearing SNMP scanner
+# cannot reach arbitrary destinations. With Egress enabled, ONLY the rules in
+# patch-networkpolicy-egress.yaml are permitted — you MUST edit the example
+# CIDRs/ports to match your environment or the exporter will lose connectivity.
+#
+# Enable it from an overlay's kustomization.yaml:
+#
+#   components:
+#     - ../../components/egress-networkpolicy
+#
+# Helm users get the equivalent via networkPolicy.egress.* values.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-networkpolicy-egress.yaml
+    target:
+      kind: NetworkPolicy
+      name: topology-exporter

--- a/deploy/kustomize/components/egress-networkpolicy/patch-networkpolicy-egress.yaml
+++ b/deploy/kustomize/components/egress-networkpolicy/patch-networkpolicy-egress.yaml
@@ -1,0 +1,38 @@
+# Adds Egress to the base NetworkPolicy. EDIT the example CIDRs/ports below to
+# your environment — with Egress enabled, anything not listed here is DENIED.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: topology-exporter
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    # DNS resolution (kube-dns / CoreDNS). Required.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # SNMP polling targets — EDIT to your discovery scope (cidr_allow_list).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - port: 161
+          protocol: UDP
+    # OTLP traces/metrics collector — EDIT to your collector address.
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.0/16
+      ports:
+        - port: 4317
+          protocol: TCP
+    # Hub federation peers (spoke → hub push) — EDIT, or remove if standalone.
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - port: 9101
+          protocol: TCP


### PR DESCRIPTION
Batch of low-risk supply-chain / deployment hardening from the deep-audit backlog. Four independent commits, one per issue.

## Closes #120 — CodeQL static analysis
`.github/workflows/codeql.yml`: CodeQL for Go (`security-extended`), on PR + push-to-main + weekly schedule, SARIF uploaded to Security → Code scanning. Adds dataflow analysis the existing gosec/govulncheck/OSS-Fuzz stack lacked.

## Closes #121 — scheduled govulncheck
`.github/workflows/security-scan.yml`: weekly (+ `workflow_dispatch`) `govulncheck ./...` against `main`, so a CVE on an unchanged dependency surfaces without waiting for a commit. The push/PR job in `ci.yml` is unchanged.

## Closes #124 — SHA-pin third-party Actions
All 17 third-party `uses:` refs pinned to 40-char commit SHAs with `# vX.Y.Z` comments (grafana/*, docker/*, helm/kind-action, azure/setup-helm, sigstore/cosign-installer, anchore/sbom-action, softprops/action-gh-release, golangci/golangci-lint-action). Dependabot maintains them. First-party `actions/*` and `github/*` stay on major tags per the issue.

## Closes #122 — deployment manifest hardening
- **Opt-in egress NetworkPolicy** (default off → existing deployments unchanged):
  - Helm: `networkPolicy.egress.{enabled,allowDNS,snmp,otlp,hub,extraRules}` → `policyTypes: [Ingress, Egress]` with allow-rules for DNS, SNMP scope CIDRs, OTLP collector, hub peers. `values.schema.json` updated.
  - Kustomize: `components/egress-networkpolicy` component; overlays opt in via `components:`. README documents both.
- **CPU-limit omission documented** inline (Helm values + Kustomize base): intentional, to avoid CFS throttling on a bursty workload.

## Test Plan
- [x] `helm lint` clean; `helm template` renders the egress NetworkPolicy correctly
- [x] `kubectl kustomize` builds the base/overlays; egress component adds `Egress` (verified, temp edit reverted)
- [x] All workflow YAML parses; no third-party action left on a mutable tag; 17 refs pinned to SHA
- [ ] CI (incl. the new CodeQL job) green on this PR — the `ci.yml` run also validates the pinned SHAs resolve

Note: weekly schedules and Security-tab SARIF visibility are inherently post-merge.