### PR TITLE
fix(snmptest): resolve two CodeQL integer-conversion alerts in capture parser

### DIFF
--- a/internal/snmptest/capture.go
+++ b/internal/snmptest/capture.go
@@ -134,13 +134,16 @@ func typedValue(pdu gsnmp.SnmpPDU, typ, val string) (gsnmp.SnmpPDU, error) {
 		}
 		pdu.Type, pdu.Value = gsnmp.Integer, n
 	case "Gauge32", "Gauge", "Unsigned32":
-		n, err := strconv.ParseUint(val, 10, 64)
+		// 32-bit SNMP type: parse with bitSize 32 so the value is bounded and
+		// the uint conversion cannot overflow (and a malformed >32-bit value is
+		// rejected rather than silently truncated).
+		n, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
 			return pdu, fmt.Errorf("%s %q: %w", typ, val, err)
 		}
 		pdu.Type, pdu.Value = gsnmp.Gauge32, uint(n)
 	case "Counter32", "Counter":
-		n, err := strconv.ParseUint(val, 10, 64)
+		n, err := strconv.ParseUint(val, 10, 32)
 		if err != nil {
 			return pdu, fmt.Errorf("%s %q: %w", typ, val, err)
 		}


### PR DESCRIPTION
## Summary
Resolves the two high-severity **CodeQL `go/incorrect-integer-conversion`** alerts surfaced by the new CodeQL workflow (#120), both in `internal/snmptest/capture.go`:

- `Gauge32` (line ~141) and `Counter32` (line ~147) were parsed with `strconv.ParseUint(val, 10, 64)` then converted to `uint` with no upper-bound check — an overflow risk where `uint` is 32-bit.

Both are **32-bit SNMP types**, so they're now parsed with `bitSize 32`. The parsed value is provably in range for the `uint` conversion, and a malformed value exceeding 32 bits is rejected with a parse error instead of silently truncated. This mirrors the existing `math.MaxUint32` guard on the `Timeticks` case (which CodeQL did not flag).

## Test Plan
- [x] `go test ./internal/snmptest/ ./internal/discovery/bgp/` — pass (real captures still parse; vendor walkers still produce expected edges)
- [x] `golangci-lint run ./internal/snmptest/...` — 0 issues
- [ ] CodeQL on this PR clears both alerts