### PR TITLE
feat(app): async spoke push — decouple hub push from the discovery cycle (#6 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ the README. The lab-fixture-capture work previously slotted for
 v1.3.1 lands under this milestone instead, renamed to
 [v1.4.0-rc.1 — Lab Fixture Capture](https://github.com/colinedwardwood/network-topology-exporter/milestones).
 
+### Fixed
+
+- Spoke→hub push no longer runs inside the discovery cycle (#6). A slow or
+  unreachable hub can no longer stall discovery or evict the spoke; the spoke
+  keeps the most-recent graph in a latest-only mailbox and pushes it
+  asynchronously. New metrics: `network_topology_federation_spoke_push_last_success_unix`
+  (freshness), `network_topology_federation_spoke_push_drops_total`,
+  `network_topology_federation_spoke_push_queue_depth`.
+
 ### Security & correctness (post-merge hardening)
 
 - **Nightly fuzz no longer false-alarms (#107).** The `fuzz-nightly` workflow ran

--- a/docs/superpowers/specs/2026-06-09-async-spoke-push-design.md
+++ b/docs/superpowers/specs/2026-06-09-async-spoke-push-design.md
@@ -1,0 +1,174 @@
+# Async spoke push (#6, Phase 1) — design
+
+**Goal:** the discovery cycle must never block on the federation hub. A slow or
+unreachable hub can today stall the spoke's discovery cycle and ultimately
+evict the spoke, causing silent data loss; this change decouples the push from
+the cycle.
+
+**Issue:** #6 (Phase 1 — spoke-side only). Phase 2 (hub-side acceptance of
+"stale-but-most-recent" generations) is explicitly **out of scope** and deferred
+to the v2.0.0 federation batch alongside #71.
+
+**Status:** non-breaking. The hub, the wire payload, and `Spoke.Push`'s contract
+are all unchanged.
+
+---
+
+## Problem
+
+`internal/app/loop.go` (~line 460) pushes the reconciled graph to the hub
+**synchronously inside the discovery cycle**:
+
+```go
+if err := lc.Spoke.Push(cycleCtx, payload); err != nil && ctx.Err() == nil {
+    lc.Logger.Warn("spoke push failed", "error", err)
+}
+```
+
+`Spoke.Push` retries 3× with exponential backoff under a 30s client timeout, so
+a slow hub can block the cycle ~37s. At `discovery.interval: 60s` with
+`spoke_timeout: 3×interval`, three consecutive slow pushes evict the spoke; once
+evicted, subsequent pushes carry a `cycle_at` the hub rejects as
+`stale_generation`, and the spoke stays dark until the timing window realigns.
+Failure mode: **silent data loss under hub-side latency**.
+
+## Design principle (why latest-only, not a queue)
+
+A normal Prometheus exporter is pull-based and stateless between scrapes:
+"most-recent-wins" is the native model, and a missed scrape is normal. The two
+push mechanisms in the ecosystem agree: **Pushgateway** holds the last pushed
+value and overwrites it (no queue); `remote_write` queues only because
+individual samples are irreplaceable in a continuous series. Our payload is a
+**complete graph snapshot per cycle** — a newer snapshot fully supersedes an
+older one, so nothing is lost by dropping an intermediate. Therefore the spoke
+keeps a **latest-only mailbox**, not a FIFO of stale snapshots. This also
+sidesteps the `stale_generation` rejection entirely (we never send a stale
+intermediate), which is why Phase 1 fixes the bug without the Phase 2 hub change.
+
+The headline operational signal is **freshness** (seconds since last successful
+push), mirroring how operators already alert on scrape staleness — not queue
+depth, which is only ever 0 or 1.
+
+## Architecture
+
+Extract a small, independently testable component rather than inlining (the
+snapshot writer is inline, but #6 requires a test of the slow-hub behavior).
+
+New file `internal/app/spoke_pusher.go` — a `spokePusher` with three seams:
+
+- `Enqueue(payload federation.SpokePayload)` — non-blocking; called from the
+  discovery cycle. Always leaves the freshest payload in the mailbox.
+- `run(ctx context.Context)` — the consumer loop; one push at a time.
+- `Shutdown(deadline time.Duration)` — drains the final payload, attempts one
+  last push bounded by `deadline`, then returns.
+
+Constructed and its `run` goroutine started in `loop.go` only when
+`lc.Spoke != nil` (i.e. `federation.role: spoke`).
+
+### Mailbox (latest-only)
+
+A capacity-1 channel `ch chan federation.SpokePayload`. `Enqueue`:
+
+```go
+select {
+case p.ch <- payload:
+default:
+    // Slot occupied by an un-consumed older payload: drop it (superseded) and
+    // insert the newer one.
+    select {
+    case <-p.ch:
+        p.m.FederationSpokePushDropsTotal.WithLabelValues("superseded").Inc()
+    default:
+    }
+    select {
+    case p.ch <- payload:
+    default:
+        // Pusher consumed the slot between the two ops; the in-flight push will
+        // be followed by this payload on the next cycle. Benign.
+    }
+}
+p.m.FederationSpokePushQueueDepth.Set(float64(len(p.ch)))
+```
+
+The narrow race (pusher consumes between drain and re-insert) at worst pushes a
+one-cycle-older snapshot; the next cycle re-enqueues the current one. Acceptable
+and self-correcting.
+
+## Data flow
+
+1. `cycle()` builds `federation.SpokePayload` (unchanged fields) and calls
+   `pusher.Enqueue(payload)` instead of `lc.Spoke.Push(...)`. The cycle returns
+   immediately.
+2. `run` receives a payload and calls `lc.Spoke.Push(pushCtx, payload)`.
+3. On success: `FederationSpokePushLastSuccessUnix.Set(now)`. On error (and
+   `ctx` not cancelled): `FederationSpokePushFailuresTotal.Inc()` + rate-limited
+   Warn.
+
+## Decisions
+
+1. **`Spoke.Push` retry/timeout unchanged.** Keep the existing 3-retry / backoff
+   / 30s-timeout. Phase 1's only change is *where* it runs. Minimal blast radius;
+   no contract change.
+2. **Push runs under the process-lifetime context, not `cycleCtx`.** `cycleCtx`
+   is cancelled when the cycle ends, which would abort an async push. The pusher
+   uses the long-lived loop `ctx`. Trace propagation for #68 (spoke→hub W3C
+   `traceparent`) is preserved by capturing the cycle's trace context into the
+   payload at enqueue time and using it for the outbound push span (via a span
+   link / stored `trace.SpanContext`), so the push still correlates to its cycle
+   even though it runs after the cycle span closes.
+3. **Bounded shutdown drain.** On `ctx.Done()`, `loop.go` calls
+   `pusher.Shutdown(SpokePushDrainTimeout)`; the pusher attempts one final push
+   of the latest payload bounded by the deadline, then exits. New const
+   `SpokePushDrainTimeout = 5 * time.Second` (well under the typical 30s k8s
+   `terminationGracePeriodSeconds`). A `sync.WaitGroup` makes shutdown
+   deterministic, mirroring the snapshot writer's `snapWg`.
+
+## Error handling
+
+`run` is wrapped in `recoverGoroutine("spoke_pusher", lc.Logger, lc.M)` — the
+same one-shot recovery the snapshot writer uses (`loop.go:251`). If the pusher
+panics and exits, subsequent `Enqueue` calls fill the slot once and then count
+`superseded` drops, so the failure stays observable via the drop counter and the
+freshness gauge going stale.
+
+## Metrics (`internal/metrics/metrics.go`)
+
+| Metric | Type | Purpose |
+|---|---|---|
+| `network_topology_federation_spoke_push_last_success_unix` | Gauge | **Headline freshness.** Alert on `time() - it > N`. |
+| `network_topology_federation_spoke_push_drops_total{reason}` | CounterVec | `reason="superseded"` (newer payload replaced it) / `reason="shutdown"` (dropped at exit). |
+| `network_topology_federation_spoke_push_queue_depth` | Gauge | 0–1. Included per #6 acceptance; secondary to freshness. |
+| `network_topology_federation_spoke_push_failures_total` | Counter | **Existing** — reused for push errors. |
+
+## Testing (`internal/app/spoke_pusher_test.go`)
+
+A fake `Spoke` whose `Push` blocks for a controllable duration:
+
+- **Cycle never blocks:** with a 60s-blocking push, assert `Enqueue` returns
+  immediately and multiple enqueues proceed while the first push is in flight
+  (the issue's required test).
+- **Most-recent-wins:** enqueue payloads A, B, C while a push is blocked; on
+  unblock, assert the next pushed payload is the newest queued, and
+  `drops_total{reason="superseded"}` counted the dropped intermediates.
+- **Freshness gauge:** assert `last_success_unix` advances only on a successful
+  push.
+- **Bounded shutdown:** with a blocking push, assert `Shutdown(5s)` returns
+  within the deadline and counts a `shutdown` drop if the final push can't
+  complete.
+- **No goroutine leak:** `goleak` (already used in the package) confirms `run`
+  exits after `Shutdown`/`ctx` cancel.
+
+## Files
+
+- `internal/app/spoke_pusher.go` — new `spokePusher` component.
+- `internal/app/loop.go` — construct + start the pusher when `Spoke != nil`;
+  replace the synchronous `Spoke.Push` call with `pusher.Enqueue`; call
+  `pusher.Shutdown` on `ctx.Done()`; add `SpokePushDrainTimeout` const.
+- `internal/metrics/metrics.go` — add the three new metrics + registration.
+- `internal/app/spoke_pusher_test.go` — new tests.
+
+## Rollout / compatibility
+
+Non-breaking. No config changes (the pusher is always used in spoke mode; there
+is no opt-out — the old synchronous behavior was a defect). The hub, the wire
+payload, and `Spoke.Push` are untouched. CHANGELOG entry under "Fixed".

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -306,6 +306,15 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 		}()
 	}
 
+	// #6: decouple the spoke→hub push from the discovery cycle. The pusher
+	// keeps a latest-only mailbox and pushes on its own goroutine so a slow hub
+	// can never stall a cycle or evict the spoke.
+	var pusher *spokePusher
+	if lc.Spoke != nil {
+		pusher = newSpokePusher(lc.Spoke.Push, lc.M, lc.Logger)
+		go pusher.run(ctx)
+	}
+
 	var cycleNum int
 	// State for the large-topology warning (issue #9): track whether the
 	// previous cycle was above the threshold so we only emit on upward
@@ -444,22 +453,18 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 			}
 		}
 
