### PR TITLE
ci(security): pin tool installs and first-party actions to immutable refs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.4"
           cache: true
 
       - name: install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@3cf34090a3db6bb64df2259e30021db7ff5d9595 # golang/perf untagged; pinned to master 2026-05-12
 
       - name: benchmark PR head
         run: go test -run='^$' -bench=. -benchmem -count=6 ./... | tee /tmp/new.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     name: build + unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -46,7 +46,7 @@ jobs:
           }
 
       - name: upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage
           path: coverage.out
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -71,9 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -96,7 +96,7 @@ jobs:
 
       - name: upload fuzz corpus on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-corpus-failure
           path: internal/discovery/*/testdata/fuzz/**
@@ -105,9 +105,9 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -120,15 +120,15 @@ jobs:
     name: vulnerability scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 # v1.1.4
 
       - name: govulncheck
         run: govulncheck ./...
@@ -137,15 +137,15 @@ jobs:
     name: license compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@v1.6.0 # v1.6.0
 
       # Fails the build if any dependency carries a forbidden or unidentifiable
       # license. The project is AGPL-3.0, so copyleft (GPL/LGPL/MPL) deps are
@@ -162,7 +162,7 @@ jobs:
     name: helm lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-test, lint]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
@@ -217,9 +217,9 @@ jobs:
     needs: [build-test]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -240,9 +240,9 @@ jobs:
     needs: [build-test]
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -260,14 +260,14 @@ jobs:
     name: scripts lint + tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: install bats
         run: |
           sudo apt-get install -y bats
       - name: install python + ruff + pytest
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
       - name: install python deps
@@ -309,9 +309,9 @@ jobs:
       id-token: write       # OIDC for cosign keyless + SLSA attestations
       attestations: write   # write build-provenance attestations to GitHub
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
 
@@ -388,7 +388,7 @@ jobs:
           done
 
       - name: attest container image build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build_push.outputs.digest }}
@@ -397,7 +397,7 @@ jobs:
       # Same digest, mirrored to Docker Hub; only runs when the mirror is enabled.
       - name: attest container image build provenance (Docker Hub)
         if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: docker.io/${{ github.repository }}
           subject-digest: ${{ steps.build_push.outputs.digest }}
@@ -425,7 +425,7 @@ jobs:
           done
 
       - name: attest binary build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             bin/topology-exporter-linux-amd64

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,23 +26,23 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: go
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           category: "/language:go"

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -16,9 +16,9 @@ jobs:
     name: fuzz (long, nightly)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.4'
           cache: true
@@ -66,7 +66,7 @@ jobs:
 
       - name: upload fuzz corpus on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-corpus-${{ github.run_id }}
           path: internal/discovery/*/testdata/fuzz/**
@@ -74,7 +74,7 @@ jobs:
 
       - name: open issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const title = `fuzz-nightly: regression detected in run ${context.runId}`;

--- a/.github/workflows/k6-load.yml
+++ b/.github/workflows/k6-load.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26.4"
           cache: true

--- a/.github/workflows/kustomize-smoke.yml
+++ b/.github/workflows/kustomize-smoke.yml
@@ -26,7 +26,7 @@ jobs:
     name: render overlays (required)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # kubectl ships with kustomize built in (kubectl kustomize).
       - name: validate overlays render
@@ -46,7 +46,7 @@ jobs:
     # not block the PR. Keep the `render` job as the required status check.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,15 +18,15 @@ jobs:
     name: govulncheck (scheduled)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 # v1.1.4
 
       # Fails the scheduled run (red workflow + notification) when a new advisory
       # affects the module's actually-reachable code.


### PR DESCRIPTION
## Summary

Completes CI supply-chain hardening by removing all floating/mutable refs from `.github/workflows/`.

### #136 — pin tool installs (no `@latest`)
| tool | was | now |
|------|-----|-----|
| govulncheck (ci.yml, security-scan.yml) | `@latest` | `@v1.1.4` |
| go-licenses (ci.yml) | `@latest` | `@v1.6.0` |
| benchstat (benchmarks.yml) | `@latest` | `@3cf3409` |

Notes:
- go-licenses pinned to latest **v1** (`v1.6.0`): v2.0.1 moved the module path to `github.com/google/go-licenses/v2`, which would require rewriting the install path. v1.6.0 keeps the existing path and behavior identical.
- golang/perf publishes no semver tags, so benchstat is pinned to the current master commit SHA.

### #138 — pin first-party actions to commit SHAs
Pinned every remaining `actions/*` and `github/*` `uses:` ref to a full 40-char commit SHA with a trailing `# vX.Y.Z` comment, completing the SHA-pinning that #124 did for third-party actions.

| action | SHA | version |
|--------|-----|---------|
| actions/checkout | `df4cb1c…` | v6.0.3 |
| actions/setup-go | `40f1582…` | v5.6.0 |
| actions/upload-artifact | `ea165f8…` | v4.6.2 |
| actions/github-script | `f28e40c…` | v7.1.0 |
| actions/setup-python | `a26af69…` | v5.6.0 |
| actions/attest-build-provenance | `a2bbfa2…` | v4.1.0 |
| github/codeql-action (init/autobuild/analyze) | `dd903d2…` | v3.36.2 |

44 first-party `uses:` refs updated across 7 workflow files; combined with #124's third-party pins, all 61 `uses:` refs are now SHA-pinned.

## Test Plan
- [x] All workflows still parse: `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('ok')"` -> `ok`
- [x] No mutable `@vN` refs remain: `grep -rnE "uses:.*@v[0-9]" .github/workflows/` -> nothing
- [x] No `@latest` remains: `grep -rn "@latest" .github/workflows/` -> nothing
- [x] 61 `uses:` refs SHA-pinned: `grep -rohE "uses:.*@[0-9a-f]{40}" .github/workflows/*.yml | wc -l` -> 61
- [x] Every resolved SHA verified as a real 40-hex commit via the GitHub API
- [ ] CI green on this PR (validates the pinned versions install and run)

Closes #136
Closes #138