### PR TITLE
ci: fuzz-short fails only on real crashers, not fuzztime deadlines (#143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,15 +84,35 @@ jobs:
       # coverage-guided engine more thoroughly.
       - name: fuzz parsers
         run: |
-          set -e
+          set -uo pipefail
+          # Only a GENUINE crasher fails this job (#143, same fix as the nightly
+          # job's #107/#126). On a loaded runner a 30s fuzztime pass can exit with
+          # a benign "context deadline exceeded" and no crasher — that must NOT
+          # red the PR. -timeout has generous headroom over -fuzztime so the test
+          # deadline never races the fuzz deadline; we fail only when Go actually
+          # wrote a minimised crashing input ("Failing input written") or panicked.
+          crash=0
           for pkg in bgp fdb ospf mpls lldp snmp; do
-            cd "$GITHUB_WORKSPACE"
             FUZZ_TARGETS=$(go test -list 'Fuzz.*' "./internal/discovery/$pkg" | grep '^Fuzz')
             for t in $FUZZ_TARGETS; do
               echo "▼ $pkg.$t"
-              go test -run=NONE -fuzz="^$t\$" -fuzztime=30s "./internal/discovery/$pkg"
+              if out=$(go test -run=NONE -fuzz="^$t\$" -fuzztime=30s -timeout=2m "./internal/discovery/$pkg" 2>&1); then
+                printf '%s\n' "$out"
+                continue
+              fi
+              printf '%s\n' "$out"
+              if printf '%s\n' "$out" | grep -qE 'Failing input written|^[[:space:]]*panic:'; then
+                echo "::error::fuzz crash found in $pkg.$t — crasher written to testdata/fuzz/"
+                crash=1
+              elif printf '%s\n' "$out" | grep -q 'context deadline exceeded'; then
+                echo "::warning::$pkg.$t reached the fuzztime deadline with no crasher (benign); continuing"
+              else
+                echo "::error::$pkg.$t fuzz run failed for a non-crash reason (build/setup); investigate"
+                crash=1
+              fi
             done
           done
+          exit "$crash"
 
       - name: upload fuzz corpus on failure
         if: failure()


### PR DESCRIPTION
## Summary
Closes #143. The per-PR `fuzz (short, every PR)` job in `ci.yml` flaked on `context deadline exceeded` (a starved 30s fuzztime pass on a loaded runner), reddening PRs with no actual crash — it blocked #134 and #142 (×2) this week.

Mirrors the fix PR #126 already applied to the **nightly** `fuzz-nightly.yml` job, scaled to the short pass:
- `-fuzztime=30s -timeout=2m` (timeout has generous headroom, so the test deadline never races the fuzz deadline)
- capture each run's output; fail **only** on a genuine crasher (`Failing input written` / `panic:`); treat `context deadline exceeded` as a benign `::warning::` and continue; still fail on non-crash build/setup errors.

Crash detection is unchanged — a real fuzz find still fails the job and uploads the corpus artifact.

## Test Plan
- [x] `ci.yml` YAML parses
- [x] Local: happy-path fuzz run exits 0 through the new `if out=$(...)` wrapper
- [x] Local: decision logic verified — `Failing input written`→fail, `context deadline exceeded`→pass, other error→fail
- [x] This PR's own `fuzz (short)` job exercises the fixed logic