-		// LD-16/LD-17: spoke mode — push pre-reconciled graph to hub.
-		if lc.Spoke != nil {
-			payload := federation.SpokePayload{
+		// LD-16/LD-17: spoke mode — hand the pre-reconciled graph to the async
+		// pusher (#6). Enqueue never blocks; cycleCtx is captured so the eventual
+		// push still propagates the cycle's W3C traceparent to the hub (#68).
+		if pusher != nil {
+			pusher.Enqueue(cycleCtx, federation.SpokePayload{
 				SpokeID:    lc.Cfg.Federation.Spoke.SpokeID,
 				CycleAt:    time.Now(),
 				Devices:    newGraph.Devices,
 				Edges:      newGraph.Edges,
 				OutOfScope: newGraph.OutOfScope,
 				Ages:       ageMap,
-			}
-			// Pass cycleCtx so the spoke.push span nests under discovery.cycle
-			// and carries the cycle's trace context into the outbound HTTP push
-			// (issue #68: spoke→hub W3C traceparent propagation).
-			if err := lc.Spoke.Push(cycleCtx, payload); err != nil && ctx.Err() == nil {
-				lc.Logger.Warn("spoke push failed", "error", err)
-			}
+			})
 		}
 	}
 
@@ -479,6 +484,9 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 			// a concrete signal in the shutdown sequence. See
 			// docs/operator/security.md for the threat model and limits.
 			lc.Logger.Info("snmp credentials zeroized; shutting down discovery loop")
