### PR TITLE
feat: RFC 8345/8346 YANG-JSON topology output at GET /topology/yang (#75)

### DIFF
--- a/.github/workflows/yang-validate.yml
+++ b/.github/workflows/yang-validate.yml
@@ -1,0 +1,26 @@
+name: yang-validate
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  yang-validate:
+    name: yanglint RFC 8345 validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: '1.26.4'
+          cache: true
+      - name: install yanglint (libyang)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends yang-tools
+      - name: load-closure smoke (all modules resolve)
+        run: yanglint -p yang yang/*.yang
+      - name: generate adversarial instance
+        run: YANG_VALIDATE_OUT="$RUNNER_TEMP/topo.json" go test ./internal/output/yang/ -run TestGenerateValidationDoc
+      - name: validate instance against the model
+        run: yanglint -p yang yang/*.yang "$RUNNER_TEMP/topo.json"

--- a/.github/workflows/yang-validate.yml
+++ b/.github/workflows/yang-validate.yml
@@ -16,8 +16,21 @@ jobs:
         with:
           go-version: '1.26.4'
           cache: true
-      - name: install yanglint (libyang)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends yang-tools
+      - name: install yanglint (build libyang from source, pinned)
+        # No reliable distro package across runner images (Ubuntu 24.04 has no
+        # `yang-tools`), so build libyang at a pinned release.
+        env:
+          LIBYANG_VERSION: v2.1.148
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential cmake libpcre2-dev git
+          git clone --depth 1 --branch "$LIBYANG_VERSION" https://github.com/CESNET/libyang.git /tmp/libyang
+          cmake -S /tmp/libyang -B /tmp/libyang/build -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=OFF
+          cmake --build /tmp/libyang/build -j"$(nproc)"
+          sudo cmake --install /tmp/libyang/build
+          sudo ldconfig
+          yanglint --version
       - name: load-closure smoke (all modules resolve)
         run: yanglint -p yang yang/*.yang
       - name: generate adversarial instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ the README. The lab-fixture-capture work previously slotted for
 v1.3.1 lands under this milestone instead, renamed to
 [v1.4.0-rc.1 — Lab Fixture Capture](https://github.com/colinedwardwood/network-topology-exporter/milestones).
 
+### Added
+
+- RFC 8345/8346 YANG-JSON topology output (#75). When `output.yang.enabled` is
+  set, `GET /topology/yang` renders the current reconciled topology as RFC 8345
+  `ietf-network` JSON (8346 l3-unicast network-type marker; `ntx-topology`
+  augmentation for discovery provenance), validated in CI with `yanglint`.
+
 ### Fixed
 
 - Spoke→hub push no longer runs inside the discovery cycle (#6). A slow or

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -302,6 +302,12 @@ snapshot:
 #       # (ParentBased). Default 0.1. Use 1.0 to trace every cycle while
 #       # debugging; keep it small in production to bound trace volume.
 #       sample_rate: 0.1              # default 0.1; [0, 1]
+#   # RFC 8345 YANG-JSON topology output (#75). When enabled, GET /topology/yang
+#   # renders the current reconciled topology as RFC 8345/8346 YANG-JSON (same
+#   # trust level as /metrics).
+#   yang:
+#     enabled: false
+#     network_id: network-topology-exporter
 
 # ─── Per-device enrichment ─────────────────────────────────────────────────
 # Targets attach enrichment metadata (SNMP port, site label, custom labels)

--- a/deploy/helm/topology-exporter/values.schema.json
+++ b/deploy/helm/topology-exporter/values.schema.json
@@ -442,6 +442,19 @@
           "type": "array",
           "description": "Static device targets to always include in discovery.",
           "items": { "type": "object", "additionalProperties": true }
+        },
+        "output": {
+          "type": "object",
+          "properties": {
+            "otlp": { "type": "object" },
+            "yang": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "network_id": { "type": "string" }
+              }
+            }
+          }
         }
       }
     },

--- a/docs/operator/yang-topology.md
+++ b/docs/operator/yang-topology.md
@@ -1,12 +1,13 @@
 # RFC 8345 YANG topology mapping
 
-> **Status: design reference (v2.0.0).** This document defines how the
+> **Status: implemented behind a flag (#75).** This document defines how the
 > exporter's in-memory topology graph maps onto the RFC 8345 / RFC 8346 YANG
-> data models. The YANG output path itself is planned for v2.0.0 behind
-> `output.yang.enabled: false` (tracked in #75); this document is the mapping
-> contract the implementation and its `pyang`/`yanglint` conformance tests will
-> follow. It is published now so the mapping is reviewable independently of the
-> code.
+> data models. The YANG output path is implemented and ships disabled by default
+> behind `output.yang.enabled: false`; when enabled, `GET /topology/yang`
+> renders the current reconciled topology as RFC 8345/8346 YANG-JSON (see
+> [Accessing the output](#accessing-the-output)). This document remains the
+> mapping contract, and the emitted document is validated against the canonical
+> modules with `yanglint` in CI (the `yang-validate` workflow).
 
 ## Why YANG
 
@@ -115,7 +116,9 @@ record per physical/logical link with a `Direction` flag, so:
 `DiscoveryProto`, `LinkKind`, `Direction`, `Confidence`, and `Adjacency` have no
 home in base RFC 8345/8346. They are the exporter's reconciliation provenance
 and are too useful to drop. They are carried under a small **vendor
-augmentation module** (working name `ntx-topology`, namespace TBD) that adds:
+augmentation module** (`ntx-topology`, namespace
+`https://github.com/colinedwardwood/network-topology-exporter/yang/ntx-topology`)
+that adds:
 
 - `link/ntx-topology:discovery-protocol` (enum mirroring `DiscoveryProtocol`)
 - `link/ntx-topology:link-kind`
@@ -160,15 +163,40 @@ Two switches with a confirmed bidirectional LLDP link `leaf1:Gi0/1 ↔ spine1:Gi
 }
 ```
 
-## Planned emission and validation (v2.0.0)
+## Accessing the output
 
-- **Config:** `output.yang.enabled` (default `false`) plus a destination
-  (file path written each cycle, parallel to the snapshot, and/or a
-  read endpoint). Exact surface decided when #75 is implemented.
-- **Conformance CI:** a job validates the emitted document against the canonical
-  RFC 8345 / RFC 8346 modules (plus the `ntx-topology` augmentation) using
-  `pyang` and `yanglint`. The mapping above is the contract those tests assert.
-- **Known gaps to encode as test expectations:** empty `l3-node-attributes`
+Enable the output in config:
+
+```yaml
+output:
+  yang:
+    enabled: true            # default false
+    network_id: my-fabric    # optional; default "network-topology-exporter"
+```
+
+When enabled, `GET /topology/yang` on the main listen port returns the current
+reconciled topology as RFC 8345/8346 YANG-JSON with
+`Content-Type: application/yang-data+json`. The `network_id` (config or the
+default) is emitted as the single `network`'s `network-id`.
+
+This read carries the **same trust level as `/metrics`**: it is served on the
+same listener with the same auth posture (no auth in the default ground state;
+basic_auth/mTLS when `listen.web_config_file` is configured). It is a
+RESTCONF-*flavored* convenience read — a single GET that returns a YANG-JSON
+document — **not** a conformant RESTCONF datastore: there is no
+`/restconf/data` tree, no query parameters, no edit/PATCH semantics, and no
+NETCONF datastore behind it.
+
+## Emission and validation
+
+- **Config:** `output.yang.enabled` (default `false`) plus optional
+  `output.yang.network_id`. The output is a read endpoint
+  (`GET /topology/yang`), not a file written each cycle.
+- **Conformance CI:** the `yang-validate` workflow validates an adversarial
+  emitted document against the canonical RFC 8345 / RFC 8346 modules (plus the
+  `ntx-topology` augmentation) with `yanglint`. The mapping above is the
+  contract those checks assert.
+- **Known gaps encoded as test expectations:** empty `l3-node-attributes`
   (no router-id/prefix collection today); termination-points are derived from
   observed edges, so a device with no discovered links contributes a node with
   no termination-points.

--- a/docs/superpowers/specs/2026-06-09-yang-emission-design.md
+++ b/docs/superpowers/specs/2026-06-09-yang-emission-design.md
@@ -47,7 +47,10 @@ reconciled graph on demand.
   topology before the first cycle.
 - `Content-Type: application/yang-data+json` (RFC 8040 media type). Documented as
   a RESTCONF-flavored convenience read, **not** a conformant RESTCONF datastore.
-- **Method:** only `GET`/`HEAD`; others → `405`.
+- **Method [AR2/I2]:** `GET` and `HEAD` only. `net/http` does not synthesize HEAD
+  for a `HandlerFunc`, so handle it explicitly: set `Content-Type` and
+  `Content-Length` (from the cached/rendered bytes) and write **no body** for HEAD.
+  Any other method → `405` with an `Allow: GET, HEAD` header (RFC 7231 §6.5.5).
 
 ## Architecture
 
@@ -69,8 +72,17 @@ New package `internal/output/yang`, split for testability:
   rendered bytes keyed on the snapshot pointer identity — re-render only when
   `CurrentGraph()` returns a different pointer — so repeated GETs of an unchanged
   graph are O(1). The published graph is immutable after the cycle swaps it in
-  (verified: each cycle allocates a fresh `Graph`), so pointer identity is a sound
-  cache key and `atomic.Pointer.Load()` is race-free.
+  (verified: each cycle allocates a fresh `Graph` via `Update(g)` storing `&g`), so
+  pointer identity is a sound cache key.
+  **[AR2/I1] Cache concurrency:** the handler's cache is itself shared mutable state
+  read/written by concurrent GETs, so it must NOT be plain struct fields (data race).
+  Hold it as a single `atomic.Pointer[renderCache]` where
+  `renderCache struct { key *discovery.Graph; bytes []byte }` is immutable once
+  built. On GET: `c := cache.Load()`; if `c == nil || c.key != CurrentGraph()`,
+  render and `cache.Store(&renderCache{key, bytes})`. Two concurrent GETs racing a
+  fresh pointer may both render — harmless, since `Render` is pure and deterministic
+  (identical bytes) and the store is last-writer-wins. A `go test -race` test with
+  concurrent GETs during a graph swap is required.
 - `internal/app/app.go` — construct the handler with the collector as
   `GraphSource` and the loop's `Ready` bool; `mux.HandleFunc("/topology/yang", …)`
   only when `cfg.Output.YANG.Enabled`.
@@ -90,11 +102,16 @@ arbitrary key strings. The renderer must therefore enforce, with unit tests:
    populated independently); synthesize a minimal `node` for any such referenced
    device so no link dangles.
 3. **Key uniqueness:** `node-id` unique across nodes; `tp-id` unique within a
-   node; `link-id` unique across links. `link-id` is derived from the full tuple
-   `<src-node>:<src-tp>-<dst-node>:<dst-tp>` plus a direction discriminator on the
-   reverse link of a bidirectional edge (per the mapping doc). A
+   node; `link-id` unique across links. `link-id` is computed from the link's
+   **own** endpoints — `<source-node>:<source-tp>-<dest-node>:<dest-tp>` — so the
+   forward and reverse links of a bidirectional edge differ naturally (forward
+   `leaf1:Gi0/1-spine1:Gi0/2`, reverse `spine1:Gi0/2-leaf1:Gi0/1`, matching the
+   committed doc's worked example — no separate discriminator needed). For the
+   residual collision cases (parallel edges between the same endpoint pair from
+   different protocols, or a self-loop with equal tps), append a stable
+   discriminator `#<discovery-proto>` and, if still colliding, `#<n>`. A
    `TestRenderLinkIDsUnique` asserts no collision on an adversarial graph
-   (parallel edges, multiple protocols between the same pair).
+   (parallel multi-protocol edges between the same pair; self-loop).
 4. **Empty/degenerate inputs:** `source-tp`/`dest-tp` are *optional* leafs in
    RFC 8345, so when `SrcPort`/`DstPort` is empty the link **omits** the
    `source-tp`/`dest-tp` (and no empty tp is created) — cleaner and valid, vs.
@@ -117,13 +134,44 @@ type YANGOutputConfig struct {
 ```
 `values.schema.json` (Helm) and `config/example.yaml` updated to match.
 
+## The `ntx-topology` augmentation module [AR2/C1]
+
+Concretely defined (the committed mapping doc left these `TBD`):
+
+- **namespace:** `https://github.com/colinedwardwood/network-topology-exporter/yang/ntx-topology`
+- **prefix:** `ntx` · **revision:** `2026-06-09`
+- **imports:** `ietf-network` (`nw`), `ietf-network-topology` (`nt`)
+- **augment targets** (absolute schema-tree paths, each step prefixed by the module
+  that *defines* it — `nt:link` is contributed to `nw:network` by an
+  `ietf-network-topology` augment, which is legal to further-augment):
+  - `/nw:networks/nw:network/nt:link` → leaves `discovery-protocol`, `link-kind`,
+    `confidence`, `adjacency`
+  - `/nw:networks/nw:network/nw:node` → leaves `vendor`, `model`, `os-version`, `site`
+- **enum leaves use plain `enumeration`** whose `enum` names are **byte-identical to
+  the Go wire constants** so the renderer can emit `string(e.DiscoveryProto)` directly:
+  - `discovery-protocol`: `lldp cdp bgp ospf fdb isis mpls_te configured` (note the
+    underscore in `mpls_te` — matches `discovery.DiscoveryProtocolMPLSTE`)
+  - `link-kind`: `ethernet mpls-te ip logical` (note the hyphen in `mpls-te`)
+  - `confidence`: `high medium low`
+  - `adjacency`: `direct indirect unknown`
+  - node leaves (`vendor`/`model`/`os-version`/`site`) are `type string`.
+- **Parity test (required):** a Go test asserts every constant returned valid by
+  `DiscoveryProtocol.Valid()` / `LinkKind.Valid()` / `Confidence.Valid()` /
+  `Adjacency.Valid()` (`internal/discovery/discovery.go:125-249`) has a matching
+  `enum` in the module, so the schema and the wire values can never drift (a new
+  protocol constant without a matching enum fails CI, not production).
+
 ## Validation (CI) [AR/C3]
 
-- Vendor the import closure under `yang/`: `ietf-network`, `ietf-network-topology`,
-  `ietf-inet-types`, `ietf-yang-types`, `ietf-l3-unicast-topology`, plus the new
-  `ntx-topology.yang` augmentation (enums mirroring `DiscoveryProtocol`/`LinkKind`/
-  `Confidence`/`Adjacency`; node leaves vendor/model/os-version/site). Offline,
-  reproducible — not fetched at build time.
+- Vendor the **complete** import closure under `yang/` **[AR2/Fatal]**:
+  `ietf-network`, `ietf-network-topology`, `ietf-inet-types`, `ietf-yang-types`,
+  `ietf-l3-unicast-topology`, **`ietf-routing-types` (RFC 8294 — imported by
+  `ietf-l3-unicast-topology`; without it `yanglint` cannot load the schema and the
+  whole job fails)**, plus the new `ntx-topology.yang` augmentation. `ietf-routing-types`'s
+  own closure (`ietf-yang-types`, `ietf-inet-types`) is already covered, so that one
+  module completes the set. Offline, reproducible — not fetched at build time.
+  The plan must `yanglint`-load all modules with no instance doc as a first step to
+  prove the closure resolves before any instance validation.
 - New workflow job `yang-validate`: install `yanglint`; run a small generator
   (`go test`-driven or `go run`) that calls `Render` on an **adversarial fixture
   graph** — empty port, edge whose endpoint device is absent from `Devices`, a
@@ -140,17 +188,25 @@ type YANGOutputConfig struct {
   (the leaf1↔spine1 bidirectional case → two links); structural tests for the four
   correctness guarantees above; determinism (render twice → identical bytes).
 - `handler_test.go` (`httptest`): `200` + valid JSON when ready; `503` before
-  `Ready`; `404`/not-registered when disabled; `405` on POST; cache hit returns
+  `Ready`; `404`/not-registered when disabled; `405` + `Allow: GET, HEAD` on POST;
+  `HEAD` returns headers (incl. `Content-Length`) and no body; cache hit returns
   identical bytes and does not re-render (assert via a counting `GraphSource`).
-- yanglint validation in CI as above.
+- `handler_test.go` `-race`: concurrent GETs while the `GraphSource` swaps the
+  graph pointer — must be clean under `-race` **[AR2/I1]**.
+- `ntx_parity_test.go`: every `Valid()` constant of `DiscoveryProtocol`/`LinkKind`/
+  `Confidence`/`Adjacency` has a matching `enum` in `ntx-topology.yang` **[AR2/C1]**.
+- yanglint: first load all vendored modules with no instance (proves the import
+  closure resolves, incl. `ietf-routing-types`), then validate the adversarial
+  instance doc.
 
 ## Files
 
-- `internal/output/yang/{types.go,render.go,handler.go,render_test.go,handler_test.go}` (new)
+- `internal/output/yang/{types.go,render.go,handler.go,render_test.go,handler_test.go,ntx_parity_test.go}` (new)
 - `internal/metrics/topology_collector.go` — add `CurrentGraph() *discovery.Graph`
 - `internal/app/app.go` — register the endpoint when enabled
 - `internal/config/config.go` + `deploy/helm/topology-exporter/values.schema.json` + `config/example.yaml` — the `yang` block
-- `yang/*.yang` (vendored modules + `ntx-topology.yang`)
+- `yang/` — vendored `ietf-network`, `ietf-network-topology`, `ietf-inet-types`,
+  `ietf-yang-types`, `ietf-l3-unicast-topology`, `ietf-routing-types`, + new `ntx-topology.yang`
 - `.github/workflows/` — `yang-validate` job (or a job in an existing workflow)
 - `docs/operator/yang-topology.md` — resolve the two `TBD`s (augmentation namespace URI; flip status planned→implemented; add the `GET /topology/yang` usage)
 - `CHANGELOG.md` — Features entry

--- a/docs/superpowers/specs/2026-06-09-yang-emission-design.md
+++ b/docs/superpowers/specs/2026-06-09-yang-emission-design.md
@@ -1,0 +1,162 @@
+# RFC 8345 YANG topology emission (#75) — implementation design
+
+**Goal:** expose the reconciled topology as RFC 8345 / RFC 8346 YANG-JSON at a pull
+endpoint, behind `output.yang.enabled: false`, validated in CI with `yanglint`.
+
+**Source of truth for the data mapping:** the already-committed, reviewed
+`docs/operator/yang-topology.md` (PR #93). This spec does **not** restate the
+mapping; it honors that contract verbatim and covers what that doc does not:
+delivery, renderer architecture, correctness guarantees, validation, security,
+config, and files. Where this spec and the mapping doc could drift, the mapping
+doc wins (and we update it to resolve its two open `TBD`s — the augmentation
+namespace URI, and "planned" → "implemented").
+
+This design was revised after an adversarial review (2026-06-09) that caught the
+original draft contradicting the committed contract. Decisions taken from that
+review are marked **[AR]**.
+
+## Scope (confirmed)
+
+- Honor the committed contract: one `network` with
+  `network-types: { ietf-l3-unicast-topology:l3-unicast-topology: {} }` (RFC 8346
+  marker); `l3-node-attributes` (router-id/prefixes) **omitted** — documented gap,
+  not collected. This is 8345 structure + the 8346 type declaration, not "8345
+  only" and not "full 8346".
+- `Device → node`; incident ports → `termination-point`; `Edge → link` with
+  **bidirectional → two links**, unidirectional → one. Rich metadata in the
+  `ntx-topology` augmentation (plain `enumeration` leaves).
+- **Out of scope:** populating L3 attributes (no router-id/prefix collection),
+  any push/file delivery, multiple `network` instances, RESTCONF datastore
+  semantics.
+
+## Delivery
+
+A pull HTTP endpoint **`GET /topology/yang`** on the existing mux/port (default
+`:9100`), registered only when `output.yang.enabled`. It renders the **current**
+reconciled graph on demand.
+
+- **Trust level = same as `/metrics`** (confirmed). The endpoint exposes no data
+  `/metrics` doesn't already expose (device IDs, vendor/OS, ports, edges); it
+  inherits whatever web-auth the mux carries. The operator-facing doc states
+  plainly that this is the full topology as one structured document, so operators
+  who treat `/metrics` as sensitive treat this the same. No separate auth gate.
+- **`503` before readiness [AR/M1]:** key the not-ready response on the existing
+  `Ready *atomic.Bool` (the `/readyz` gate), **not** a nil-graph check — the
+  collector stores a non-nil *empty* graph at init (`topology_collector.go`
+  `c.snap.Store(&empty)`), so a nil check would serve `200` with an empty
+  topology before the first cycle.
+- `Content-Type: application/yang-data+json` (RFC 8040 media type). Documented as
+  a RESTCONF-flavored convenience read, **not** a conformant RESTCONF datastore.
+- **Method:** only `GET`/`HEAD`; others → `405`.
+
+## Architecture
+
+New package `internal/output/yang`, split for testability:
+
+- `types.go` — Go structs modeling the RFC 8345/8346 JSON with `encoding/json`
+  tags carrying the **RFC 7951** module-qualified member names (e.g.
+  `ietf-network-topology:link`, `ntx-topology:discovery-protocol`). **[AR/C3]**
+  Rendering via typed structs + `encoding/json`, never string concatenation —
+  this removes the namespace-prefix bug class at the source.
+- `render.go` — `Render(g *discovery.Graph, cfg Config) ([]byte, error)`: pure,
+  no I/O. Builds nodes, termination-points, links from the graph per the mapping
+  contract. Deterministic output (sort nodes by node-id, tps by tp-id, links by
+  link-id) so byte output is stable for golden tests and cache keys.
+- `handler.go` — `Handler(src GraphSource, ready *atomic.Bool, cfg Config) http.HandlerFunc`.
+  `GraphSource` is a one-method interface `CurrentGraph() *discovery.Graph`
+  satisfied by the `TopologyCollector` (add that accessor; it already holds
+  `snap atomic.Pointer[discovery.Graph]`). **[AR/I3]** The handler caches the last
+  rendered bytes keyed on the snapshot pointer identity — re-render only when
+  `CurrentGraph()` returns a different pointer — so repeated GETs of an unchanged
+  graph are O(1). The published graph is immutable after the cycle swaps it in
+  (verified: each cycle allocates a fresh `Graph`), so pointer identity is a sound
+  cache key and `atomic.Pointer.Load()` is race-free.
+- `internal/app/app.go` — construct the handler with the collector as
+  `GraphSource` and the loop's `Ready` bool; `mux.HandleFunc("/topology/yang", …)`
+  only when `cfg.Output.YANG.Enabled`.
+
+## Correctness guarantees the validator will NOT give us [AR/C1,C2]
+
+RFC 8345's leafrefs (`source-node`, `source-tp`, `dest-node`, `dest-tp`) are
+`require-instance false`, and its keys (`node-id`/`tp-id`/`link-id`/`network-id`)
+are pattern-free `inet:uri`. So `yanglint` will accept dangling references and
+arbitrary key strings. The renderer must therefore enforce, with unit tests:
+
+1. **Termination-point completeness:** every `source-tp`/`dest-tp` a link
+   references is declared as a `termination-point` under its node. Build the tp
+   set per node from *all* incident edges first, then emit links.
+2. **Node completeness:** every `source-node`/`dest-node` exists as a `node`.
+   Edges may reference a device not present in `Graph.Devices` (the slices are
+   populated independently); synthesize a minimal `node` for any such referenced
+   device so no link dangles.
+3. **Key uniqueness:** `node-id` unique across nodes; `tp-id` unique within a
+   node; `link-id` unique across links. `link-id` is derived from the full tuple
+   `<src-node>:<src-tp>-<dst-node>:<dst-tp>` plus a direction discriminator on the
+   reverse link of a bidirectional edge (per the mapping doc). A
+   `TestRenderLinkIDsUnique` asserts no collision on an adversarial graph
+   (parallel edges, multiple protocols between the same pair).
+4. **Empty/degenerate inputs:** `source-tp`/`dest-tp` are *optional* leafs in
+   RFC 8345, so when `SrcPort`/`DstPort` is empty the link **omits** the
+   `source-tp`/`dest-tp` (and no empty tp is created) — cleaner and valid, vs.
+   inventing a sentinel key. A device with no incident edges → a `node` with no
+   tps and no links; an empty graph → a valid empty `network` (with the
+   `network-types` marker still present).
+
+## Config
+
+```go
+// internal/config/config.go — under OutputConfig
+type OutputConfig struct {
+    OTLP OTLPOutputConfig `yaml:"otlp"`
+    YANG YANGOutputConfig `yaml:"yang"`
+}
+type YANGOutputConfig struct {
+    Enabled   bool   `yaml:"enabled"`    // default false
+    NetworkID string `yaml:"network_id"` // network-id; default "network-topology-exporter"
+}
+```
+`values.schema.json` (Helm) and `config/example.yaml` updated to match.
+
+## Validation (CI) [AR/C3]
+
+- Vendor the import closure under `yang/`: `ietf-network`, `ietf-network-topology`,
+  `ietf-inet-types`, `ietf-yang-types`, `ietf-l3-unicast-topology`, plus the new
+  `ntx-topology.yang` augmentation (enums mirroring `DiscoveryProtocol`/`LinkKind`/
+  `Confidence`/`Adjacency`; node leaves vendor/model/os-version/site). Offline,
+  reproducible — not fetched at build time.
+- New workflow job `yang-validate`: install `yanglint`; run a small generator
+  (`go test`-driven or `go run`) that calls `Render` on an **adversarial fixture
+  graph** — empty port, edge whose endpoint device is absent from `Devices`, a
+  device with no edges, a unicode device ID, parallel multi-protocol edges — and
+  writes the doc; then `yanglint` the modules + the instance doc, failing on any
+  diagnostic. Validating a hand-picked happy path would be theatre; the fixture is
+  built to exercise the shapes production actually emits.
+- Pin the `yanglint`/`libyang` install to a version (no `@latest`), consistent
+  with #136.
+
+## Testing
+
+- `render_test.go`: golden-file for the worked example from the mapping doc
+  (the leaf1↔spine1 bidirectional case → two links); structural tests for the four
+  correctness guarantees above; determinism (render twice → identical bytes).
+- `handler_test.go` (`httptest`): `200` + valid JSON when ready; `503` before
+  `Ready`; `404`/not-registered when disabled; `405` on POST; cache hit returns
+  identical bytes and does not re-render (assert via a counting `GraphSource`).
+- yanglint validation in CI as above.
+
+## Files
+
+- `internal/output/yang/{types.go,render.go,handler.go,render_test.go,handler_test.go}` (new)
+- `internal/metrics/topology_collector.go` — add `CurrentGraph() *discovery.Graph`
+- `internal/app/app.go` — register the endpoint when enabled
+- `internal/config/config.go` + `deploy/helm/topology-exporter/values.schema.json` + `config/example.yaml` — the `yang` block
+- `yang/*.yang` (vendored modules + `ntx-topology.yang`)
+- `.github/workflows/` — `yang-validate` job (or a job in an existing workflow)
+- `docs/operator/yang-topology.md` — resolve the two `TBD`s (augmentation namespace URI; flip status planned→implemented; add the `GET /topology/yang` usage)
+- `CHANGELOG.md` — Features entry
+
+## Rollout / compatibility
+
+Non-breaking and **off by default** (`output.yang.enabled: false`). No change to
+`/metrics`, OTLP, snapshot, or the discovery loop beyond the read-only
+`CurrentGraph()` accessor. The endpoint is additive.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
+	yangout "github.com/colinedwardwood/network-topology-exporter/internal/output/yang"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snapshot"
 	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 	"github.com/colinedwardwood/network-topology-exporter/internal/version"
@@ -367,6 +368,12 @@ func Run(ctx context.Context, args []string) int {
 
 	mux.HandleFunc("/readyz", httpx.NewReadyzHandler(isReadyFn))
 
+	// Issue #75: opt-in RFC 8345 YANG-JSON pull endpoint. Off by default; when
+	// enabled, GET /topology/yang renders the current reconciled topology. The
+	// handler shares the same readiness flag as /readyz, so it returns 503 until
+	// the first live cycle/push has populated the graph.
+	registerYANG(mux, m.Topology, &ready, cfg.Output.YANG)
+
 	go func() {
 		var serveErr error
 		switch {
@@ -477,6 +484,18 @@ func livenessMaxStale(cfg *config.Config) time.Duration {
 		return 0
 	}
 	return cfg.Discovery.Interval * time.Duration(cycles)
+}
+
+// registerYANG wires the issue-#75 GET /topology/yang endpoint onto mux when
+// output.yang.enabled is true; when disabled it registers nothing, so the route
+// 404s. src is the live graph source (the *metrics.TopologyCollector), ready is
+// the same readiness flag feeding /readyz. Extracted so the wiring contract is
+// unit-testable without standing up the full Run server.
+func registerYANG(mux *http.ServeMux, src yangout.GraphSource, ready *atomic.Bool, cfg config.YANGOutputConfig) {
+	if !cfg.Enabled {
+		return
+	}
+	mux.HandleFunc("/topology/yang", yangout.Handler(src, ready, yangout.Config{NetworkID: cfg.NetworkID}))
 }
 
 // NewLogger returns a slog.Logger configured to emit JSON to stderr at the

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -372,7 +372,7 @@ func Run(ctx context.Context, args []string) int {
 	// enabled, GET /topology/yang renders the current reconciled topology. The
 	// handler shares the same readiness flag as /readyz, so it returns 503 until
 	// the first live cycle/push has populated the graph.
-	registerYANG(mux, m.Topology, &ready, cfg.Output.YANG)
+	registerYANG(mux, m.Topology, isReadyFn, cfg.Output.YANG)
 
 	go func() {
 		var serveErr error
@@ -489,9 +489,10 @@ func livenessMaxStale(cfg *config.Config) time.Duration {
 // registerYANG wires the issue-#75 GET /topology/yang endpoint onto mux when
 // output.yang.enabled is true; when disabled it registers nothing, so the route
 // 404s. src is the live graph source (the *metrics.TopologyCollector), ready is
-// the same readiness flag feeding /readyz. Extracted so the wiring contract is
+// the same readiness func feeding /readyz (isReadyFn), so the YANG endpoint
+// reports ready in hub mode too. Extracted so the wiring contract is
 // unit-testable without standing up the full Run server.
-func registerYANG(mux *http.ServeMux, src yangout.GraphSource, ready *atomic.Bool, cfg config.YANGOutputConfig) {
+func registerYANG(mux *http.ServeMux, src yangout.GraphSource, ready func() bool, cfg config.YANGOutputConfig) {
 	if !cfg.Enabled {
 		return
 	}

--- a/internal/app/yang_endpoint_test.go
+++ b/internal/app/yang_endpoint_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// TestRegisterYANG_Enabled asserts that, with output.yang.enabled true and the
+// server ready, GET /topology/yang returns 200 with the RFC 8345 YANG-JSON
+// content type. It mirrors the real Run wiring: a metrics.New collector
+// (m.Topology), the readiness atomic.Bool that also feeds /readyz, and a plain
+// http.ServeMux, all passed to the same registerYANG helper Run uses.
+func TestRegisterYANG_Enabled(t *testing.T) {
+	t.Parallel()
+
+	m := metrics.New(false)
+	var ready atomic.Bool
+	ready.Store(true) // simulate post-first-cycle readiness
+
+	mux := http.NewServeMux()
+	registerYANG(mux, m.Topology, &ready, config.YANGOutputConfig{Enabled: true, NetworkID: "test-net"})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/topology/yang")
+	if err != nil {
+		t.Fatalf("GET /topology/yang: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/yang-data+json" {
+		t.Fatalf("Content-Type = %q, want application/yang-data+json", ct)
+	}
+}
+
+// TestRegisterYANG_Disabled asserts that, with output.yang.enabled false, the
+// route is never registered, so GET /topology/yang 404s.
+func TestRegisterYANG_Disabled(t *testing.T) {
+	t.Parallel()
+
+	m := metrics.New(false)
+	var ready atomic.Bool
+	ready.Store(true)
+
+	mux := http.NewServeMux()
+	registerYANG(mux, m.Topology, &ready, config.YANGOutputConfig{Enabled: false})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/topology/yang")
+	if err != nil {
+		t.Fatalf("GET /topology/yang: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (route should be unregistered)", resp.StatusCode, http.StatusNotFound)
+	}
+}

--- a/internal/app/yang_endpoint_test.go
+++ b/internal/app/yang_endpoint_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
@@ -13,17 +12,16 @@ import (
 // TestRegisterYANG_Enabled asserts that, with output.yang.enabled true and the
 // server ready, GET /topology/yang returns 200 with the RFC 8345 YANG-JSON
 // content type. It mirrors the real Run wiring: a metrics.New collector
-// (m.Topology), the readiness atomic.Bool that also feeds /readyz, and a plain
+// (m.Topology), the readiness func that also feeds /readyz, and a plain
 // http.ServeMux, all passed to the same registerYANG helper Run uses.
 func TestRegisterYANG_Enabled(t *testing.T) {
 	t.Parallel()
 
 	m := metrics.New(false)
-	var ready atomic.Bool
-	ready.Store(true) // simulate post-first-cycle readiness
+	ready := func() bool { return true } // simulate post-first-cycle readiness
 
 	mux := http.NewServeMux()
-	registerYANG(mux, m.Topology, &ready, config.YANGOutputConfig{Enabled: true, NetworkID: "test-net"})
+	registerYANG(mux, m.Topology, ready, config.YANGOutputConfig{Enabled: true, NetworkID: "test-net"})
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -48,11 +46,10 @@ func TestRegisterYANG_Disabled(t *testing.T) {
 	t.Parallel()
 
 	m := metrics.New(false)
-	var ready atomic.Bool
-	ready.Store(true)
+	ready := func() bool { return true }
 
 	mux := http.NewServeMux()
-	registerYANG(mux, m.Topology, &ready, config.YANGOutputConfig{Enabled: false})
+	registerYANG(mux, m.Topology, ready, config.YANGOutputConfig{Enabled: false})
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,9 +52,18 @@ type ListenConfig struct {
 	DebugListenAddr string `yaml:"debug_listen_addr"`
 }
 
-// OutputConfig holds optional push-mode output paths.
+// OutputConfig holds optional output paths beyond Prometheus /metrics.
 type OutputConfig struct {
 	OTLP OTLPOutputConfig `yaml:"otlp"`
+	YANG YANGOutputConfig `yaml:"yang"`
+}
+
+// YANGOutputConfig configures the RFC 8345 YANG-JSON pull endpoint (#75).
+// Disabled by default; when enabled, GET /topology/yang renders the current
+// reconciled topology as RFC 8345/8346 YANG-JSON.
+type YANGOutputConfig struct {
+	Enabled   bool   `yaml:"enabled"`    // default false
+	NetworkID string `yaml:"network_id"` // RFC 8345 network-id; default applied in defaults
 }
 
 // OTLPOutputConfig configures the OTLP push output.
@@ -525,6 +534,9 @@ func (c *Config) applyDefaults() {
 	if c.Output.OTLP.Traces.SampleRate == nil {
 		def := 0.1
 		c.Output.OTLP.Traces.SampleRate = &def
+	}
+	if c.Output.YANG.NetworkID == "" {
+		c.Output.YANG.NetworkID = "network-topology-exporter"
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadAppliesDefaults(t *testing.T) {
@@ -2544,5 +2546,24 @@ targets: []
 	}
 	if _, err := Load(path); err == nil {
 		t.Fatalf("expected error for negative session_pool.max_idle, got nil")
+	}
+}
+
+func TestOutputYANGConfigParses(t *testing.T) {
+	const y = `
+output:
+  yang:
+    enabled: true
+    network_id: my-net
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !c.Output.YANG.Enabled {
+		t.Error("Output.YANG.Enabled = false, want true")
+	}
+	if c.Output.YANG.NetworkID != "my-net" {
+		t.Errorf("Output.YANG.NetworkID = %q, want my-net", c.Output.YANG.NetworkID)
 	}
 }

--- a/internal/metrics/topology_collector.go
+++ b/internal/metrics/topology_collector.go
@@ -105,6 +105,14 @@ func (c *TopologyCollector) Update(g discovery.Graph) {
 	c.snap.Store(&g)
 }
 
+// CurrentGraph returns the current immutable graph snapshot (the same one
+// Collect reads). Never nil: the constructor stores an empty graph at init.
+// The returned pointer is safe to read concurrently — the graph is replaced,
+// never mutated in place.
+func (c *TopologyCollector) CurrentGraph() *discovery.Graph {
+	return c.snap.Load()
+}
+
 // Describe sends all metric descriptors to ch.
 func (c *TopologyCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.deviceInfoDesc

--- a/internal/metrics/topology_collector_test.go
+++ b/internal/metrics/topology_collector_test.go
@@ -409,3 +409,17 @@ func TestTopologyCollectorDescribeAllDescriptors(t *testing.T) {
 		}
 	}
 }
+
+func TestCurrentGraphReturnsLatest(t *testing.T) {
+	c := newTopologyCollector(false,
+		prometheus.NewGauge(prometheus.GaugeOpts{Name: "t_dur"}),
+		prometheus.NewGauge(prometheus.GaugeOpts{Name: "t_smp"}))
+	if g := c.CurrentGraph(); g == nil {
+		t.Fatal("CurrentGraph returned nil before any Update (init stores empty graph)")
+	}
+	c.Update(discovery.Graph{Devices: []discovery.Device{{ID: "x"}}})
+	g := c.CurrentGraph()
+	if g == nil || len(g.Devices) != 1 || g.Devices[0].ID != "x" {
+		t.Fatalf("CurrentGraph did not return the updated graph: %+v", g)
+	}
+}

--- a/internal/output/yang/handler.go
+++ b/internal/output/yang/handler.go
@@ -1,0 +1,60 @@
+package yang
+
+import (
+	"net/http"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+// GraphSource yields the current immutable topology graph. Satisfied by
+// *metrics.TopologyCollector.
+type GraphSource interface {
+	CurrentGraph() *discovery.Graph
+}
+
+type renderCache struct {
+	key   *discovery.Graph
+	bytes []byte
+}
+
+const contentType = "application/yang-data+json"
+
+// Handler serves the current topology as RFC 8345 YANG-JSON. It returns 503
+// until ready; 405 (+ Allow) on non-GET/HEAD; HEAD returns headers with no
+// body. Renders are cached by graph pointer identity, so repeated GETs of an
+// unchanged graph are O(1). Cache state is an atomic.Pointer over an immutable
+// struct, so concurrent GETs are race-free.
+func Handler(src GraphSource, ready *atomic.Bool, cfg Config) http.HandlerFunc {
+	var cache atomic.Pointer[renderCache]
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if ready == nil || !ready.Load() {
+			http.Error(w, "topology not ready", http.StatusServiceUnavailable)
+			return
+		}
+		g := src.CurrentGraph()
+		c := cache.Load()
+		if c == nil || c.key != g {
+			b, err := Render(g, cfg)
+			if err != nil {
+				http.Error(w, "render error", http.StatusInternalServerError)
+				return
+			}
+			c = &renderCache{key: g, bytes: b}
+			cache.Store(c)
+		}
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Length", strconv.Itoa(len(c.bytes)))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		_, _ = w.Write(c.bytes)
+	}
+}

--- a/internal/output/yang/handler.go
+++ b/internal/output/yang/handler.go
@@ -26,7 +26,7 @@ const contentType = "application/yang-data+json"
 // body. Renders are cached by graph pointer identity, so repeated GETs of an
 // unchanged graph are O(1). Cache state is an atomic.Pointer over an immutable
 // struct, so concurrent GETs are race-free.
-func Handler(src GraphSource, ready *atomic.Bool, cfg Config) http.HandlerFunc {
+func Handler(src GraphSource, ready func() bool, cfg Config) http.HandlerFunc {
 	var cache atomic.Pointer[renderCache]
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -34,7 +34,7 @@ func Handler(src GraphSource, ready *atomic.Bool, cfg Config) http.HandlerFunc {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		if ready == nil || !ready.Load() {
+		if ready == nil || !ready() {
 			http.Error(w, "topology not ready", http.StatusServiceUnavailable)
 			return
 		}

--- a/internal/output/yang/handler_test.go
+++ b/internal/output/yang/handler_test.go
@@ -1,0 +1,108 @@
+package yang
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+type fakeSource struct {
+	mu sync.Mutex
+	g  *discovery.Graph
+}
+
+func (f *fakeSource) CurrentGraph() *discovery.Graph {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.g
+}
+func (f *fakeSource) set(g *discovery.Graph) { f.mu.Lock(); f.g = g; f.mu.Unlock() }
+
+func newReady(v bool) *atomic.Bool { b := &atomic.Bool{}; b.Store(v); return b }
+
+func TestHandler200WhenReady(t *testing.T) {
+	src := &fakeSource{g: &discovery.Graph{Devices: []discovery.Device{{ID: "a"}}}}
+	h := Handler(src, newReady(true), Config{NetworkID: "n"})
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodGet, "/topology/yang", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/yang-data+json" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestHandler503BeforeReady(t *testing.T) {
+	src := &fakeSource{g: &discovery.Graph{}}
+	h := Handler(src, newReady(false), Config{})
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodGet, "/topology/yang", nil))
+	if rr.Code != 503 {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+func TestHandler405(t *testing.T) {
+	h := Handler(&fakeSource{g: &discovery.Graph{}}, newReady(true), Config{})
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodPost, "/topology/yang", nil))
+	if rr.Code != 405 {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+	if a := rr.Header().Get("Allow"); a != "GET, HEAD" {
+		t.Errorf("Allow = %q, want GET, HEAD", a)
+	}
+}
+
+func TestHandlerHEADNoBody(t *testing.T) {
+	src := &fakeSource{g: &discovery.Graph{Devices: []discovery.Device{{ID: "a"}}}}
+	h := Handler(src, newReady(true), Config{})
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodHead, "/topology/yang", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if rr.Body.Len() != 0 {
+		t.Errorf("HEAD wrote a body of %d bytes", rr.Body.Len())
+	}
+	if rr.Header().Get("Content-Length") == "" {
+		t.Error("HEAD must set Content-Length")
+	}
+}
+
+func TestHandlerCacheStableBytes(t *testing.T) {
+	src := &fakeSource{g: &discovery.Graph{Devices: []discovery.Device{{ID: "a"}}}}
+	h := Handler(src, newReady(true), Config{})
+	get := func() string {
+		rr := httptest.NewRecorder()
+		h(rr, httptest.NewRequest(http.MethodGet, "/topology/yang", nil))
+		return rr.Body.String()
+	}
+	first, second := get(), get()
+	if first != second {
+		t.Error("repeated GET of unchanged graph returned different bytes")
+	}
+}
+
+func TestHandlerRaceConcurrentGET(t *testing.T) {
+	src := &fakeSource{g: &discovery.Graph{Devices: []discovery.Device{{ID: "a"}}}}
+	h := Handler(src, newReady(true), Config{})
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%4 == 0 {
+				src.set(&discovery.Graph{Devices: []discovery.Device{{ID: "a"}, {ID: "b"}}})
+			}
+			rr := httptest.NewRecorder()
+			h(rr, httptest.NewRequest(http.MethodGet, "/topology/yang", nil))
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/output/yang/handler_test.go
+++ b/internal/output/yang/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
@@ -22,7 +21,7 @@ func (f *fakeSource) CurrentGraph() *discovery.Graph {
 }
 func (f *fakeSource) set(g *discovery.Graph) { f.mu.Lock(); f.g = g; f.mu.Unlock() }
 
-func newReady(v bool) *atomic.Bool { b := &atomic.Bool{}; b.Store(v); return b }
+func newReady(v bool) func() bool { return func() bool { return v } }
 
 func TestHandler200WhenReady(t *testing.T) {
 	src := &fakeSource{g: &discovery.Graph{Devices: []discovery.Device{{ID: "a"}}}}

--- a/internal/output/yang/ntx_parity_test.go
+++ b/internal/output/yang/ntx_parity_test.go
@@ -1,0 +1,50 @@
+package yang
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+// Every Go wire constant must have a matching enum in ntx-topology.yang, so the
+// schema and the renderer can never drift (a new protocol without an enum fails
+// CI, not production).
+func TestNtxEnumParity(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "yang", "ntx-topology@2026-06-09.yang")
+	b, err := os.ReadFile(path) // #nosec G304 -- path is a fixed in-repo test fixture, no user input
+	if err != nil {
+		t.Fatalf("read ntx module: %v", err)
+	}
+	mod := string(b)
+	has := func(v string) bool { return strings.Contains(mod, `enum "`+v+`"`) }
+
+	for _, v := range []discovery.DiscoveryProtocol{
+		discovery.DiscoveryProtocolLLDP, discovery.DiscoveryProtocolCDP, discovery.DiscoveryProtocolBGP,
+		discovery.DiscoveryProtocolOSPF, discovery.DiscoveryProtocolFDB, discovery.DiscoveryProtocolISIS,
+		discovery.DiscoveryProtocolMPLSTE, discovery.DiscoveryProtocolConfigured,
+	} {
+		if !has(v.String()) {
+			t.Errorf("discovery-protocol enum missing %q", v)
+		}
+	}
+	for _, v := range []discovery.LinkKind{
+		discovery.LinkKindEthernet, discovery.LinkKindMPLSTE, discovery.LinkKindIP, discovery.LinkKindLogical,
+	} {
+		if !has(v.String()) {
+			t.Errorf("link-kind enum missing %q", v)
+		}
+	}
+	for _, v := range []discovery.Confidence{discovery.ConfidenceHigh, discovery.ConfidenceMedium, discovery.ConfidenceLow} {
+		if !has(v.String()) {
+			t.Errorf("confidence enum missing %q", v)
+		}
+	}
+	for _, v := range []discovery.Adjacency{discovery.AdjacencyDirect, discovery.AdjacencyIndirect, discovery.AdjacencyUnknown} {
+		if !has(v.String()) {
+			t.Errorf("adjacency enum missing %q", v)
+		}
+	}
+}

--- a/internal/output/yang/render.go
+++ b/internal/output/yang/render.go
@@ -1,0 +1,143 @@
+package yang
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+const defaultNetworkID = "network-topology-exporter"
+
+// Config controls rendering.
+type Config struct {
+	NetworkID string
+}
+
+// Render maps a reconciled graph to RFC 8345/8346 YANG-JSON (RFC 7951). Pure
+// and deterministic: identical input -> byte-identical output. It guarantees
+// referential integrity (every referenced node/tp is declared) and key
+// uniqueness (node-id, tp-id within a node, link-id) — yanglint does NOT
+// enforce these (require-instance false; pattern-free inet:uri keys).
+func Render(g *discovery.Graph, cfg Config) ([]byte, error) {
+	nid := cfg.NetworkID
+	if nid == "" {
+		nid = defaultNetworkID
+	}
+
+	type nodeAcc struct {
+		dev *discovery.Device
+		tps map[string]bool
+	}
+	nodes := map[string]*nodeAcc{}
+	ensure := func(id string) *nodeAcc {
+		if id == "" {
+			return nil
+		}
+		n := nodes[id]
+		if n == nil {
+			n = &nodeAcc{tps: map[string]bool{}}
+			nodes[id] = n
+		}
+		return n
+	}
+	for i := range g.Devices {
+		d := &g.Devices[i]
+		if d.ID == "" {
+			continue
+		}
+		ensure(d.ID).dev = d
+	}
+	for i := range g.Edges {
+		e := &g.Edges[i]
+		if e.SrcDevice == "" || e.DstDevice == "" {
+			continue
+		}
+		if sp := e.SrcPort; sp != "" {
+			ensure(e.SrcDevice).tps[sp] = true
+		} else {
+			ensure(e.SrcDevice)
+		}
+		if dp := e.DstPort; dp != "" {
+			ensure(e.DstDevice).tps[dp] = true
+		} else {
+			ensure(e.DstDevice)
+		}
+	}
+
+	nodeIDs := make([]string, 0, len(nodes))
+	for id := range nodes {
+		nodeIDs = append(nodeIDs, id)
+	}
+	sort.Strings(nodeIDs)
+	outNodes := make([]Node, 0, len(nodeIDs))
+	for _, id := range nodeIDs {
+		acc := nodes[id]
+		n := Node{NodeID: id}
+		if acc.dev != nil {
+			n.Vendor, n.Model, n.OSVersion, n.Site = acc.dev.Vendor, acc.dev.Model, acc.dev.OSVersion, acc.dev.Site
+		}
+		tps := make([]string, 0, len(acc.tps))
+		for p := range acc.tps {
+			tps = append(tps, p)
+		}
+		sort.Strings(tps)
+		for _, p := range tps {
+			n.TerminationPoint = append(n.TerminationPoint, TerminationPoint{TPID: p})
+		}
+		outNodes = append(outNodes, n)
+	}
+
+	used := map[string]bool{}
+	mkLinkID := func(sn, stp, dn, dtp, proto string) string {
+		base := fmt.Sprintf("%s:%s-%s:%s", sn, stp, dn, dtp)
+		id := base
+		if used[id] {
+			id = base + "#" + proto
+		}
+		for n := 2; used[id]; n++ {
+			id = fmt.Sprintf("%s#%s#%d", base, proto, n)
+		}
+		used[id] = true
+		return id
+	}
+	var outLinks []Link
+	addLink := func(sn, stp, dn, dtp string, e *discovery.Edge) {
+		outLinks = append(outLinks, Link{
+			LinkID:            mkLinkID(sn, stp, dn, dtp, e.DiscoveryProto.String()),
+			Source:            Source{SourceNode: sn, SourceTP: stp},
+			Destination:       Destination{DestNode: dn, DestTP: dtp},
+			DiscoveryProtocol: e.DiscoveryProto.String(),
+			LinkKind:          e.LinkKind.String(),
+			Confidence:        e.Confidence.String(),
+			Adjacency:         e.Adjacency.String(),
+		})
+	}
+	edges := make([]discovery.Edge, len(g.Edges))
+	copy(edges, g.Edges)
+	sort.SliceStable(edges, func(i, j int) bool {
+		a, b := edges[i], edges[j]
+		ka := a.SrcDevice + "\x00" + a.SrcPort + "\x00" + a.DstDevice + "\x00" + a.DstPort + "\x00" + a.DiscoveryProto.String()
+		kb := b.SrcDevice + "\x00" + b.SrcPort + "\x00" + b.DstDevice + "\x00" + b.DstPort + "\x00" + b.DiscoveryProto.String()
+		return ka < kb
+	})
+	for i := range edges {
+		e := &edges[i]
+		if e.SrcDevice == "" || e.DstDevice == "" {
+			continue
+		}
+		addLink(e.SrcDevice, e.SrcPort, e.DstDevice, e.DstPort, e)
+		if e.Direction == discovery.DirectionBidirectional {
+			addLink(e.DstDevice, e.DstPort, e.SrcDevice, e.SrcPort, e)
+		}
+	}
+
+	doc := Document{Networks: Networks{Network: []Network{{
+		NetworkID:    nid,
+		NetworkTypes: NetworkTypes{},
+		Node:         outNodes,
+		Link:         outLinks,
+	}}}}
+	return json.Marshal(doc)
+}

--- a/internal/output/yang/render_test.go
+++ b/internal/output/yang/render_test.go
@@ -1,0 +1,179 @@
+package yang
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+func bidiEdge(sd, sp, dd, dp string, proto discovery.DiscoveryProtocol) discovery.Edge {
+	return discovery.Edge{
+		SrcDevice: sd, SrcPort: sp, DstDevice: dd, DstPort: dp,
+		DiscoveryProto: proto, Direction: discovery.DirectionBidirectional,
+		Confidence: discovery.ConfidenceHigh, LinkKind: discovery.LinkKindEthernet,
+		Adjacency: discovery.AdjacencyDirect,
+	}
+}
+
+func TestRenderWorkedExample(t *testing.T) {
+	g := &discovery.Graph{
+		Devices: []discovery.Device{{ID: "leaf1"}, {ID: "spine1"}},
+		Edges:   []discovery.Edge{bidiEdge("leaf1", "Gi0/1", "spine1", "Gi0/2", discovery.DiscoveryProtocolLLDP)},
+	}
+	b, err := Render(g, Config{NetworkID: "lab"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc Document
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	net := doc.Networks.Network[0]
+	if net.NetworkID != "lab" {
+		t.Errorf("network-id = %q, want lab", net.NetworkID)
+	}
+	if len(net.Node) != 2 {
+		t.Fatalf("nodes = %d, want 2", len(net.Node))
+	}
+	if len(net.Link) != 2 {
+		t.Fatalf("links = %d, want 2 (bidirectional -> fwd+rev)", len(net.Link))
+	}
+	if net.Link[0].LinkID == net.Link[1].LinkID {
+		t.Error("forward and reverse link-id must differ")
+	}
+	if !strings.Contains(string(b), `"ietf-l3-unicast-topology:l3-unicast-topology":{}`) {
+		t.Error("missing l3-unicast network-type marker")
+	}
+}
+
+func TestRenderReferentialIntegrityAndUniqueness(t *testing.T) {
+	g := &discovery.Graph{
+		Devices: []discovery.Device{{ID: "a"}},
+		Edges: []discovery.Edge{
+			bidiEdge("a", "p1", "ghost", "p9", discovery.DiscoveryProtocolLLDP),
+			{SrcDevice: "a", SrcPort: "p1", DstDevice: "ghost", DstPort: "p9",
+				DiscoveryProto: discovery.DiscoveryProtocolCDP, Direction: discovery.DirectionUnidirectional},
+			{SrcDevice: "a", SrcPort: "", DstDevice: "ghost", DstPort: "",
+				DiscoveryProto: discovery.DiscoveryProtocolFDB, Direction: discovery.DirectionUnidirectional},
+		},
+	}
+	b, err := Render(g, Config{NetworkID: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc Document
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	net := doc.Networks.Network[0]
+	nodeIDs := map[string]bool{}
+	tpByNode := map[string]map[string]bool{}
+	for _, n := range net.Node {
+		if nodeIDs[n.NodeID] {
+			t.Errorf("duplicate node-id %q", n.NodeID)
+		}
+		nodeIDs[n.NodeID] = true
+		tpByNode[n.NodeID] = map[string]bool{}
+		seen := map[string]bool{}
+		for _, tp := range n.TerminationPoint {
+			if seen[tp.TPID] {
+				t.Errorf("duplicate tp-id %q under %q", tp.TPID, n.NodeID)
+			}
+			seen[tp.TPID] = true
+			tpByNode[n.NodeID][tp.TPID] = true
+		}
+	}
+	if !nodeIDs["ghost"] {
+		t.Error("edge endpoint absent from Devices was not synthesized as a node")
+	}
+	linkIDs := map[string]bool{}
+	for _, l := range net.Link {
+		if linkIDs[l.LinkID] {
+			t.Errorf("duplicate link-id %q", l.LinkID)
+		}
+		linkIDs[l.LinkID] = true
+		if !nodeIDs[l.Source.SourceNode] {
+			t.Errorf("link %q source-node %q has no node", l.LinkID, l.Source.SourceNode)
+		}
+		if !nodeIDs[l.Destination.DestNode] {
+			t.Errorf("link %q dest-node %q has no node", l.LinkID, l.Destination.DestNode)
+		}
+		if l.Source.SourceTP != "" && !tpByNode[l.Source.SourceNode][l.Source.SourceTP] {
+			t.Errorf("link %q source-tp %q not declared under %q", l.LinkID, l.Source.SourceTP, l.Source.SourceNode)
+		}
+		if l.Destination.DestTP != "" && !tpByNode[l.Destination.DestNode][l.Destination.DestTP] {
+			t.Errorf("link %q dest-tp %q not declared under %q", l.LinkID, l.Destination.DestTP, l.Destination.DestNode)
+		}
+	}
+}
+
+func TestRenderDeterministic(t *testing.T) {
+	g := &discovery.Graph{
+		Devices: []discovery.Device{{ID: "b"}, {ID: "a"}},
+		Edges: []discovery.Edge{
+			bidiEdge("a", "p1", "b", "p2", discovery.DiscoveryProtocolLLDP),
+			bidiEdge("b", "p3", "a", "p4", discovery.DiscoveryProtocolCDP),
+		},
+	}
+	b1, _ := Render(g, Config{NetworkID: "x"})
+	b2, _ := Render(g, Config{NetworkID: "x"})
+	if string(b1) != string(b2) {
+		t.Error("Render is not deterministic")
+	}
+}
+
+func TestRenderEmptyGraph(t *testing.T) {
+	b, err := Render(&discovery.Graph{}, Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc Document
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if len(doc.Networks.Network) != 1 {
+		t.Fatalf("want exactly one network, got %d", len(doc.Networks.Network))
+	}
+	if doc.Networks.Network[0].NetworkID != "network-topology-exporter" {
+		t.Errorf("empty NetworkID should default; got %q", doc.Networks.Network[0].NetworkID)
+	}
+}
+
+func TestRenderSelfLoopUnique(t *testing.T) {
+	g := &discovery.Graph{
+		Devices: []discovery.Device{{ID: "a"}},
+		Edges: []discovery.Edge{
+			{SrcDevice: "a", SrcPort: "p1", DstDevice: "a", DstPort: "p1",
+				DiscoveryProto: discovery.DiscoveryProtocolLLDP, Direction: discovery.DirectionBidirectional},
+		},
+	}
+	b, err := Render(g, Config{NetworkID: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc Document
+	_ = json.Unmarshal(b, &doc)
+	ids := map[string]bool{}
+	for _, l := range doc.Networks.Network[0].Link {
+		if ids[l.LinkID] {
+			t.Errorf("self-loop produced colliding link-id %q", l.LinkID)
+		}
+		ids[l.LinkID] = true
+	}
+}
+
+func TestRenderUnicodeID(t *testing.T) {
+	g := &discovery.Graph{
+		Devices: []discovery.Device{{ID: "switch-Ωμέγα"}},
+		Edges:   []discovery.Edge{bidiEdge("switch-Ωμέγα", "Gi0/1", "peer", "Gi0/2", discovery.DiscoveryProtocolLLDP)},
+	}
+	b, err := Render(g, Config{NetworkID: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(b) {
+		t.Error("unicode device id produced invalid JSON")
+	}
+}

--- a/internal/output/yang/types.go
+++ b/internal/output/yang/types.go
@@ -1,0 +1,69 @@
+// Package yang renders the reconciled topology graph as RFC 8345/8346
+// YANG-JSON (RFC 7951 encoding). See docs/operator/yang-topology.md for the
+// normative mapping and docs/superpowers/specs/2026-06-09-yang-emission-design.md.
+package yang
+
+// Document is the RFC 7951 top level: {"ietf-network:networks": {...}}.
+type Document struct {
+	Networks Networks `json:"ietf-network:networks"`
+}
+
+// Networks is the RFC 8345 list of networks under ietf-network:networks.
+type Networks struct {
+	Network []Network `json:"network"`
+}
+
+// NetworkTypes carries the RFC 8346 l3-unicast presence marker. The empty
+// struct marshals to {} — the correct RFC 7951 encoding for a presence
+// container. l3-node-attributes are intentionally omitted (not collected).
+type NetworkTypes struct {
+	L3Unicast struct{} `json:"ietf-l3-unicast-topology:l3-unicast-topology"`
+}
+
+// Network is a single RFC 8345 network with its nodes and links.
+type Network struct {
+	NetworkID    string       `json:"network-id"`
+	NetworkTypes NetworkTypes `json:"network-types"`
+	Node         []Node       `json:"node,omitempty"`
+	Link         []Link       `json:"ietf-network-topology:link,omitempty"`
+}
+
+// Node is an RFC 8345 node augmented with ntx-topology device attributes.
+type Node struct {
+	NodeID           string             `json:"node-id"`
+	TerminationPoint []TerminationPoint `json:"ietf-network-topology:termination-point,omitempty"`
+	// ntx-topology node augmentation
+	Vendor    string `json:"ntx-topology:vendor,omitempty"`
+	Model     string `json:"ntx-topology:model,omitempty"`
+	OSVersion string `json:"ntx-topology:os-version,omitempty"`
+	Site      string `json:"ntx-topology:site,omitempty"`
+}
+
+// TerminationPoint is an RFC 8345 termination point on a node.
+type TerminationPoint struct {
+	TPID string `json:"tp-id"`
+}
+
+// Source is the RFC 8345 source endpoint of a link.
+type Source struct {
+	SourceNode string `json:"source-node"`
+	SourceTP   string `json:"source-tp,omitempty"`
+}
+
+// Destination is the RFC 8345 destination endpoint of a link.
+type Destination struct {
+	DestNode string `json:"dest-node"`
+	DestTP   string `json:"dest-tp,omitempty"`
+}
+
+// Link is an RFC 8345 link augmented with ntx-topology discovery attributes.
+type Link struct {
+	LinkID      string      `json:"link-id"`
+	Source      Source      `json:"source"`
+	Destination Destination `json:"destination"`
+	// ntx-topology link augmentation
+	DiscoveryProtocol string `json:"ntx-topology:discovery-protocol,omitempty"`
+	LinkKind          string `json:"ntx-topology:link-kind,omitempty"`
+	Confidence        string `json:"ntx-topology:confidence,omitempty"`
+	Adjacency         string `json:"ntx-topology:adjacency,omitempty"`
+}

--- a/internal/output/yang/types_test.go
+++ b/internal/output/yang/types_test.go
@@ -1,0 +1,39 @@
+package yang
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDocumentJSONKeys(t *testing.T) {
+	doc := Document{Networks: Networks{Network: []Network{{
+		NetworkID:    "n1",
+		NetworkTypes: NetworkTypes{},
+		Node:         []Node{{NodeID: "d1", Vendor: "cisco"}},
+		Link: []Link{{
+			LinkID:            "d1:p1-d2:p2",
+			Source:            Source{SourceNode: "d1", SourceTP: "p1"},
+			Destination:       Destination{DestNode: "d2", DestTP: "p2"},
+			DiscoveryProtocol: "lldp",
+		}},
+	}}}}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"ietf-network:networks"`,
+		`"ietf-l3-unicast-topology:l3-unicast-topology":{}`,
+		`"ietf-network-topology:link"`,
+		`"ntx-topology:vendor":"cisco"`,
+		`"ntx-topology:discovery-protocol":"lldp"`,
+		`"source-node":"d1"`,
+		`"dest-tp":"p2"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("marshalled doc missing %s\n got: %s", want, s)
+		}
+	}
+}

--- a/internal/output/yang/validate_gen_test.go
+++ b/internal/output/yang/validate_gen_test.go
@@ -1,0 +1,39 @@
+package yang
+
+import (
+	"os"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+)
+
+// TestGenerateValidationDoc writes a YANG-JSON instance to YANG_VALIDATE_OUT
+// when set, for the CI yanglint step. No-op otherwise. The graph is adversarial
+// on purpose: an edge endpoint absent from Devices (spine1), parallel
+// multi-protocol edges, empty ports, and a unicode device id.
+func TestGenerateValidationDoc(t *testing.T) {
+	out := os.Getenv("YANG_VALIDATE_OUT")
+	if out == "" {
+		t.Skip("YANG_VALIDATE_OUT not set")
+	}
+	g := &discovery.Graph{
+		Devices: []discovery.Device{
+			{ID: "leaf1", Vendor: "cisco", OSVersion: "17.12"},
+			{ID: "switch-Ωμέγα"},
+		},
+		Edges: []discovery.Edge{
+			bidiEdge("leaf1", "Gi0/1", "spine1", "Gi0/2", discovery.DiscoveryProtocolLLDP),
+			{SrcDevice: "leaf1", SrcPort: "Gi0/1", DstDevice: "spine1", DstPort: "Gi0/2",
+				DiscoveryProto: discovery.DiscoveryProtocolCDP, Direction: discovery.DirectionUnidirectional},
+			{SrcDevice: "leaf1", SrcPort: "", DstDevice: "switch-Ωμέγα", DstPort: "",
+				DiscoveryProto: discovery.DiscoveryProtocolFDB, Direction: discovery.DirectionUnidirectional},
+		},
+	}
+	b, err := Render(g, Config{NetworkID: "ci-adversarial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(out, b, 0o644); err != nil { //nolint:gosec // CI-controlled output path
+		t.Fatal(err)
+	}
+}

--- a/yang/README.md
+++ b/yang/README.md
@@ -1,0 +1,37 @@
+# YANG modules
+
+This directory vendors the IETF YANG modules used to emit RFC 8345 network
+topology, plus our own augmentation module.
+
+## Provenance
+
+The IETF modules below were copied **verbatim** (no hand-edits) from the
+authoritative [YangModels/yang](https://github.com/YangModels/yang) repository.
+Upstream base URL:
+`https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/`
+
+| File | RFC | Source URL |
+| --- | --- | --- |
+| `ietf-yang-types@2013-07-15.yang` | [RFC 6991](https://www.rfc-editor.org/rfc/rfc6991) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-yang-types@2013-07-15.yang |
+| `ietf-inet-types@2013-07-15.yang` | [RFC 6991](https://www.rfc-editor.org/rfc/rfc6991) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-inet-types@2013-07-15.yang |
+| `ietf-routing-types@2017-12-04.yang` | [RFC 8294](https://www.rfc-editor.org/rfc/rfc8294) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-routing-types@2017-12-04.yang |
+| `ietf-network@2018-02-26.yang` | [RFC 8345](https://www.rfc-editor.org/rfc/rfc8345) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-network@2018-02-26.yang |
+| `ietf-network-topology@2018-02-26.yang` | [RFC 8345](https://www.rfc-editor.org/rfc/rfc8345) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-network-topology@2018-02-26.yang |
+| `ietf-l3-unicast-topology@2018-02-26.yang` | [RFC 8346](https://www.rfc-editor.org/rfc/rfc8346) | https://raw.githubusercontent.com/YangModels/yang/main/standard/ietf/RFC/ietf-l3-unicast-topology@2018-02-26.yang |
+
+## Local module
+
+| File | Description |
+| --- | --- |
+| `ntx-topology@2026-06-09.yang` | Exporter-specific augmentations (issue #75): per-link discovery protocol, link kind, confidence, adjacency; per-node inventory. Augments `ietf-network` and `ietf-network-topology`. A consumer that understands only base RFC 8345 ignores these augmentations. |
+
+## Smoke test
+
+Load the full closure (every module, no instance doc) with
+[`yanglint`](https://github.com/CESNET/libyang):
+
+```sh
+yanglint -p yang yang/*.yang
+```
+
+A clean exit (no errors) means every `import` resolves within this directory.

--- a/yang/ietf-inet-types@2013-07-15.yang
+++ b/yang/ietf-inet-types@2013-07-15.yang
@@ -1,0 +1,458 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+      length "1..253";
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/yang/ietf-l3-unicast-topology@2018-02-26.yang
+++ b/yang/ietf-l3-unicast-topology@2018-02-26.yang
@@ -1,0 +1,359 @@
+module ietf-l3-unicast-topology {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-l3-unicast-topology";
+  prefix "l3t";
+  import ietf-network {
+    prefix "nw";
+  }
+  import ietf-network-topology {
+    prefix "nt";
+  }
+  import ietf-inet-types {
+    prefix "inet";
+  }
+  import ietf-routing-types {
+    prefix "rt-types";
+  }
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>";
+  description
+    "This module defines a model for Layer 3 Unicast
+     topologies.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of
+     RFC 8346; see the RFC itself for full legal notices.";
+  revision "2018-02-26" {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8346: A YANG Data Model for Layer 3 Topologies";
+  }
+
+  identity flag-identity {
+    description "Base type for flags";
+  }
+
+  typedef l3-event-type {
+    type enumeration {
+      enum "add" {
+        description
+          "A Layer 3 node, link, prefix, or termination point has
+          been added";
+      }
+      enum "remove" {
+        description
+          "A Layer 3 node, link, prefix, or termination point has
+          been removed";
+      }
+      enum "update" {
+        description
+          "A Layer 3 node, link, prefix, or termination point has
+          been updated";
+      }
+    }
+    description "Layer 3 event type for notifications";
+  }
+
+  typedef prefix-flag-type {
+    type identityref {
+      base "flag-identity";
+    }
+    description "Prefix flag attributes";
+  }
+
+  typedef node-flag-type {
+    type identityref {
+      base "flag-identity";
+    }
+    description "Node flag attributes";
+  }
+
+  typedef link-flag-type {
+    type identityref {
+      base "flag-identity";
+    }
+    description "Link flag attributes";
+  }
+
+  typedef l3-flag-type {
+    type identityref {
+      base "flag-identity";
+    }
+    description "L3 flag attributes";
+  }
+
+  grouping l3-prefix-attributes {
+    description
+      "L3 prefix attributes";
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "IP prefix value";
+    }
+    leaf metric {
+      type uint32;
+      description
+        "Prefix metric";
+    }
+    leaf-list flag {
+      type prefix-flag-type;
+      description
+        "Prefix flags";
+    }
+  }
+  grouping l3-unicast-topology-type {
+    description "Identifies the topology type to be L3 Unicast.";
+    container l3-unicast-topology {
+      presence "indicates L3 Unicast topology";
+      description
+        "The presence of the container node indicates L3 Unicast
+        topology";
+    }
+  }
+  grouping l3-topology-attributes {
+    description "Topology scope attributes";
+    container l3-topology-attributes {
+      description "Contains topology attributes";
+      leaf name {
+        type string;
+        description
+          "Name of the topology";
+      }
+      leaf-list flag {
+        type l3-flag-type;
+        description
+          "Topology flags";
+      }
+    }
+  }
+  grouping l3-node-attributes {
+    description "L3 node scope attributes";
+    container l3-node-attributes {
+      description
+        "Contains node attributes";
+      leaf name {
+        type inet:domain-name;
+        description
+          "Node name";
+      }
+      leaf-list flag {
+        type node-flag-type;
+        description
+          "Node flags";
+      }
+      leaf-list router-id {
+        type rt-types:router-id;
+        description
+          "Router-id for the node";
+      }
+      list prefix {
+        key "prefix";
+        description
+          "A list of prefixes along with their attributes";
+        uses l3-prefix-attributes;
+      }
+    }
+  }
+  grouping l3-link-attributes {
+    description
+      "L3 link scope attributes";
+    container l3-link-attributes {
+      description
+        "Contains link attributes";
+      leaf name {
+        type string;
+        description
+          "Link Name";
+      }
+      leaf-list flag {
+        type link-flag-type;
+        description
+          "Link flags";
+      }
+      leaf metric1 {
+        type uint64;
+        description
+            "Link Metric 1";
+      }
+      leaf metric2 {
+        type uint64;
+        description
+            "Link Metric 2";
+      }
+    }
+  }
+  grouping l3-termination-point-attributes {
+    description "L3 termination point scope attributes";
+    container l3-termination-point-attributes {
+      description
+        "Contains termination point attributes";
+      choice termination-point-type {
+        description
+          "Indicates the termination point type";
+        case ip {
+          leaf-list ip-address {
+            type inet:ip-address;
+            description
+              "IPv4 or IPv6 address.";
+          }
+        }
+        case unnumbered {
+          leaf unnumbered-id {
+            type uint32;
+            description
+              "Unnumbered interface identifier.
+               The identifier will correspond to the ifIndex value
+               of the interface, i.e., the ifIndex value of the
+               ifEntry that represents the interface in
+               implementations where the Interfaces Group MIB
+               (RFC 2863) is supported.";
+            reference
+              "RFC 2863: The Interfaces Group MIB";
+          }
+        }
+        case interface-name {
+          leaf interface-name {
+            type string;
+            description
+              "Name of the interface.  The name can (but does not
+               have to) correspond to an interface reference of a
+               containing node's interface, i.e., the path name of a
+               corresponding interface data node on the containing
+               node reminiscent of data type interface-ref defined
+               in RFC 8343. It should be noted that data type
+               interface-ref of RFC 8343 cannot be used directly,
+
+               as this data type is used to reference an interface
+               in a datastore of a single node in the network, not
+               to uniquely reference interfaces across a network.";
+            reference
+              "RFC 8343: A YANG Data Model for Interface Management";
+          }
+        }
+      }
+    }
+  }
+  augment "/nw:networks/nw:network/nw:network-types" {
+    description
+      "Introduces new network type for L3 Unicast topology";
+    uses l3-unicast-topology-type;
+  }
+  augment "/nw:networks/nw:network" {
+    when "nw:network-types/l3t:l3-unicast-topology" {
+      description
+        "Augmentation parameters apply only for networks with
+        L3 Unicast topology";
+    }
+    description
+        "L3 Unicast for the network as a whole";
+    uses l3-topology-attributes;
+  }
+  augment "/nw:networks/nw:network/nw:node" {
+    when "../nw:network-types/l3t:l3-unicast-topology" {
+      description
+        "Augmentation parameters apply only for networks with
+        L3 Unicast topology";
+    }
+    description
+        "L3 Unicast node-level attributes ";
+    uses l3-node-attributes;
+  }
+  augment "/nw:networks/nw:network/nt:link" {
+    when "../nw:network-types/l3t:l3-unicast-topology" {
+      description
+        "Augmentation parameters apply only for networks with
+        L3 Unicast topology";
+    }
+    description
+      "Augments topology link attributes";
+    uses l3-link-attributes;
+  }
+  augment "/nw:networks/nw:network/nw:node/"
+         +"nt:termination-point" {
+    when "../../nw:network-types/l3t:l3-unicast-topology" {
+      description
+        "Augmentation parameters apply only for networks with
+        L3 Unicast topology";
+    }
+    description "Augments topology termination point configuration";
+    uses l3-termination-point-attributes;
+  }
+  notification l3-node-event {
+    description
+      "Notification event for L3 node";
+    leaf l3-event-type {
+      type l3-event-type;
+      description
+        "Event type";
+    }
+    uses nw:node-ref;
+    uses l3-unicast-topology-type;
+    uses l3-node-attributes;
+  }
+  notification l3-link-event {
+    description
+      "Notification event for L3 link";
+    leaf l3-event-type {
+      type l3-event-type;
+      description
+        "Event type";
+    }
+    uses nt:link-ref;
+    uses l3-unicast-topology-type;
+    uses l3-link-attributes;
+  }
+  notification l3-prefix-event {
+    description
+      "Notification event for L3 prefix";
+    leaf l3-event-type {
+      type l3-event-type;
+      description
+        "Event type";
+    }
+    uses nw:node-ref;
+    uses l3-unicast-topology-type;
+    container prefix {
+      description
+        "Contains L3 prefix attributes";
+      uses l3-prefix-attributes;
+    }
+  }
+  notification termination-point-event {
+    description
+      "Notification event for L3 termination point";
+    leaf l3-event-type {
+      type l3-event-type;
+      description
+        "Event type";
+    }
+    uses nt:tp-ref;
+    uses l3-unicast-topology-type;
+    uses l3-termination-point-attributes;
+  }
+}

--- a/yang/ietf-network-topology@2018-02-26.yang
+++ b/yang/ietf-network-topology@2018-02-26.yang
@@ -1,0 +1,294 @@
+module ietf-network-topology {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-topology";
+  prefix nt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-network {
+    prefix nw;
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+
+  description
+    "This module defines a common base model for a network topology,
+     augmenting the base network data model with links to connect
+     nodes, as well as termination points to terminate links
+     on nodes.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef link-id {
+    type inet:uri;
+    description
+      "An identifier for a link in a topology.  The precise
+       structure of the link-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same link in a
+       real network topology will always be identified through the
+       same identifier, even if the data model is instantiated in
+       separate datastores.  An implementation MAY choose to capture
+       semantics in the identifier -- for example, to indicate the
+       type of link and/or the type of topology of which the link is
+       a part.";
+  }
+
+  typedef tp-id {
+    type inet:uri;
+    description
+      "An identifier for termination points on a node.  The precise
+       structure of the tp-id will be up to the implementation.
+       The identifier SHOULD be chosen such that the same termination
+       point in a real network topology will always be identified
+       through the same identifier, even if the data model is
+       instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of termination point and/or the type of
+       node that contains the termination point.";
+  }
+
+  grouping link-ref {
+    description
+      "This grouping can be used to reference a link in a specific
+       network.  Although it is not used in this module, it is
+       defined here for the convenience of augmenting modules.";
+    leaf link-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nt:link/nt:link-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a link instance.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:network-ref;
+  }
+
+  grouping tp-ref {
+    description
+      "This grouping can be used to reference a termination point
+       in a specific node.  Although it is not used in this module,
+       it is defined here for the convenience of augmenting
+       modules.";
+    leaf tp-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node[nw:node-id=current()/../"+
+          "node-ref]/nt:termination-point/nt:tp-id";
+        require-instance false;
+      }
+      description
+        "A type for an absolute reference to a termination point.
+         (This type should not be used for relative references.
+         In such a case, a relative path should be used instead.)";
+    }
+    uses nw:node-ref;
+  }
+
+  augment "/nw:networks/nw:network" {
+    description
+      "Add links to the network data model.";
+    list link {
+      key "link-id";
+      description
+        "A network link connects a local (source) node and
+         a remote (destination) node via a set of the respective
+         node's termination points.  It is possible to have several
+         links between the same source and destination nodes.
+         Likewise, a link could potentially be re-homed between
+         termination points.  Therefore, in order to ensure that we
+         would always know to distinguish between links, every link
+         is identified by a dedicated link identifier.  Note that a
+         link models a point-to-point link, not a multipoint link.";
+      leaf link-id {
+        type link-id;
+        description
+          "The identifier of a link in the topology.
+           A link is specific to a topology to which it belongs.";
+      }
+      container source {
+        description
+          "This container holds the logical source of a particular
+           link.";
+        leaf source-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+            require-instance false;
+          }
+          description
+            "Source node identifier.  Must be in the same topology.";
+        }
+        leaf source-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "source-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the source node
+             and terminates the link.";
+        }
+      }
+
+      container destination {
+        description
+          "This container holds the logical destination of a
+           particular link.";
+        leaf dest-node {
+          type leafref {
+            path "../../../nw:node/nw:node-id";
+          require-instance false;
+          }
+          description
+            "Destination node identifier.  Must be in the same
+             network.";
+        }
+        leaf dest-tp {
+          type leafref {
+            path "../../../nw:node[nw:node-id=current()/../"+
+              "dest-node]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "This termination point is located within the
+             destination node and terminates the link.";
+        }
+      }
+      list supporting-link {
+        key "network-ref link-ref";
+        description
+          "Identifies the link or links on which this link depends.";
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-network/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which underlay topology
+             the supporting link is present.";
+        }
+
+        leaf link-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/link/link-id";
+            require-instance false;
+          }
+          description
+            "This leaf identifies a link that is a part
+             of this link's underlay.  Reference loops in which
+             a link identifies itself as its underlay, either
+             directly or transitively, are not allowed.";
+        }
+      }
+    }
+  }
+  augment "/nw:networks/nw:network/nw:node" {
+    description
+      "Augments termination points that terminate links.
+       Termination points can ultimately be mapped to interfaces.";
+    list termination-point {
+      key "tp-id";
+      description
+        "A termination point can terminate a link.
+         Depending on the type of topology, a termination point
+         could, for example, refer to a port or an interface.";
+      leaf tp-id {
+        type tp-id;
+        description
+          "Termination point identifier.";
+      }
+      list supporting-termination-point {
+        key "network-ref node-ref tp-ref";
+        description
+          "This list identifies any termination points on which a
+           given termination point depends or onto which it maps.
+           Those termination points will themselves be contained
+           in a supporting node.  This dependency information can be
+           inferred from the dependencies between links.  Therefore,
+           this item is not separately configurable.  Hence, no
+           corresponding constraint needs to be articulated.
+           The corresponding information is simply provided by the
+           implementing system.";
+
+        leaf network-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:network-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which topology the
+             supporting termination point is present.";
+        }
+        leaf node-ref {
+          type leafref {
+            path "../../../nw:supporting-node/nw:node-ref";
+          require-instance false;
+          }
+          description
+            "This leaf identifies in which node the supporting
+             termination point is present.";
+        }
+        leaf tp-ref {
+          type leafref {
+            path "/nw:networks/nw:network[nw:network-id=current()/"+
+              "../network-ref]/nw:node[nw:node-id=current()/../"+
+              "node-ref]/termination-point/tp-id";
+            require-instance false;
+          }
+          description
+            "Reference to the underlay node (the underlay node must
+             be in a different topology).";
+        }
+      }
+    }
+  }
+}

--- a/yang/ietf-network@2018-02-26.yang
+++ b/yang/ietf-network@2018-02-26.yang
@@ -1,0 +1,192 @@
+module ietf-network {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network";
+  prefix nw;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF I2RS (Interface to the Routing System) Working Group";
+
+  contact
+    "WG Web:    <https://datatracker.ietf.org/wg/i2rs/>
+     WG List:   <mailto:i2rs@ietf.org>
+
+     Editor:    Alexander Clemm
+                <mailto:ludwig@clemm.org>
+
+     Editor:    Jan Medved
+                <mailto:jmedved@cisco.com>
+
+     Editor:    Robert Varga
+                <mailto:robert.varga@pantheon.tech>
+
+     Editor:    Nitin Bahadur
+                <mailto:nitin_bahadur@yahoo.com>
+
+     Editor:    Hariharan Ananthakrishnan
+                <mailto:hari@packetdesign.com>
+
+     Editor:    Xufeng Liu
+                <mailto:xufeng.liu.ietf@gmail.com>";
+  description
+    "This module defines a common base data model for a collection
+     of nodes in a network.  Node definitions are further used
+     in network topologies and inventories.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8345;
+     see the RFC itself for full legal notices.";
+
+  revision 2018-02-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8345: A YANG Data Model for Network Topologies";
+  }
+
+  typedef node-id {
+    type inet:uri;
+    description
+      "Identifier for a node.  The precise structure of the node-id
+       will be up to the implementation.  For example, some
+       implementations MAY pick a URI that includes the network-id
+       as part of the path.  The identifier SHOULD be chosen
+       such that the same node in a real network topology will
+       always be identified through the same identifier, even if
+       the data model is instantiated in separate datastores.  An
+       implementation MAY choose to capture semantics in the
+       identifier -- for example, to indicate the type of node.";
+  }
+
+  typedef network-id {
+    type inet:uri;
+    description
+      "Identifier for a network.  The precise structure of the
+       network-id will be up to the implementation.  The identifier
+       SHOULD be chosen such that the same network will always be
+       identified through the same identifier, even if the data model
+       is instantiated in separate datastores.  An implementation MAY
+       choose to capture semantics in the identifier -- for example,
+       to indicate the type of network.";
+  }
+
+  grouping network-ref {
+    description
+      "Contains the information necessary to reference a network --
+       for example, an underlay network.";
+    leaf network-ref {
+      type leafref {
+        path "/nw:networks/nw:network/nw:network-id";
+      require-instance false;
+      }
+      description
+        "Used to reference a network -- for example, an underlay
+         network.";
+    }
+  }
+
+  grouping node-ref {
+    description
+      "Contains the information necessary to reference a node.";
+    leaf node-ref {
+      type leafref {
+        path "/nw:networks/nw:network[nw:network-id=current()/../"+
+          "network-ref]/nw:node/nw:node-id";
+        require-instance false;
+      }
+      description
+        "Used to reference a node.
+         Nodes are identified relative to the network that
+         contains them.";
+    }
+    uses network-ref;
+  }
+
+  container networks {
+    description
+      "Serves as a top-level container for a list of networks.";
+    list network {
+      key "network-id";
+      description
+        "Describes a network.
+         A network typically contains an inventory of nodes,
+         topological information (augmented through the
+         network-topology data model), and layering information.";
+      leaf network-id {
+        type network-id;
+        description
+          "Identifies a network.";
+      }
+      container network-types {
+        description
+          "Serves as an augmentation target.
+           The network type is indicated through corresponding
+           presence containers augmented into this container.";
+      }
+      list supporting-network {
+        key "network-ref";
+        description
+          "An underlay network, used to represent layered network
+           topologies.";
+        leaf network-ref {
+          type leafref {
+            path "/nw:networks/nw:network/nw:network-id";
+          require-instance false;
+          }
+          description
+            "References the underlay network.";
+        }
+      }
+
+      list node {
+        key "node-id";
+        description
+          "The inventory of nodes of this network.";
+        leaf node-id {
+          type node-id;
+          description
+            "Uniquely identifies a node within the containing
+             network.";
+        }
+        list supporting-node {
+          key "network-ref node-ref";
+          description
+            "Represents another node that is in an underlay network
+             and that supports this node.  Used to represent layering
+             structure.";
+          leaf network-ref {
+            type leafref {
+              path "../../../nw:supporting-network/nw:network-ref";
+            require-instance false;
+            }
+            description
+              "References the underlay network of which the
+               underlay node is a part.";
+          }
+          leaf node-ref {
+            type leafref {
+              path "/nw:networks/nw:network/nw:node/nw:node-id";
+            require-instance false;
+            }
+            description
+              "References the underlay node itself.";
+          }
+        }
+      }
+    }
+  }
+}

--- a/yang/ietf-routing-types@2017-12-04.yang
+++ b/yang/ietf-routing-types@2017-12-04.yang
@@ -1,0 +1,771 @@
+module ietf-routing-types {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-routing-types";
+  prefix rt-types;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  organization
+    "IETF RTGWG - Routing Area Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/rtgwg/>
+     WG List:  <mailto:rtgwg@ietf.org>
+
+     Editors:  Xufeng Liu
+               <mailto:Xufeng_Liu@jabail.com>
+               Yingzhen Qu
+               <mailto:yingzhen.qu@huawei.com>
+               Acee Lindem
+               <mailto:acee@cisco.com>
+               Christian Hopps
+               <mailto:chopps@chopps.org>
+               Lou Berger
+               <mailto:lberger@labn.com>";
+
+  description
+    "This module contains a collection of YANG data types
+     considered generally useful for routing protocols.
+
+     Copyright (c) 2017 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8294; see
+     the RFC itself for full legal notices.";
+   revision 2017-12-04 {
+     description "Initial revision.";
+     reference
+       "RFC 8294: Common YANG Data Types for the Routing Area.
+        Section 3.";
+  }
+
+  /*** Identities related to MPLS/GMPLS ***/
+
+  identity mpls-label-special-purpose-value {
+    description
+      "Base identity for deriving identities describing
+       special-purpose Multiprotocol Label Switching (MPLS) label
+       values.";
+    reference
+      "RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.";
+  }
+
+  identity ipv4-explicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the IPv4 Explicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity router-alert-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Router Alert Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity ipv6-explicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the IPv6 Explicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity implicit-null-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Implicit NULL Label.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.  Section 2.1.";
+  }
+
+  identity entropy-label-indicator {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Entropy Label Indicator.";
+    reference
+      "RFC 6790: The Use of Entropy Labels in MPLS Forwarding.
+       Sections 3 and 10.1.";
+  }
+
+  identity gal-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Generic Associated Channel
+       (G-ACh) Label (GAL).";
+    reference
+      "RFC 5586: MPLS Generic Associated Channel.
+       Sections 4 and 10.";
+  }
+
+  identity oam-alert-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the OAM Alert Label.";
+    reference
+      "RFC 3429: Assignment of the 'OAM Alert Label' for
+       Multiprotocol Label Switching Architecture (MPLS)
+       Operation and Maintenance (OAM) Functions.
+       Sections 3 and 6.";
+  }
+
+  identity extension-label {
+    base mpls-label-special-purpose-value;
+    description
+      "This identity represents the Extension Label.";
+    reference
+      "RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.  Sections 3.1 and 5.";
+  }
+
+  /*** Collection of types related to routing ***/
+
+  typedef router-id {
+    type yang:dotted-quad;
+    description
+      "A 32-bit number in the dotted-quad format assigned to each
+       router.  This number uniquely identifies the router within
+       an Autonomous System.";
+  }
+
+  /*** Collection of types related to VPNs ***/
+
+  typedef route-target {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +     '[0-9a-fA-F]{1,12})';
+    }
+
+    description
+      "A Route Target is an 8-octet BGP extended community
+       initially identifying a set of sites in a BGP VPN
+       (RFC 4364).  However, it has since taken on a more general
+       role in BGP route filtering.  A Route Target consists of two
+       or three fields: a 2-octet Type field, an administrator
+       field, and, optionally, an assigned number field.
+
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+
+       Additionally, a generic pattern is defined for future
+       Route Target types:
+
+       2-octet-other-hex-number:6-octet-hex-number
+
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef ipv6-route-target {
+    type string {
+      pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+          + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+          + '(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}'
+          + '(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+      pattern '((([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+          + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+    }
+    description
+      "An IPv6 Route Target is a 20-octet BGP IPv6 Address
+       Specific Extended Community serving the same function
+       as a standard 8-octet Route Target, except that it only
+       allows an IPv6 address as the global administrator.
+       The format is <ipv6-address:2-octet-number>.
+
+       Two valid examples are 2001:db8::1:6544 and
+       2001:db8::5eb1:791:6b37:17958.";
+    reference
+      "RFC 5701: IPv6 Address Specific BGP Extended Community
+       Attribute.";
+  }
+
+  typedef route-target-type {
+    type enumeration {
+      enum import {
+        value 0;
+        description
+          "The Route Target applies to route import.";
+      }
+      enum export {
+        value 1;
+        description
+          "The Route Target applies to route export.";
+      }
+
+      enum both {
+        value 2;
+        description
+          "The Route Target applies to both route import and
+           route export.";
+      }
+    }
+    description
+      "Indicates the role a Route Target takes in route filtering.";
+    reference
+      "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).";
+  }
+
+  typedef route-distinguisher {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +     '[0-9a-fA-F]{1,12})';
+    }
+
+    description
+      "A Route Distinguisher is an 8-octet value used to
+       distinguish routes from different BGP VPNs (RFC 4364).
+       A Route Distinguisher will have the same format as a
+       Route Target as per RFC 4360 and will consist of
+       two or three fields: a 2-octet Type field, an administrator
+       field, and, optionally, an assigned number field.
+
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+
+       Additionally, a generic pattern is defined for future
+       route discriminator types:
+
+       2-octet-other-hex-number:6-octet-hex-number
+
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef route-origin {
+    type string {
+      pattern
+        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
+      +     '42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+      +     '42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
+      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
+      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
+      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
+      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
+      +     '655[0-2][0-9]|'
+      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
+      +     '4294967[01][0-9]{2}|'
+      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
+      +     '4294[0-8][0-9]{5}|'
+      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
+      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
+      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+      +     '6[0-4][0-9]{3}|'
+      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
+      + '(6(:[a-fA-F0-9]{2}){6})|'
+      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
+      +    '[0-9a-fA-F]{1,12})';
+    }
+    description
+      "A Route Origin is an 8-octet BGP extended community
+       identifying the set of sites where the BGP route
+       originated (RFC 4364).  A Route Origin will have the same
+       format as a Route Target as per RFC 4360 and will consist
+       of two or three fields: a 2-octet Type field, an
+       administrator field, and, optionally, an assigned number
+       field.
+
+       According to the data formats for types 0, 1, 2, and 6 as
+       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
+       pattern is defined as:
+
+       0:2-octet-asn:4-octet-number
+       1:4-octet-ipv4addr:2-octet-number
+       2:4-octet-asn:2-octet-number
+       6:6-octet-mac-address
+       Additionally, a generic pattern is defined for future
+       Route Origin types:
+
+       2-octet-other-hex-number:6-octet-hex-number
+
+       Some valid examples are 0:100:100, 1:1.1.1.1:100,
+       2:1234567890:203, and 6:26:00:08:92:78:00.";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute.
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 5668: 4-Octet AS Specific BGP Extended Community.
+       RFC 7432: BGP MPLS-Based Ethernet VPN.";
+  }
+
+  typedef ipv6-route-origin {
+    type string {
+      pattern
+          '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+          + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+          + '(((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}'
+          + '(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+      pattern '((([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+          + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))'
+          + ':'
+          + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+          + '6[0-4][0-9]{3}|'
+          + '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+    }
+    description
+      "An IPv6 Route Origin is a 20-octet BGP IPv6 Address
+       Specific Extended Community serving the same function
+       as a standard 8-octet route, except that it only allows
+       an IPv6 address as the global administrator.  The format
+       is <ipv6-address:2-octet-number>.
+
+       Two valid examples are 2001:db8::1:6544 and
+       2001:db8::5eb1:791:6b37:17958.";
+    reference
+      "RFC 5701: IPv6 Address Specific BGP Extended Community
+       Attribute.";
+  }
+
+  /*** Collection of types common to multicast ***/
+
+  typedef ipv4-multicast-group-address {
+    type inet:ipv4-address {
+      pattern '(2((2[4-9])|(3[0-9]))\.).*';
+    }
+    description
+      "This type represents an IPv4 multicast group address,
+       which is in the range of 224.0.0.0 to 239.255.255.255.";
+    reference
+      "RFC 1112: Host Extensions for IP Multicasting.";
+  }
+
+  typedef ipv6-multicast-group-address {
+    type inet:ipv6-address {
+      pattern '(([fF]{2}[0-9a-fA-F]{2}):).*';
+    }
+    description
+      "This type represents an IPv6 multicast group address,
+       which is in the range of ff00::/8.";
+    reference
+      "RFC 4291: IP Version 6 Addressing Architecture.  Section 2.7.
+       RFC 7346: IPv6 Multicast Address Scopes.";
+  }
+
+  typedef ip-multicast-group-address {
+    type union {
+      type ipv4-multicast-group-address;
+      type ipv6-multicast-group-address;
+    }
+    description
+      "This type represents a version-neutral IP multicast group
+       address.  The format of the textual representation implies
+       the IP version.";
+  }
+
+  typedef ipv4-multicast-source-address {
+    type union {
+      type enumeration {
+        enum * {
+          description
+            "Any source address.";
+        }
+      }
+      type inet:ipv4-address;
+    }
+    description
+      "Multicast source IPv4 address type.";
+  }
+
+  typedef ipv6-multicast-source-address {
+    type union {
+      type enumeration {
+        enum * {
+          description
+            "Any source address.";
+        }
+      }
+      type inet:ipv6-address;
+    }
+    description
+      "Multicast source IPv6 address type.";
+  }
+
+  /*** Collection of types common to protocols ***/
+
+  typedef bandwidth-ieee-float32 {
+    type string {
+      pattern
+        '0[xX](0((\.0?)?[pP](\+)?0?|(\.0?))|'
+      + '1(\.([0-9a-fA-F]{0,5}[02468aAcCeE]?)?)?[pP](\+)?(12[0-7]|'
+      + '1[01][0-9]|0?[0-9]?[0-9])?)';
+    }
+    description
+      "Bandwidth in IEEE 754 floating-point 32-bit binary format:
+       (-1)**(S) * 2**(Exponent-127) * (1 + Fraction),
+       where Exponent uses 8 bits and Fraction uses 23 bits.
+       The units are octets per second.
+       The encoding format is the external hexadecimal-significant
+       character sequences specified in IEEE 754 and ISO/IEC C99.
+       The format is restricted to be normalized, non-negative, and
+       non-fraction: 0x1.hhhhhhp{+}d, 0X1.HHHHHHP{+}D, or 0x0p0,
+       where 'h' and 'H' are hexadecimal digits and 'd' and 'D' are
+       integers in the range of [0..127].
+       When six hexadecimal digits are used for 'hhhhhh' or
+       'HHHHHH', the least significant digit must be an even
+       number.  'x' and 'X' indicate hexadecimal; 'p' and 'P'
+       indicate a power of two.  Some examples are 0x0p0, 0x1p10,
+       and 0x1.abcde2p+20.";
+    reference
+      "IEEE Std 754-2008: IEEE Standard for Floating-Point
+       Arithmetic.
+       ISO/IEC C99: Information technology - Programming
+       Languages - C.";
+  }
+
+  typedef link-access-type {
+    type enumeration {
+      enum broadcast {
+        description
+          "Specify broadcast multi-access network.";
+      }
+      enum non-broadcast-multiaccess {
+        description
+          "Specify Non-Broadcast Multi-Access (NBMA) network.";
+      }
+      enum point-to-multipoint {
+        description
+          "Specify point-to-multipoint network.";
+      }
+      enum point-to-point {
+        description
+          "Specify point-to-point network.";
+      }
+    }
+    description
+      "Link access type.";
+  }
+
+  typedef timer-multiplier {
+    type uint8;
+    description
+      "The number of timer value intervals that should be
+       interpreted as a failure.";
+  }
+
+  typedef timer-value-seconds16 {
+    type union {
+      type uint16 {
+        range "1..65535";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "seconds";
+    description
+      "Timer value type, in seconds (16-bit range).";
+  }
+
+  typedef timer-value-seconds32 {
+    type union {
+      type uint32 {
+        range "1..4294967295";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "seconds";
+    description
+      "Timer value type, in seconds (32-bit range).";
+  }
+
+  typedef timer-value-milliseconds {
+    type union {
+      type uint32 {
+        range "1..4294967295";
+      }
+      type enumeration {
+        enum infinity {
+          description
+            "The timer is set to infinity.";
+        }
+        enum not-set {
+          description
+            "The timer is not set.";
+        }
+      }
+    }
+    units "milliseconds";
+    description
+      "Timer value type, in milliseconds.";
+  }
+
+  typedef percentage {
+    type uint8 {
+      range "0..100";
+    }
+    description
+      "Integer indicating a percentage value.";
+  }
+
+  typedef timeticks64 {
+    type uint64;
+    description
+      "This type is based on the timeticks type defined in
+       RFC 6991, but with 64-bit width.  It represents the time,
+       modulo 2^64, in hundredths of a second between two epochs.";
+    reference
+      "RFC 6991: Common YANG Data Types.";
+  }
+
+  typedef uint24 {
+    type uint32 {
+      range "0..16777215";
+    }
+    description
+      "24-bit unsigned integer.";
+  }
+
+  /*** Collection of types related to MPLS/GMPLS ***/
+
+  typedef generalized-label {
+    type binary;
+    description
+      "Generalized Label.  Nodes sending and receiving the
+       Generalized Label are aware of the link-specific
+       label context and type.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description.  Section 3.2.";
+  }
+
+  typedef mpls-label-special-purpose {
+    type identityref {
+      base mpls-label-special-purpose-value;
+    }
+    description
+      "This type represents the special-purpose MPLS label values.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.
+       RFC 7274: Allocating and Retiring Special-Purpose MPLS
+       Labels.";
+  }
+
+  typedef mpls-label-general-use {
+    type uint32 {
+      range "16..1048575";
+    }
+    description
+      "The 20-bit label value in an MPLS label stack as specified
+       in RFC 3032.  This label value does not include the
+       encodings of Traffic Class and TTL (Time to Live).
+       The label range specified by this type is for general use,
+       with special-purpose MPLS label values excluded.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.";
+  }
+
+  typedef mpls-label {
+    type union {
+      type mpls-label-special-purpose;
+      type mpls-label-general-use;
+    }
+    description
+      "The 20-bit label value in an MPLS label stack as specified
+       in RFC 3032.  This label value does not include the
+       encodings of Traffic Class and TTL.";
+    reference
+      "RFC 3032: MPLS Label Stack Encoding.";
+  }
+
+  /*** Groupings **/
+
+  grouping mpls-label-stack {
+    description
+      "This grouping specifies an MPLS label stack.  The label
+       stack is encoded as a list of label stack entries.  The
+       list key is an identifier that indicates the relative
+       ordering of each entry, with the lowest-value identifier
+       corresponding to the top of the label stack.";
+    container mpls-label-stack {
+      description
+        "Container for a list of MPLS label stack entries.";
+      list entry {
+        key "id";
+        description
+          "List of MPLS label stack entries.";
+        leaf id {
+          type uint8;
+          description
+            "Identifies the entry in a sequence of MPLS label
+             stack entries.  An entry with a smaller identifier
+             value precedes an entry with a larger identifier
+             value in the label stack.  The value of this ID has
+             no semantic meaning other than relative ordering
+             and referencing the entry.";
+        }
+        leaf label {
+          type rt-types:mpls-label;
+          description
+            "Label value.";
+        }
+
+        leaf ttl {
+          type uint8;
+          description
+            "Time to Live (TTL).";
+          reference
+            "RFC 3032: MPLS Label Stack Encoding.";
+        }
+        leaf traffic-class {
+          type uint8 {
+            range "0..7";
+          }
+          description
+            "Traffic Class (TC).";
+          reference
+            "RFC 5462: Multiprotocol Label Switching (MPLS) Label
+             Stack Entry: 'EXP' Field Renamed to 'Traffic Class'
+             Field.";
+        }
+      }
+    }
+  }
+
+  grouping vpn-route-targets {
+    description
+      "A grouping that specifies Route Target import-export rules
+       used in BGP-enabled VPNs.";
+    reference
+      "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
+       RFC 4664: Framework for Layer 2 Virtual Private Networks
+       (L2VPNs).";
+    list vpn-target {
+      key "route-target";
+      description
+        "List of Route Targets.";
+      leaf route-target {
+        type rt-types:route-target;
+        description
+          "Route Target value.";
+      }
+      leaf route-target-type {
+        type rt-types:route-target-type;
+        mandatory true;
+        description
+          "Import/export type of the Route Target.";
+      }
+    }
+  }
+}

--- a/yang/ietf-yang-types@2013-07-15.yang
+++ b/yang/ietf-yang-types@2013-07-15.yang
@@ -1,0 +1,474 @@
+module ietf-yang-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
+  prefix "yang";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - yang-identifier
+      - hex-string
+      - uuid
+      - dotted-quad";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of counter and gauge types ***/
+
+  typedef counter32 {
+    type uint32;
+    description
+     "The counter32 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter32 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter32 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter32.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter32 {
+    type yang:counter32;
+    default "0";
+    description
+     "The zero-based-counter32 type represents a counter32
+      that has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^32-1 (4294967295 decimal), when it
+      wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter32 textual convention of the SMIv2.";
+    reference
+      "RFC 4502: Remote Network Monitoring Management Information
+                 Base Version 2";
+  }
+
+  typedef counter64 {
+    type uint64;
+    description
+     "The counter64 type represents a non-negative integer
+      that monotonically increases until it reaches a
+      maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Counters have no defined 'initial' value, and thus, a
+      single value of a counter has (in general) no information
+      content.  Discontinuities in the monotonically increasing
+      value normally occur at re-initialization of the
+      management system, and at other times as specified in the
+      description of a schema node using this type.  If such
+      other times can occur, for example, the creation of
+      a schema node of type counter64 at times other than
+      re-initialization, then a corresponding schema node
+      should be defined, with an appropriate type, to indicate
+      the last discontinuity.
+
+      The counter64 type should not be used for configuration
+      schema nodes.  A default statement SHOULD NOT be used in
+      combination with the type counter64.
+
+      In the value set and its semantics, this type is equivalent
+      to the Counter64 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef zero-based-counter64 {
+    type yang:counter64;
+    default "0";
+    description
+     "The zero-based-counter64 type represents a counter64 that
+      has the defined 'initial' value zero.
+
+      A schema node of this type will be set to zero (0) on creation
+      and will thereafter increase monotonically until it reaches
+      a maximum value of 2^64-1 (18446744073709551615 decimal),
+      when it wraps around and starts increasing again from zero.
+
+      Provided that an application discovers a new schema node
+      of this type within the minimum time to wrap, it can use the
+      'initial' value as a delta.  It is important for a management
+      station to be aware of this minimum time and the actual time
+      between polls, and to discard data if the actual time is too
+      long or there is no defined minimum time.
+
+      In the value set and its semantics, this type is equivalent
+      to the ZeroBasedCounter64 textual convention of the SMIv2.";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  typedef gauge32 {
+    type uint32;
+    description
+     "The gauge32 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^32-1 (4294967295 decimal), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge32 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge32 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the Gauge32 type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef gauge64 {
+    type uint64;
+    description
+     "The gauge64 type represents a non-negative integer, which
+      may increase or decrease, but shall never exceed a maximum
+      value, nor fall below a minimum value.  The maximum value
+      cannot be greater than 2^64-1 (18446744073709551615), and
+      the minimum value cannot be smaller than 0.  The value of
+      a gauge64 has its maximum value whenever the information
+      being modeled is greater than or equal to its maximum
+      value, and has its minimum value whenever the information
+      being modeled is smaller than or equal to its minimum value.
+      If the information being modeled subsequently decreases
+      below (increases above) the maximum (minimum) value, the
+      gauge64 also decreases (increases).
+
+      In the value set and its semantics, this type is equivalent
+      to the CounterBasedGauge64 SMIv2 textual convention defined
+      in RFC 2856";
+    reference
+     "RFC 2856: Textual Conventions for Additional High Capacity
+                Data Types";
+  }
+
+  /*** collection of identifier-related types ***/
+
+  typedef object-identifier {
+    type string {
+      pattern '(([0-1](\.[1-3]?[0-9]))|(2\.(0|([1-9]\d*))))'
+            + '(\.(0|([1-9]\d*)))*';
+    }
+    description
+     "The object-identifier type represents administratively
+      assigned names in a registration-hierarchical-name tree.
+
+      Values of this type are denoted as a sequence of numerical
+      non-negative sub-identifier values.  Each sub-identifier
+      value MUST NOT exceed 2^32-1 (4294967295).  Sub-identifiers
+      are separated by single dots and without any intermediate
+      whitespace.
+
+      The ASN.1 standard restricts the value space of the first
+      sub-identifier to 0, 1, or 2.  Furthermore, the value space
+      of the second sub-identifier is restricted to the range
+      0 to 39 if the first sub-identifier is 0 or 1.  Finally,
+      the ASN.1 standard requires that an object identifier
+      has always at least two sub-identifiers.  The pattern
+      captures these restrictions.
+
+      Although the number of sub-identifiers is not limited,
+      module designers should realize that there may be
+      implementations that stick with the SMIv2 limit of 128
+      sub-identifiers.
+
+      This type is a superset of the SMIv2 OBJECT IDENTIFIER type
+      since it is not restricted to 128 sub-identifiers.  Hence,
+      this type SHOULD NOT be used to represent the SMIv2 OBJECT
+      IDENTIFIER type; the object-identifier-128 type SHOULD be
+      used instead.";
+    reference
+     "ISO9834-1: Information technology -- Open Systems
+      Interconnection -- Procedures for the operation of OSI
+      Registration Authorities: General procedures and top
+      arcs of the ASN.1 Object Identifier tree";
+  }
+
+  typedef object-identifier-128 {
+    type object-identifier {
+      pattern '\d*(\.\d*){1,127}';
+    }
+    description
+     "This type represents object-identifiers restricted to 128
+      sub-identifiers.
+
+      In the value set and its semantics, this type is equivalent
+      to the OBJECT IDENTIFIER type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef yang-identifier {
+    type string {
+      length "1..max";
+      pattern '[a-zA-Z_][a-zA-Z0-9\-_.]*';
+      pattern '.|..|[^xX].*|.[^mM].*|..[^lL].*';
+    }
+    description
+      "A YANG identifier string as defined by the 'identifier'
+       rule in Section 12 of RFC 6020.  An identifier must
+       start with an alphabetic character or an underscore
+       followed by an arbitrary sequence of alphabetic or
+       numeric characters, underscores, hyphens, or dots.
+
+       A YANG identifier MUST NOT start with any possible
+       combination of the lowercase or uppercase character
+       sequence 'xml'.";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the Network
+                 Configuration Protocol (NETCONF)";
+  }
+
+  /*** collection of types related to date and time***/
+
+  typedef date-and-time {
+    type string {
+      pattern '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?'
+            + '(Z|[\+\-]\d{2}:\d{2})';
+    }
+    description
+     "The date-and-time type is a profile of the ISO 8601
+      standard for representation of dates and times using the
+      Gregorian calendar.  The profile is defined by the
+      date-time production in Section 5.6 of RFC 3339.
+
+      The date-and-time type is compatible with the dateTime XML
+      schema type with the following notable exceptions:
+
+      (a) The date-and-time type does not allow negative years.
+
+      (b) The date-and-time time-offset -00:00 indicates an unknown
+          time zone (see RFC 3339) while -00:00 and +00:00 and Z
+          all represent the same time zone in dateTime.
+
+      (c) The canonical format (see below) of data-and-time values
+          differs from the canonical format used by the dateTime XML
+          schema type, which requires all times to be in UTC using
+          the time-offset 'Z'.
+
+      This type is not equivalent to the DateAndTime textual
+      convention of the SMIv2 since RFC 3339 uses a different
+      separator between full-date and full-time and provides
+      higher resolution of time-secfrac.
+
+      The canonical format for date-and-time values with a known time
+      zone uses a numeric time zone offset that is calculated using
+      the device's configured known offset to UTC time.  A change of
+      the device's offset to UTC time will cause date-and-time values
+      to change accordingly.  Such changes might happen periodically
+      in case a server follows automatically daylight saving time
+      (DST) time zone offset changes.  The canonical format for
+      date-and-time values with an unknown time zone (usually
+      referring to the notion of local time) uses the time-offset
+      -00:00.";
+    reference
+     "RFC 3339: Date and Time on the Internet: Timestamps
+      RFC 2579: Textual Conventions for SMIv2
+      XSD-TYPES: XML Schema Part 2: Datatypes Second Edition";
+  }
+
+  typedef timeticks {
+    type uint32;
+    description
+     "The timeticks type represents a non-negative integer that
+      represents the time, modulo 2^32 (4294967296 decimal), in
+      hundredths of a second between two epochs.  When a schema
+      node is defined that uses this type, the description of
+      the schema node identifies both of the reference epochs.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeTicks type of the SMIv2.";
+    reference
+     "RFC 2578: Structure of Management Information Version 2
+                (SMIv2)";
+  }
+
+  typedef timestamp {
+    type yang:timeticks;
+    description
+     "The timestamp type represents the value of an associated
+      timeticks schema node at which a specific occurrence
+      happened.  The specific occurrence must be defined in the
+      description of any schema node defined using this type.  When
+      the specific occurrence occurred prior to the last time the
+      associated timeticks attribute was zero, then the timestamp
+      value is zero.  Note that this requires all timestamp values
+      to be reset to zero when the value of the associated timeticks
+      attribute reaches 497+ days and wraps around to zero.
+
+      The associated timeticks schema node must be specified
+      in the description of any schema node using this type.
+
+      In the value set and its semantics, this type is equivalent
+      to the TimeStamp textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of generic address types ***/
+
+  typedef phys-address {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+
+    description
+     "Represents media- or physical-level addresses represented
+      as a sequence octets, each octet represented by two hexadecimal
+      numbers.  Octets are separated by colons.  The canonical
+      representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the PhysAddress textual convention of the SMIv2.";
+    reference
+     "RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  typedef mac-address {
+    type string {
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+    }
+    description
+     "The mac-address type represents an IEEE 802 MAC address.
+      The canonical representation uses lowercase characters.
+
+      In the value set and its semantics, this type is equivalent
+      to the MacAddress textual convention of the SMIv2.";
+    reference
+     "IEEE 802: IEEE Standard for Local and Metropolitan Area
+                Networks: Overview and Architecture
+      RFC 2579: Textual Conventions for SMIv2";
+  }
+
+  /*** collection of XML-specific types ***/
+
+  typedef xpath1.0 {
+    type string;
+    description
+     "This type represents an XPATH 1.0 expression.
+
+      When a schema node is defined that uses this type, the
+      description of the schema node MUST specify the XPath
+      context in which the XPath expression is evaluated.";
+    reference
+     "XPATH: XML Path Language (XPath) Version 1.0";
+  }
+
+  /*** collection of string types ***/
+
+  typedef hex-string {
+    type string {
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+    }
+    description
+     "A hexadecimal string with octets represented as hex digits
+      separated by colons.  The canonical representation uses
+      lowercase characters.";
+  }
+
+  typedef uuid {
+    type string {
+      pattern '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+            + '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    }
+    description
+     "A Universally Unique IDentifier in the string representation
+      defined in RFC 4122.  The canonical representation uses
+      lowercase characters.
+
+      The following is an example of a UUID in string representation:
+      f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+      ";
+    reference
+     "RFC 4122: A Universally Unique IDentifier (UUID) URN
+                Namespace";
+  }
+
+  typedef dotted-quad {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      + '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])';
+    }
+    description
+      "An unsigned 32-bit number expressed in the dotted-quad
+       notation, i.e., four octets written as decimal numbers
+       and separated with the '.' (full stop) character.";
+  }
+}

--- a/yang/ntx-topology@2026-06-09.yang
+++ b/yang/ntx-topology@2026-06-09.yang
@@ -1,0 +1,48 @@
+module ntx-topology {
+  yang-version 1.1;
+  namespace "https://github.com/colinedwardwood/network-topology-exporter/yang/ntx-topology";
+  prefix ntx;
+
+  import ietf-network { prefix nw; }
+  import ietf-network-topology { prefix nt; }
+
+  organization "network-topology-exporter";
+  contact "https://github.com/colinedwardwood/network-topology-exporter";
+  description
+    "Exporter-specific augmentations carrying reconciliation provenance that has
+     no home in base RFC 8345/8346: per-link discovery protocol, link kind,
+     confidence and adjacency; per-node inventory. A consumer that understands
+     only base RFC 8345 ignores these augmentations.";
+
+  revision 2026-06-09 {
+    description "Initial revision (issue #75).";
+  }
+
+  typedef discovery-protocol {
+    type enumeration {
+      enum "lldp"; enum "cdp"; enum "bgp"; enum "ospf";
+      enum "fdb"; enum "isis"; enum "mpls_te"; enum "configured";
+    }
+    description "Mirrors discovery.DiscoveryProtocol wire values verbatim.";
+  }
+  typedef link-kind {
+    type enumeration { enum "ethernet"; enum "mpls-te"; enum "ip"; enum "logical"; }
+  }
+  typedef confidence { type enumeration { enum "high"; enum "medium"; enum "low"; } }
+  typedef adjacency { type enumeration { enum "direct"; enum "indirect"; enum "unknown"; } }
+
+  augment "/nw:networks/nw:network/nt:link" {
+    description "Reconciliation provenance on each discovered link.";
+    leaf discovery-protocol { type discovery-protocol; }
+    leaf link-kind { type link-kind; }
+    leaf confidence { type confidence; }
+    leaf adjacency { type adjacency; }
+  }
+  augment "/nw:networks/nw:network/nw:node" {
+    description "Inventory attributes RFC 8345 has no home for.";
+    leaf vendor { type string; }
+    leaf model { type string; }
+    leaf os-version { type string; }
+    leaf site { type string; }
+  }
+}


### PR DESCRIPTION
## Summary
Closes #75. Adds a third output path: the reconciled topology served as **RFC 8345/8346 YANG-JSON** at `GET /topology/yang`, behind `output.yang.enabled: false` (default off), validated in CI with `yanglint`. Honors the committed mapping contract `docs/operator/yang-topology.md`.

- **Pull endpoint** on the metrics mux (same trust as `/metrics`), rendering the current `atomic.Pointer[discovery.Graph]` on demand; pointer-keyed render cache; 503 gated on the same readiness source as `/readyz` (correct in hub mode); HEAD/405+Allow; `application/yang-data+json`.
- **Pure `Render`** (typed structs → RFC 7951 JSON): Device→node, ports→termination-point, Edge→link with **bidirectional→two links**; 8346 `l3-unicast` network-type marker (l3-node-attributes omitted — documented gap); `ntx-topology` augmentation (enums = Go wire constants) for discovery provenance. Renderer enforces referential integrity + key uniqueness + determinism (yanglint can't — `require-instance false`, pattern-free `inet:uri` keys).
- **Vendored** RFC 8345/8346/8294/6991 modules + `ntx-topology.yang` under `yang/`; CI `yang-validate` job loads the closure and validates an **adversarial** instance (empty ports, missing-node edge, unicode id, parallel multi-protocol edges).
- Config `output.yang.{enabled,network_id}`; Helm `values.schema.json` admits it; docs + CHANGELOG.

## Process
Brainstorm → spec → plan → subagent-driven execution (9 TDD tasks). Design **adversarially reviewed twice** (caught a missed committed mapping contract + a missing `ietf-routing-types` import); final whole-branch review **APPROVE**. Three minor non-blocking nits noted for optional follow-up (parity-test rigor, pin yanglint apt pkg, a config-load defaulting test).

## Test Plan
- [x] `go build ./...`; `go test ./... -race` — green; `golangci-lint run` — 0 issues
- [x] `helm lint` + `helm template` with the new config — render clean
- [x] Renderer: bidirectional fan-out, referential integrity, uniqueness (parallel/self-loop), determinism, unicode, empty graph
- [x] Handler: 200/503/404/405/HEAD + `-race` concurrent GET
- [ ] **CI `yang-validate`**: yanglint loads the full module closure and validates the adversarial instance (the one gate that only runs on CI — libyang isn't installable locally)