### PR TITLE
fix(deploy): harden opt-in egress NetworkPolicy (#135)

### DIFF
--- a/deploy/helm/topology-exporter/templates/networkpolicy.yaml
+++ b/deploy/helm/topology-exporter/templates/networkpolicy.yaml
@@ -35,10 +35,17 @@ spec:
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   {{- $eg := .Values.networkPolicy.egress }}
+  {{- if and (not $eg.snmp.cidrs) (not $eg.otlp.cidrs) (not $eg.hub.cidrs) (not $eg.extraRules) }}
+  {{- fail "networkPolicy.egress.enabled is true but no egress destinations are configured (snmp.cidrs/otlp.cidrs/hub.cidrs/extraRules) — this would deny all SNMP discovery. Set at least snmp.cidrs." }}
+  {{- end }}
   egress:
     {{- if $eg.allowDNS }}
-    # DNS resolution (kube-dns / CoreDNS).
-    - ports:
+    # DNS resolution (kube-dns / CoreDNS), scoped to the cluster DNS namespace.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $eg.dnsNamespace | default "kube-system" }}
+      ports:
         - port: 53
           protocol: UDP
         - port: 53

--- a/deploy/helm/topology-exporter/values.schema.json
+++ b/deploy/helm/topology-exporter/values.schema.json
@@ -523,6 +523,10 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "allowDNS": { "type": "boolean" },
+            "dnsNamespace": {
+              "type": "string",
+              "description": "Namespace the cluster DNS service runs in, matched via the kubernetes.io/metadata.name namespaceSelector label. Defaults to kube-system."
+            },
             "snmp": {
               "type": "object",
               "additionalProperties": false,

--- a/deploy/helm/topology-exporter/values.yaml
+++ b/deploy/helm/topology-exporter/values.yaml
@@ -177,11 +177,19 @@ networkPolicy:
   # scanner has no business reaching arbitrary destinations, so locking egress
   # limits the blast radius if the pod is compromised. You MUST enumerate every
   # destination the exporter legitimately needs, or it will break.
+  #
+  # Enabling egress requires at least one destination: when egress.enabled is
+  # true the chart FAILS to render unless one of snmp.cidrs / otlp.cidrs /
+  # hub.cidrs / extraRules is set, because a DNS-only egress policy would
+  # silently deny all SNMP discovery.
   egress:
     enabled: false
     # DNS resolution (kube-dns / CoreDNS). Almost always required. Allows
-    # UDP+TCP 53 egress (to any destination, since the DNS service IP varies).
+    # UDP+TCP 53 egress, scoped via namespaceSelector to dnsNamespace below.
     allowDNS: true
+    # Namespace the cluster DNS service runs in. Matched on the standard
+    # kubernetes.io/metadata.name label. Override for non-standard clusters.
+    dnsNamespace: kube-system
     # SNMP polling targets — typically your discovery scope
     # (config.discovery.scope.cidr_allow_list).
     snmp:

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -41,9 +41,13 @@ components:
   - ../../components/egress-networkpolicy
 ```
 
-With Egress enabled, **only the listed destinations are reachable** — edit the
-example CIDRs/ports in the component's patch to your environment first, or the
-exporter will lose connectivity. (Helm users set `networkPolicy.egress.*`.)
+With Egress enabled, **only the listed destinations are reachable**. The
+component **fails safe (deny-until-edit)**: the SNMP/OTLP/hub example CIDRs ship
+as `0.0.0.0/32` placeholders — a non-routable single address that matches no
+real traffic — so applying this component **unedited DENIES all SNMP/OTLP/hub
+egress** until you replace each `0.0.0.0/32` with your real CIDRs (and adjust
+ports). The DNS rule is scoped to the `kube-system` namespace; change it if your
+cluster DNS lives elsewhere. (Helm users set `networkPolicy.egress.*`.)
 
 ## Federation modes
 

--- a/deploy/kustomize/components/egress-networkpolicy/patch-networkpolicy-egress.yaml
+++ b/deploy/kustomize/components/egress-networkpolicy/patch-networkpolicy-egress.yaml
@@ -1,5 +1,10 @@
-# Adds Egress to the base NetworkPolicy. EDIT the example CIDRs/ports below to
-# your environment — with Egress enabled, anything not listed here is DENIED.
+# Adds Egress to the base NetworkPolicy.
+#
+# FAIL-SAFE BY DESIGN: applying this component UNEDITED DENIES all SNMP/OTLP/hub
+# egress. The example CIDRs below are 0.0.0.0/32 placeholders — a non-routable
+# single address that matches no real traffic. You MUST replace each 0.0.0.0/32
+# with your real CIDRs (and adjust ports) before the exporter can reach anything.
+# With Egress enabled, anything not listed here is DENIED.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -9,30 +14,38 @@ spec:
     - Ingress
     - Egress
   egress:
-    # DNS resolution (kube-dns / CoreDNS). Required.
-    - ports:
+    # DNS resolution (kube-dns / CoreDNS), scoped to the cluster DNS namespace.
+    # Required. Change kube-system if your cluster DNS lives elsewhere.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
-    # SNMP polling targets — EDIT to your discovery scope (cidr_allow_list).
+    # SNMP polling targets — REPLACE 0.0.0.0/32 with your discovery scope
+    # (cidr_allow_list). Until replaced, all SNMP egress is DENIED.
     - to:
         - ipBlock:
-            cidr: 10.0.0.0/8
+            cidr: 0.0.0.0/32
       ports:
         - port: 161
           protocol: UDP
-    # OTLP traces/metrics collector — EDIT to your collector address.
+    # OTLP traces/metrics collector — REPLACE 0.0.0.0/32 with your collector
+    # address. Until replaced, all OTLP egress is DENIED.
     - to:
         - ipBlock:
-            cidr: 10.96.0.0/16
+            cidr: 0.0.0.0/32
       ports:
         - port: 4317
           protocol: TCP
-    # Hub federation peers (spoke → hub push) — EDIT, or remove if standalone.
+    # Hub federation peers (spoke → hub push) — REPLACE 0.0.0.0/32, or remove
+    # this rule if standalone. Until replaced, all hub egress is DENIED.
     - to:
         - ipBlock:
-            cidr: 10.0.0.0/8
+            cidr: 0.0.0.0/32
       ports:
         - port: 9101
           protocol: TCP


### PR DESCRIPTION
Hardens the opt-in egress NetworkPolicy added in #122. Three coupled defects in the deploy manifests are fixed.

## Fixes

1. **DNS rule no longer allows port 53 to anywhere.** The egress `allowDNS` rule previously emitted `53/UDP` + `53/TCP` with no `to:` selector — DNS egress to any host (a DNS-tunnel exfil path). Both the Helm template and the Kustomize component now scope the rule with a `namespaceSelector` matching the cluster DNS namespace (`kubernetes.io/metadata.name`). The namespace is configurable via a new `networkPolicy.egress.dnsNamespace` value (default `kube-system`).

2. **Enabling egress with no destinations now fails loudly.** Previously `egress.enabled: true` with default (empty) CIDRs rendered a DNS-only egress policy that silently denied all SNMP discovery. The Helm template now calls `fail` when `egress.enabled` is true and none of `snmp.cidrs` / `otlp.cidrs` / `hub.cidrs` / `extraRules` are set.

3. **Kustomize component example CIDRs now fail safe.** The component patch hardcoded `10.0.0.0/8` and `10.96.0.0/16`, so an unedited apply authorized egress to all of RFC1918 plus a /16. The SNMP/OTLP/hub example CIDRs are now `0.0.0.0/32` placeholders (a non-routable single address — deny-until-edit). A prominent header comment and the kustomize README explain that an unedited apply denies SNMP/OTLP/hub egress until the placeholders are replaced.

`values.yaml` and `values.schema.json` document `dnsNamespace` and the destination-CIDR requirement.

## Test Plan

- `helm lint deploy/helm/topology-exporter` — passes.
- `helm template ... --set networkPolicy.egress.enabled=true --set 'networkPolicy.egress.snmp.cidrs={10.0.0.0/8}'` — DNS rule renders with the `kube-system` `namespaceSelector` `to:`, and the SNMP rule renders.
- `helm template ... --set networkPolicy.egress.enabled=true` (no CIDRs) — render ERRORS with the fail message.
- `kubectl kustomize` of the standalone overlay with the egress component temporarily added — renders Egress with `0.0.0.0/32` placeholders and the `kube-system`-scoped DNS rule (temp edit reverted).

Closes #135