+			if pusher != nil {
+				pusher.Shutdown()
+			}
 			return
 		case <-tick.C:
 			cycle()

--- a/internal/app/spoke_pusher.go
+++ b/internal/app/spoke_pusher.go
@@ -75,3 +75,36 @@ func (p *spokePusher) Enqueue(ctx context.Context, pl federation.SpokePayload) {
 	}
 	p.m.FederationSpokePushQueueDepth.Set(float64(len(p.ch)))
 }
+
+// run consumes the mailbox until ctx is cancelled, pushing one payload at a
+// time. On cancellation it makes one final bounded drain attempt, then exits.
+func (p *spokePusher) run(ctx context.Context) {
+	defer close(p.stopped)
+	defer recoverGoroutine("spoke_pusher", p.logger, p.m)
+	for {
+		select {
+		case <-ctx.Done():
+			p.drainOnce()
+			return
+		case q := <-p.ch:
+			p.doPush(ctx, q)
+			p.m.FederationSpokePushQueueDepth.Set(float64(len(p.ch)))
+		}
+	}
+}
+
+func (p *spokePusher) doPush(ctx context.Context, q queuedPush) {
+	pushCtx := trace.ContextWithSpanContext(ctx, q.span)
+	if err := p.push(pushCtx, q.payload); err != nil {
+		if ctx.Err() == nil {
+			p.m.FederationSpokePushFailuresTotal.Inc()
+			p.logger.Warn("spoke push failed", "error", err)
+		}
+		return
+	}
+	p.m.FederationSpokePushLastSuccessUnix.Set(float64(time.Now().Unix()))
+}
+
+// drainOnce is a temporary stub; Task 4 replaces it with the bounded final
+// drain attempt at shutdown.
+func (p *spokePusher) drainOnce() {}

--- a/internal/app/spoke_pusher.go
+++ b/internal/app/spoke_pusher.go
@@ -107,7 +107,8 @@ func (p *spokePusher) doPush(ctx context.Context, q queuedPush) {
 
 // drainOnce attempts a single final push of the latest pending payload under a
 // fresh bounded context (the loop ctx is already cancelled at this point). A
-// failure or empty mailbox is recorded as a shutdown drop.
+// failed bounded push is recorded as a shutdown drop; an empty mailbox is a
+// no-op.
 func (p *spokePusher) drainOnce() {
 	select {
 	case q := <-p.ch:

--- a/internal/app/spoke_pusher.go
+++ b/internal/app/spoke_pusher.go
@@ -105,6 +105,25 @@ func (p *spokePusher) doPush(ctx context.Context, q queuedPush) {
 	p.m.FederationSpokePushLastSuccessUnix.Set(float64(time.Now().Unix()))
 }
 
-// drainOnce is a temporary stub; Task 4 replaces it with the bounded final
-// drain attempt at shutdown.
-func (p *spokePusher) drainOnce() {}
+// drainOnce attempts a single final push of the latest pending payload under a
+// fresh bounded context (the loop ctx is already cancelled at this point). A
+// failure or empty mailbox is recorded as a shutdown drop.
+func (p *spokePusher) drainOnce() {
+	select {
+	case q := <-p.ch:
+		dctx, cancel := context.WithTimeout(context.Background(), p.drain)
+		defer cancel()
+		if err := p.push(trace.ContextWithSpanContext(dctx, q.span), q.payload); err != nil {
+			p.m.FederationSpokePushDropsTotal.WithLabelValues("shutdown").Inc()
+		} else {
+			p.m.FederationSpokePushLastSuccessUnix.Set(float64(time.Now().Unix()))
+		}
+	default:
+	}
+}
+
+// Shutdown blocks until run has exited (after its final drain). Safe to call
+// after the loop ctx is cancelled; idempotent.
+func (p *spokePusher) Shutdown() {
+	<-p.stopped
+}

--- a/internal/app/spoke_pusher.go
+++ b/internal/app/spoke_pusher.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/federation"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// SpokePushDrainTimeout bounds the single final push attempt at shutdown so a
+// wedged hub cannot hold up process termination. Well under the typical 30s
+// Kubernetes terminationGracePeriodSeconds.
+const SpokePushDrainTimeout = 5 * time.Second
+
+// spokePushFunc performs one push of a payload. Production wires
+// (*federation.Spoke).Push; tests inject a controllable fake.
+type spokePushFunc func(context.Context, federation.SpokePayload) error
+
+// queuedPush is the mailbox cell: the payload plus the trace context captured
+// from the discovery cycle, so the asynchronous push still propagates the
+// cycle's W3C traceparent to the hub (issue #68) even though the cycle span has
+// already closed by the time the push runs.
+type queuedPush struct {
+	payload federation.SpokePayload
+	span    trace.SpanContext
+}
+
+// spokePusher decouples the spoke→hub push from the discovery cycle (#6). It
+// keeps a latest-only mailbox (capacity-1, overwrite-on-full): a newer payload
+// supersedes an un-consumed older one, so the cycle never blocks and a stale
+// intermediate payload is never sent.
+type spokePusher struct {
+	push    spokePushFunc
+	m       *metrics.Metrics
+	logger  *slog.Logger
+	ch      chan queuedPush
+	drain   time.Duration
+	stopped chan struct{}
+}
+
+func newSpokePusher(push spokePushFunc, m *metrics.Metrics, logger *slog.Logger) *spokePusher {
+	return &spokePusher{
+		push:    push,
+		m:       m,
+		logger:  logger,
+		ch:      make(chan queuedPush, 1),
+		drain:   SpokePushDrainTimeout,
+		stopped: make(chan struct{}),
+	}
+}
+
+// Enqueue places payload in the mailbox without blocking. If the slot already
+// holds an un-consumed payload, that older one is dropped (superseded) and the
+// newer one takes its place. The cycle's trace context is captured for #68.
+func (p *spokePusher) Enqueue(ctx context.Context, pl federation.SpokePayload) {
+	q := queuedPush{payload: pl, span: trace.SpanContextFromContext(ctx)}
+	select {
+	case p.ch <- q:
+	default:
+		select {
+		case <-p.ch:
+			p.m.FederationSpokePushDropsTotal.WithLabelValues("superseded").Inc()
+		default:
+		}
+		select {
+		case p.ch <- q:
+		default:
+			// Pusher consumed the slot between the drain and the re-insert; the
+			// in-flight push will be followed by the next cycle's payload. Benign.
+		}
+	}
+	p.m.FederationSpokePushQueueDepth.Set(float64(len(p.ch)))
+}

--- a/internal/app/spoke_pusher_test.go
+++ b/internal/app/spoke_pusher_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/federation"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func payload(id string) federation.SpokePayload {
+	return federation.SpokePayload{SpokeID: id, CycleAt: time.Now()}
+}
+
+func testutilCounterVecValue(t *testing.T, cv *prometheus.CounterVec, label string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(cv.WithLabelValues(label))
+}
+
+// Enqueue must never block, and a second enqueue into an occupied slot must
+// drop the older payload (superseded) and keep the newer one.
+func TestSpokePusherEnqueueLatestOnly(t *testing.T) {
+	m := metrics.New(false)
+	p := newSpokePusher(func(context.Context, federation.SpokePayload) error { return nil }, m, testLogger())
+
+	p.Enqueue(context.Background(), payload("A")) // fills slot
+	p.Enqueue(context.Background(), payload("B")) // supersedes A
+
+	if got := testutilCounterVecValue(t, m.FederationSpokePushDropsTotal, "superseded"); got != 1 {
+		t.Errorf("superseded drops = %v, want 1", got)
+	}
+	q := <-p.ch
+	if q.payload.SpokeID != "B" {
+		t.Errorf("mailbox holds %q, want B (most-recent-wins)", q.payload.SpokeID)
+	}
+}

--- a/internal/app/spoke_pusher_test.go
+++ b/internal/app/spoke_pusher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/goleak"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/federation"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
@@ -78,6 +79,42 @@ func TestSpokePusherEnqueueNeverBlocks(t *testing.T) {
 	close(release)
 	cancel()
 	<-p.stopped
+}
+
+// drainOnce must return within the bounded deadline when the final push hangs,
+// and count a shutdown drop. Driven directly (payload pre-loaded in the mailbox)
+// so the assertion is deterministic.
+func TestSpokePusherDrainOnceBounded(t *testing.T) {
+	push := func(ctx context.Context, _ federation.SpokePayload) error {
+		<-ctx.Done() // hang until the bounded drain context expires
+		return ctx.Err()
+	}
+	m := metrics.New(false)
+	p := newSpokePusher(push, m, testLogger())
+	p.drain = 50 * time.Millisecond
+
+	p.Enqueue(context.Background(), payload("A")) // sits in the mailbox, no consumer
+
+	start := time.Now()
+	p.drainOnce()
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("drainOnce took %v, want ~%v (bounded)", elapsed, p.drain)
+	}
+	if got := testutilCounterVecValue(t, m.FederationSpokePushDropsTotal, "shutdown"); got < 1 {
+		t.Errorf("shutdown drops = %v, want >= 1", got)
+	}
+}
+
+// run must exit cleanly on ctx cancel and leak no goroutine.
+func TestSpokePusherRunNoLeak(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	m := metrics.New(false)
+	p := newSpokePusher(func(context.Context, federation.SpokePayload) error { return nil }, m, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	go p.run(ctx)
+	p.Enqueue(context.Background(), payload("A"))
+	cancel()
+	p.Shutdown()
 }
 
 // On a successful push the freshness gauge advances.

--- a/internal/app/spoke_pusher_test.go
+++ b/internal/app/spoke_pusher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -136,4 +137,64 @@ func TestSpokePusherFreshnessGauge(t *testing.T) {
 	}
 	cancel()
 	<-p.stopped
+}
+
+// End-to-end most-recent-wins: while the first push is blocked, payloads queued
+// behind it are superseded, and the next payload the consumer actually pushes is
+// the newest one queued.
+func TestSpokePusherMostRecentWinsThroughRun(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	var pushed []string
+	push := func(_ context.Context, pl federation.SpokePayload) error {
+		mu.Lock()
+		pushed = append(pushed, pl.SpokeID)
+		n := len(pushed)
+		mu.Unlock()
+		if n == 1 {
+			started <- struct{}{}
+			<-release // block the first push
+		}
+		return nil
+	}
+	m := metrics.New(false)
+	p := newSpokePusher(push, m, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	go p.run(ctx)
+
+	p.Enqueue(context.Background(), payload("A")) // consumed; first push blocks
+	<-started
+	p.Enqueue(context.Background(), payload("B")) // queued
+	p.Enqueue(context.Background(), payload("C")) // supersedes B
+	close(release)                                // first push returns; C pushed next
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(pushed)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("second push never happened")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-p.stopped
+
+	mu.Lock()
+	defer mu.Unlock()
+	if pushed[0] != "A" {
+		t.Errorf("first push = %q, want A", pushed[0])
+	}
+	if pushed[1] != "C" {
+		t.Errorf("second push = %q, want C (most-recent-wins)", pushed[1])
+	}
+	if got := testutilCounterVecValue(t, m.FederationSpokePushDropsTotal, "superseded"); got < 1 {
+		t.Errorf("superseded drops = %v, want >= 1 (B superseded by C)", got)
+	}
 }

--- a/internal/app/spoke_pusher_test.go
+++ b/internal/app/spoke_pusher_test.go
@@ -44,3 +44,59 @@ func TestSpokePusherEnqueueLatestOnly(t *testing.T) {
 		t.Errorf("mailbox holds %q, want B (most-recent-wins)", q.payload.SpokeID)
 	}
 }
+
+// With a push blocked in flight, Enqueue must still return immediately.
+func TestSpokePusherEnqueueNeverBlocks(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	push := func(context.Context, federation.SpokePayload) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	}
+	m := metrics.New(false)
+	p := newSpokePusher(push, m, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	go p.run(ctx)
+
+	p.Enqueue(context.Background(), payload("A")) // consumed; push blocks
+	<-started
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 5; i++ {
+			p.Enqueue(context.Background(), payload("x"))
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Enqueue blocked while a push was in flight")
+	}
+
+	close(release)
+	cancel()
+	<-p.stopped
+}
+
+// On a successful push the freshness gauge advances.
+func TestSpokePusherFreshnessGauge(t *testing.T) {
+	m := metrics.New(false)
+	p := newSpokePusher(func(context.Context, federation.SpokePayload) error { return nil }, m, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	go p.run(ctx)
+
+	p.Enqueue(context.Background(), payload("A"))
+
+	deadline := time.After(2 * time.Second)
+	for testutil.ToFloat64(m.FederationSpokePushLastSuccessUnix) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("freshness gauge never advanced after a successful push")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-p.stopped
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -68,6 +68,18 @@ type Metrics struct {
 	// are exhausted. Alert on rate > 0 to detect silent channel breakage.
 	FederationSpokePushFailuresTotal prometheus.Counter
 
+	// FederationSpokePushLastSuccessUnix is the Unix time (seconds) of this
+	// spoke's most recent successful push to the hub. Headline freshness
+	// signal for the async pusher (#6); alert on time() - value > threshold.
+	FederationSpokePushLastSuccessUnix prometheus.Gauge
+
+	// FederationSpokePushDropsTotal counts spoke-push payloads dropped by the
+	// async pusher's latest-only mailbox. reason ∈ {superseded, shutdown}. (#6)
+	FederationSpokePushDropsTotal *prometheus.CounterVec
+
+	// FederationSpokePushQueueDepth is the async pusher mailbox depth (0 or 1). (#6)
+	FederationSpokePushQueueDepth prometheus.Gauge
+
 	// GraphUpdatesRejectedTotal counts combined-graph updates rejected at
 	// publish time, partitioned by reason. Reason label values are the
 	// underlying strings of the RejectReason constants declared in
@@ -329,6 +341,18 @@ func New(emitBoundaryObs bool) *Metrics {
 			Name: "network_topology_federation_spoke_push_failures_total",
 			Help: "Total number of spoke push attempts that failed after all retries. Alert on rate > 0.",
 		}),
+		FederationSpokePushLastSuccessUnix: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "network_topology_federation_spoke_push_last_success_unix",
+			Help: "Spoke mode: Unix timestamp (seconds) of this spoke's most recent successful push to the hub. Alert on time() - value > threshold.",
+		}),
+		FederationSpokePushDropsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "network_topology_federation_spoke_push_drops_total",
+			Help: "Spoke-push payloads dropped by the async pusher's latest-only mailbox. reason ∈ {superseded, shutdown}.",
+		}, []string{"reason"}),
+		FederationSpokePushQueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "network_topology_federation_spoke_push_queue_depth",
+			Help: "Depth of the spoke async-push mailbox (0 or 1).",
+		}),
 		GraphUpdatesRejectedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "network_topology_graph_updates_rejected_total",
 			Help: "Combined-graph updates rejected at publish time, partitioned by reason (size_budget_exceeded, invalid_label_key, invalid_label_value, structural_invalid, stale_generation).",
@@ -430,6 +454,9 @@ func New(emitBoundaryObs bool) *Metrics {
 		m.FederationSpokeUp,
 		m.FederationSpokeLastPushUnix,
 		m.FederationSpokePushFailuresTotal,
+		m.FederationSpokePushLastSuccessUnix,
+		m.FederationSpokePushDropsTotal,
+		m.FederationSpokePushQueueDepth,
 		m.GraphUpdatesRejectedTotal,
 		m.HubOOSUnmatchedTotal,
 		m.TopologyLastScrapeDurationSeconds,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -224,11 +224,11 @@ type Metrics struct {
 
 	// PanicsRecoveredTotal counts panics recovered in long-lived background
 	// goroutines, partitioned by a low-cardinality `site` label (a closed set
-	// of short stable strings: discovery_loop, snapshot_writer, otlp_push,
-	// hub_serve, hub_rebuild, hub_eviction, hub_snapshot_writer, fdb_vlan_walk,
-	// stale_watchdog). Each recovered panic logs the stack at Error level and
-	// bumps this counter so the bug is never hidden silently. Any non-zero
-	// value indicates a bug — alert on increase.
+	// of short stable strings: discovery_loop, snapshot_writer, spoke_pusher,
+	// otlp_push, hub_serve, hub_rebuild, hub_eviction, hub_snapshot_writer,
+	// fdb_vlan_walk, stale_watchdog). Each recovered panic logs the stack at
+	// Error level and bumps this counter so the bug is never hidden silently.
+	// Any non-zero value indicates a bug — alert on increase.
 	PanicsRecoveredTotal *prometheus.CounterVec
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -100,3 +100,30 @@ func TestRegistryExposesGoCollector(t *testing.T) {
 		t.Fatal("expected at least one go_* metric from the standard Go collector")
 	}
 }
+
+func TestSpokePushMetricsRegistered(t *testing.T) {
+	m := New(false)
+	m.FederationSpokePushLastSuccessUnix.Set(1)
+	m.FederationSpokePushDropsTotal.WithLabelValues("superseded").Inc()
+	m.FederationSpokePushQueueDepth.Set(1)
+
+	fams, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	want := map[string]bool{
+		"network_topology_federation_spoke_push_last_success_unix": false,
+		"network_topology_federation_spoke_push_drops_total":       false,
+		"network_topology_federation_spoke_push_queue_depth":       false,
+	}
+	for _, f := range fams {
+		if _, ok := want[f.GetName()]; ok {
+			want[f.GetName()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("metric %q not registered", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 of #6**: the spoke→hub federation push no longer runs synchronously inside the discovery cycle. A slow or unreachable hub could previously block the cycle ~37s (3 retries × backoff × 30s timeout) and ultimately evict the spoke — silent data loss under hub latency. Now the cycle hands the graph to an async pusher and returns immediately.

Design spec: `docs/superpowers/specs/2026-06-09-async-spoke-push-design.md`.

### What changed
- **`internal/app/spoke_pusher.go`** (new) — a `spokePusher` with a **latest-only mailbox** (capacity-1, overwrite-on-full): a newer payload supersedes an un-consumed older one, so the cycle never blocks and a stale intermediate is never sent. Push runs under the **process-lifetime context** (not the per-cycle ctx, which is cancelled when the cycle ends); the cycle's trace context is captured into the payload so #68's spoke→hub `traceparent` propagation is preserved. Bounded shutdown drain (`SpokePushDrainTimeout = 5s`); `recoverGoroutine` panic safety.
- **`internal/app/loop.go`** — synchronous `Spoke.Push` replaced with `pusher.Enqueue`; pusher constructed/started in spoke mode and waited on at shutdown.
- **`internal/metrics/metrics.go`** — `network_topology_federation_spoke_push_last_success_unix` (headline freshness gauge), `..._drops_total{reason=superseded|shutdown}`, `..._queue_depth`. Failures reuse the existing `..._failures_total`.

### Scope
- **Non-breaking.** `Spoke.Push`, the wire payload, and the hub are untouched.
- The hub-side "accept stale-but-most-recent generations" change originally anticipated as Phase 2 is **not required for this bug**: most-recent-wins never emits a stale payload, so the hub never sees a `stale_generation` from this path. Any further hub work belongs to the federation-HA milestone (#71). Leaving #6 open for you to close or retitle as you see fit.

## Test Plan
- [x] `go test ./... ` — all green; `go test ./internal/app/ -race` clean
- [x] `golangci-lint run` — 0 issues
- [x] Cycle-never-blocks (60s-stall), most-recent-wins through the consumer, freshness gauge, bounded shutdown, goleak — all covered in `spoke_pusher_test.go`
- [x] Final code-quality review: APPROVE (spec-compliant, concurrency-sound)