### PR TITLE
fix(snmp): decode correctness — overflow rejection, TableVerdict, drop divergent Checkout (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ v1.3.1 lands under this milestone instead, renamed to
 
 ### Fixed
 
+- **SNMP decode correctness (#148):** `PDUIntStrict` now rejects out-of-range integer PDUs (e.g. a `Counter64`/`Gauge64` exceeding `math.MaxInt`) as decode failures instead of silently truncating them to a garbage value reported as success — so a required-table policy can no longer pass on corrupt rows. `EvaluateRequiredTablePolicy` returns a single three-state `TableVerdict` (`TableOK`/`TableDegraded`/`TableHardFail` + reason) instead of an error-prone `(degraded, hardFailReason)` pair. Removed a divergent test-only session-pool `Checkout` path that bypassed the real `acquire` state machine's closed/in-use guards; tests now drive the production acquisition path. No behavior change for valid data.
 - **Federation hub (#147):** spoke registrations now commit atomically with winning publication — the hub no longer speculatively writes its spoke registry before validating the combined graph. Oversize graphs are rejected without consuming a publish generation, eliminating a spurious `409 stale_generation` that could be returned to an unrelated valid push (now correctly `204`). Liveness gauges (`federation_spoke_up`, `federation_spoke_last_push_unix`) are committed under the same lock as the graph publish, closing an eviction race.
 - Nokia SR-OS BGP walker now targets the next-gen `tBgpPeerNgTable`
   (`1.3.6.1.4.1.6527.3.1.2.14.4.7`), validated against a real SR-OS 25.7.R2

--- a/docs/superpowers/specs/2026-06-09-snmp-decode-correctness-design.md
+++ b/docs/superpowers/specs/2026-06-09-snmp-decode-correctness-design.md
@@ -1,0 +1,164 @@
+# SNMP-Core Decode Correctness — Design Spec (#148)
+
+**Issue:** #148. **Process:** lighter — spec + one adversarial check + subagent-driven TDD (per-task spec/quality reviews).
+**Scope:** three independent correctness defects in `internal/discovery/snmp`, surfaced by the thermo-nuclear review. One branch (`fix/148-snmp-decode-correctness`), one PR, three TDD tasks. No behavior change for valid in-range data; the changes only affect malformed/overflow inputs and a test-only API.
+
+---
+
+## Fix 1 — `PDUIntStrict` silently truncates and reports success
+
+**File:** `internal/discovery/snmp/pdu.go:304-320`.
+
+**Problem.** `PDUIntStrict` converts `int64`/`uint64` (and `uint`) to `int` with an unconditional `int(v)` and returns `ok=true`. A `uint64 > math.MaxInt64` becomes negative; the `//nolint:gosec` papers over exactly the truncation the `*Strict` variant exists to prevent. Because `WalkToIntMapStrict` (pdu.go:119) feeds `EvaluateRequiredTablePolicy`, a required-table gate can **pass on corrupt data** counted as a valid row. Callers: `WalkToIntMapStrict` (pdu.go:119), `PDUInt` (pdu.go:295), `snmp.go:524` (uptime ticks) — all already treat `ok=false` as "skip / decode failure", so returning `ok=false` on overflow is safe for every caller.
+
+**Change.** Range-check the wide/unsigned cases against `math.MinInt`/`math.MaxInt`; return `(0, false)` when out of range. `int`/`int32` always fit `int` and stay unguarded. Remove the `//nolint:gosec` (the conversion is now guarded). Add `import "math"`.
+
+```go
+func PDUIntStrict(pdu g.SnmpPDU) (int, bool) {
+	switch v := pdu.Value.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		if v < math.MinInt || v > math.MaxInt {
+			return 0, false
+		}
+		return int(v), true
+	case uint:
+		if uint64(v) > math.MaxInt {
+			return 0, false
+		}
+		return int(v), true
+	case uint32:
+		if uint64(v) > math.MaxInt { // always false on 64-bit; correct on 32-bit
+			return 0, false
+		}
+		return int(v), true
+	case uint64:
+		if v > math.MaxInt {
+			return 0, false
+		}
+		return int(v), true
+	}
+	return 0, false
+}
+```
+
+**Tests** (extend `TestPDUIntStrict`, snmp_test.go:89): add cases — `uint64(math.MaxInt64)+1` → `(0,false)`; `uint64(math.MaxUint64)` → `(0,false)`; `int64(math.MaxInt64)` → `(MaxInt64, true)` on 64-bit; a normal `uint64(64512)` → `(64512,true)`. Confirm `WalkToIntMapStrict` counts an overflow row as a `DecodeFailure` (excluded from the map) via a small walk test with an out-of-range Counter64 PDU.
+
+---
+
+## Fix 2 — `EvaluateRequiredTablePolicy` `(degraded, hardFailReason)` foot-gun
+
+**File:** `internal/discovery/snmp/pdu.go:166-177`. **Call sites:** `mpls.go:50` + `mpls.go:63` (evaluates the *same* `operStats` **twice**, extracting one half each), `isis.go:105`.
+
+**Problem.** Two of three returns are `(false, "<reason>")` — a hard-fail returns `degraded=false`, so the two outputs are not independent and a caller checking only `degraded` (mpls.go:63 discards the reason) silently treats a hard-failed table as fine. mpls.go calls the function twice on identical stats to pull each half, inviting drift.
+
+**Change.** Return a single three-state verdict; eliminate the impossible `(false, reason)` shape.
+
+```go
+// TableOutcome is the three-state result of EvaluateRequiredTablePolicy.
+type TableOutcome int
+
+const (
+	TableOK       TableOutcome = iota // usable, no invalid rows
+	TableDegraded                     // usable, but some rows failed to decode
+	TableHardFail                     // failed a required-table floor; see Reason
+)
+
+// TableVerdict is the result of EvaluateRequiredTablePolicy. Reason is set only
+// when Outcome == TableHardFail.
+type TableVerdict struct {
+	Outcome TableOutcome
+	Reason  string
+}
+
+func (v TableVerdict) IsHardFail() bool { return v.Outcome == TableHardFail }
+func (v TableVerdict) IsDegraded() bool { return v.Outcome == TableDegraded }
+
+func EvaluateRequiredTablePolicy(stats IntMapDecodeStats, policy RequiredTablePolicy) TableVerdict {
+	if stats.ValidRows < policy.MinValidRows {
+		return TableVerdict{Outcome: TableHardFail, Reason: "required_table_no_valid_rows"}
+	}
+	if policy.MaxInvalidRatio >= 0 && stats.InvalidRatio > policy.MaxInvalidRatio {
+		return TableVerdict{Outcome: TableHardFail, Reason: "required_table_invalid_ratio_exceeded"}
+	}
+	if stats.InvalidRows > 0 {
+		return TableVerdict{Outcome: TableDegraded}
+	}
+	return TableVerdict{Outcome: TableOK}
+}
+```
+
+**Call-site updates** (behavior identical):
+- `mpls.go` — evaluate `operStats` **once**:
+  ```go
+  operVerdict := snmputil.EvaluateRequiredTablePolicy(operStats, snmputil.RequiredTablePolicy{MinValidRows: requiredMinValidRows, MaxInvalidRatio: requiredMaxInvalidRatio})
+  if operVerdict.IsHardFail() {
+      return nil, nil, &discovery.PolicyError{Module: "mpls_te", Reason: operVerdict.Reason, Err: fmt.Errorf("operStatus stats: valid=%d total=%d invalid=%d ratio=%.3f", operStats.ValidRows, operStats.TotalRows, operStats.InvalidRows, operStats.InvalidRatio)}
+  }
+  // ... later, reuse operVerdict:
+  if operVerdict.IsDegraded() {
+      degradedReasons = append(degradedReasons, discovery.DegradedReasonRequiredTablePartialDecode)
+  }
+  ```
+- `isis.go:105` —
+  ```go
+  verdict := snmputil.EvaluateRequiredTablePolicy(stats, snmputil.RequiredTablePolicy{MinValidRows: requiredMinValidRows, MaxInvalidRatio: requiredMaxInvalidRatio})
+  if verdict.IsHardFail() {
+      return nil, false, &discovery.PolicyError{Module: "isis", Reason: verdict.Reason, Err: fmt.Errorf("adjState stats: valid=%d total=%d invalid=%d ratio=%.3f", stats.ValidRows, stats.TotalRows, stats.InvalidRows, stats.InvalidRatio)}
+  }
+  return states, verdict.IsDegraded(), nil
+  ```
+
+**Tests.** Migrate `TestEvaluateRequiredTablePolicy` (snmp_test.go:261) to assert `verdict.Outcome` (Pass/Degraded/HardFail) + `verdict.Reason` instead of the `(degraded, hardFailReason)` pair. Keep the same input cases (no-valid-rows → HardFail+reason; ratio-exceeded → HardFail+reason; invalid>0 → Degraded; clean → OK). mpls/isis package tests should be unaffected (PolicyError shape unchanged); run them to confirm.
+
+---
+
+## Fix 3 — delete the divergent test-only `Checkout` acquisition path
+
+**File:** `internal/discovery/snmp/pool.go:234-263` (`Checkout`). **Callers:** `pool_test.go` only.
+
+**Problem.** `Checkout` is a second acquisition state machine that lacks every safety property `acquire` (pool.go:135) has: no `closed` check (resurrects the map after `Close`, pooling sessions the now-stopped evictor never sweeps), no defensive in-use guard, and it **unconditionally overwrites** `pl.sessions[key]` (pool.go:258), orphaning a live `*GoSNMP` without closing it. Its doc admits it exists only "so tests drive it directly." Two acquisition state machines where the test-only one violates the pool's invariants is a trap.
+
+**Change.** **Delete `Checkout`.** Tests acquire through the real `acquire` state machine via a small package-internal test helper. **Keep `Return`** — it is correct *disposal* (it verifies `e.session == s`, handles the unhealthy close+evict), not a divergent acquisition path, and it backs `TestSessionPoolReturnUnhealthyEvicts`'s coverage of connection-error eviction. (Decision recorded for the adversarial check: only the acquisition duplicate is the trap; disposal stays.)
+
+Add to `pool_test.go`:
+```go
+// checkout drives the real acquire() state machine for tests, returning the
+// session and its release func. Replaces the deleted Checkout method so tests
+// exercise exactly one acquisition path.
+func checkout(t *testing.T, pl *SessionPool, p Params) (*g.GoSNMP, func()) {
+	t.Helper()
+	s, release, err := pl.acquire(p)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	return s, release
+}
+```
+
+**Test migration** (`pool_test.go`):
+- Replace `s, err := pl.Checkout(p)` + error check with `s, release := checkout(t, pl, p)`.
+- Replace healthy `pl.Return(p, s, true)` with `release()`.
+- `TestSessionPoolReturnUnhealthyEvicts` keeps `pl.Return(p, s, false)` for the unhealthy path (the session was acquired via `checkout`; `Return` finds it by key and evicts). It must NOT also call `release()`.
+- `TestSessionPoolConcurrentDistinctKeys`: each iteration `s, release := checkout(t, pl, p); release()`.
+- Reuse/hit-miss assertions (e.g. `TestSessionPoolCheckoutReuseSameKey`) hold: `acquire` reuses the same pooled session on the second call after `release()`, producing miss=1, hit=1 — identical to the old expectations.
+
+---
+
+## Cross-cutting
+
+- Per fix, a focused TDD task: T1 = `PDUIntStrict`, T2 = `EvaluateRequiredTablePolicy` + 2 call sites, T3 = delete `Checkout` + test migration. Each: red → green → `go test ./... -race` + `gofmt` + `golangci-lint run` clean → commit. (Independent fixes; do not parallelize subagents on the same package — sequential to avoid file conflicts in pdu.go/snmp_test.go.)
+- No Co-Authored-By / AI-attribution trailers; commit author colinedwardwood.
+- CHANGELOG: one Fixed entry summarizing all three (decode overflow now rejected; required-table verdict is a single three-state result; removed the divergent test-only pool-checkout path).
+- No production behavior change for valid data; the only externally visible effect is that genuinely out-of-range integer PDUs are now counted as decode failures (excluded from maps, reflected in existing `invalid_type` decode-issue metrics) rather than silently mistruncated.
+
+## Files touched
+- `internal/discovery/snmp/pdu.go` — `PDUIntStrict` range checks (+`math` import); `TableOutcome`/`TableVerdict` + `EvaluateRequiredTablePolicy` return.
+- `internal/discovery/snmp/pool.go` — delete `Checkout`.
+- `internal/discovery/mpls/mpls.go`, `internal/discovery/isis/isis.go` — verdict call sites.
+- `internal/discovery/snmp/snmp_test.go` — `TestPDUIntStrict` overflow cases, `TestEvaluateRequiredTablePolicy` migration, `WalkToIntMapStrict` overflow-row test.
+- `internal/discovery/snmp/pool_test.go` — `checkout` helper + migrate off `Checkout`.
+- `CHANGELOG.md`.

--- a/docs/superpowers/specs/2026-06-09-snmp-decode-correctness-design.md
+++ b/docs/superpowers/specs/2026-06-09-snmp-decode-correctness-design.md
@@ -45,7 +45,7 @@ func PDUIntStrict(pdu g.SnmpPDU) (int, bool) {
 }
 ```
 
-**Tests** (extend `TestPDUIntStrict`, snmp_test.go:89): add cases — `uint64(math.MaxInt64)+1` → `(0,false)`; `uint64(math.MaxUint64)` → `(0,false)`; `int64(math.MaxInt64)` → `(MaxInt64, true)` on 64-bit; a normal `uint64(64512)` → `(64512,true)`. Confirm `WalkToIntMapStrict` counts an overflow row as a `DecodeFailure` (excluded from the map) via a small walk test with an out-of-range Counter64 PDU.
+**Tests** (extend `TestPDUIntStrict`, snmp_test.go:89): add cases — `uint64(math.MaxInt64)+1` → `(0,false)`; `uint64(math.MaxUint64)` → `(0,false)`; `int64(math.MaxInt64)` → `(MaxInt64, true)` on 64-bit; a normal `uint64(64512)` → `(64512,true)`. The unit cases above are the gate for Fix 1. A `WalkToIntMapStrict` end-to-end test that an out-of-range Counter64 PDU counts as a `DecodeFailure` (excluded from the map) is **best-effort** — only add it if the in-process `snmptest` agent round-trips a `Counter64` value > MaxInt64 through gosnmp's BER codec back as a `uint64`; if that proves fiddly, skip it (the unit cases fully prove the fix).
 
 ---
 
@@ -129,7 +129,9 @@ Add to `pool_test.go`:
 // checkout drives the real acquire() state machine for tests, returning the
 // session and its release func. Replaces the deleted Checkout method so tests
 // exercise exactly one acquisition path.
-func checkout(t *testing.T, pl *SessionPool, p Params) (*g.GoSNMP, func()) {
+// NOTE: pool_test.go imports gosnmp as `gsnmp` (not `g`), so the return type is
+// *gsnmp.GoSNMP, not *g.GoSNMP.
+func checkout(t *testing.T, pl *SessionPool, p Params) (*gsnmp.GoSNMP, func()) {
 	t.Helper()
 	s, release, err := pl.acquire(p)
 	if err != nil {

--- a/internal/discovery/isis/isis.go
+++ b/internal/discovery/isis/isis.go
@@ -102,18 +102,18 @@ func walkAdjStates(ctx context.Context, client *gsnmp.GoSNMP) (map[string]int, b
 	if err != nil {
 		return nil, false, err
 	}
-	degraded, hardFailReason := snmputil.EvaluateRequiredTablePolicy(stats, snmputil.RequiredTablePolicy{
+	verdict := snmputil.EvaluateRequiredTablePolicy(stats, snmputil.RequiredTablePolicy{
 		MinValidRows:    requiredMinValidRows,
 		MaxInvalidRatio: requiredMaxInvalidRatio,
 	})
-	if hardFailReason != "" {
+	if verdict.IsHardFail() {
 		return nil, false, &discovery.PolicyError{
 			Module: "isis",
-			Reason: hardFailReason,
+			Reason: verdict.Reason,
 			Err:    fmt.Errorf("adjState stats: valid=%d total=%d invalid=%d ratio=%.3f", stats.ValidRows, stats.TotalRows, stats.InvalidRows, stats.InvalidRatio),
 		}
 	}
-	return states, degraded, nil
+	return states, verdict.IsDegraded(), nil
 }
 
 // walkCircuitIfNames returns a map from "{sysInst}.{circIdx}" to the interface

--- a/internal/discovery/mpls/mpls.go
+++ b/internal/discovery/mpls/mpls.go
@@ -47,23 +47,21 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	if err != nil {
 		return nil, nil, fmt.Errorf("mpls_te tunnel table %s: %w", p.IP, err)
 	}
-	if _, hardFailReason := snmputil.EvaluateRequiredTablePolicy(operStats, snmputil.RequiredTablePolicy{
+	operVerdict := snmputil.EvaluateRequiredTablePolicy(operStats, snmputil.RequiredTablePolicy{
 		MinValidRows:    requiredMinValidRows,
 		MaxInvalidRatio: requiredMaxInvalidRatio,
-	}); hardFailReason != "" {
+	})
+	if operVerdict.IsHardFail() {
 		return nil, nil, &discovery.PolicyError{
 			Module: "mpls_te",
-			Reason: hardFailReason,
+			Reason: operVerdict.Reason,
 			Err:    fmt.Errorf("operStatus stats: valid=%d total=%d invalid=%d ratio=%.3f", operStats.ValidRows, operStats.TotalRows, operStats.InvalidRows, operStats.InvalidRatio),
 		}
 	}
 
 	adminStatuses, adminStats, adminErr := snmputil.WalkToIntMapStrict(ctx, client, "mpls_te", oidMplsTunnelAdminStatus)
 	degradedReasons := make([]string, 0, 2)
-	if degraded, _ := snmputil.EvaluateRequiredTablePolicy(operStats, snmputil.RequiredTablePolicy{
-		MinValidRows:    requiredMinValidRows,
-		MaxInvalidRatio: requiredMaxInvalidRatio,
-	}); degraded {
+	if operVerdict.IsDegraded() {
 		degradedReasons = append(degradedReasons, discovery.DegradedReasonRequiredTablePartialDecode)
 	}
 	if adminErr != nil {

--- a/internal/discovery/snmp/pdu.go
+++ b/internal/discovery/snmp/pdu.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -307,14 +308,26 @@ func PDUIntStrict(pdu g.SnmpPDU) (int, bool) {
 		return v, true
 	case int32:
 		return int(v), true
+	case int64:
+		if v < math.MinInt || v > math.MaxInt {
+			return 0, false
+		}
+		return int(v), true
 	case uint:
+		if uint64(v) > math.MaxInt {
+			return 0, false
+		}
 		return int(v), true
 	case uint32:
-		return int(v), true
-	case int64:
+		if uint64(v) > math.MaxInt { // always false on 64-bit; correct on 32-bit
+			return 0, false
+		}
 		return int(v), true
 	case uint64:
-		return int(v), true //nolint:gosec // SNMP Gauge64/Counter64 values in practice fit int on 64-bit hosts; this helper is only used to surface MIB-bounded values to internal callers, not untrusted arithmetic
+		if v > math.MaxInt {
+			return 0, false
+		}
+		return int(v), true
 	}
 	return 0, false
 }

--- a/internal/discovery/snmp/pdu.go
+++ b/internal/discovery/snmp/pdu.go
@@ -163,18 +163,41 @@ func WalkToIntMap(ctx context.Context, client *g.GoSNMP, oid string) (map[string
 	return m, nil
 }
 
+// TableOutcome is the three-state result of EvaluateRequiredTablePolicy.
+type TableOutcome int
+
+// TableOK, TableDegraded, and TableHardFail are the possible TableOutcome values.
+const (
+	TableOK       TableOutcome = iota // usable, no invalid rows
+	TableDegraded                     // usable, but some rows failed to decode
+	TableHardFail                     // failed a required-table floor; see Reason
+)
+
+// TableVerdict is the result of EvaluateRequiredTablePolicy. Reason is set only
+// when Outcome == TableHardFail.
+type TableVerdict struct {
+	Outcome TableOutcome
+	Reason  string
+}
+
+// IsHardFail reports whether the table failed a required-table floor.
+func (v TableVerdict) IsHardFail() bool { return v.Outcome == TableHardFail }
+
+// IsDegraded reports whether the table is usable but had decode anomalies.
+func (v TableVerdict) IsDegraded() bool { return v.Outcome == TableDegraded }
+
 // EvaluateRequiredTablePolicy checks decode stats against the required table policy.
-func EvaluateRequiredTablePolicy(stats IntMapDecodeStats, policy RequiredTablePolicy) (degraded bool, hardFailReason string) {
+func EvaluateRequiredTablePolicy(stats IntMapDecodeStats, policy RequiredTablePolicy) TableVerdict {
 	if stats.ValidRows < policy.MinValidRows {
-		return false, "required_table_no_valid_rows"
+		return TableVerdict{Outcome: TableHardFail, Reason: "required_table_no_valid_rows"}
 	}
 	if policy.MaxInvalidRatio >= 0 && stats.InvalidRatio > policy.MaxInvalidRatio {
-		return false, "required_table_invalid_ratio_exceeded"
+		return TableVerdict{Outcome: TableHardFail, Reason: "required_table_invalid_ratio_exceeded"}
 	}
 	if stats.InvalidRows > 0 {
-		return true, ""
+		return TableVerdict{Outcome: TableDegraded}
 	}
-	return false, ""
+	return TableVerdict{Outcome: TableOK}
 }
 
 // WalkIfNames walks the IF-MIB ifXTable.ifName column (RFC 2863 §3.1.4) and

--- a/internal/discovery/snmp/pool.go
+++ b/internal/discovery/snmp/pool.go
@@ -231,40 +231,9 @@ func (pl *SessionPool) returnKey(key poolKey) {
 	}
 }
 
-// Checkout returns a live session for p, opening one if none is pooled.
-// It is the lower-level handle behind acquire; tests drive it directly to
-// assert hit/miss behaviour. The returned session must be handed back via
-// Return.
-func (pl *SessionPool) Checkout(p Params) (*g.GoSNMP, error) {
-	key := poolKey{ip: p.IP.String(), profile: p.CredentialProfile}
-
-	pl.mu.Lock()
-	if e, ok := pl.sessions[key]; ok && !e.inUse {
-		e.inUse = true
-		e.lastUsed = time.Now()
-		s := e.session
-		pl.recordHitLocked()
-		pl.mu.Unlock()
-		return s, nil
-	}
-	pl.mu.Unlock()
-
-	client, err := Open(p)
-	if err != nil {
-		pl.recordMiss()
-		return nil, err
-	}
-	pl.mu.Lock()
-	pl.sessions[key] = &poolEntry{session: client, lastUsed: time.Now(), inUse: true}
-	pl.setSizeLocked()
-	pl.recordMiss()
-	pl.mu.Unlock()
-	return client, nil
-}
-
 // Return hands a session back to the pool. When healthy is false (the walk hit
 // a connection-level error), the session is closed and evicted with reason
-// connection_error so the next Checkout dials fresh rather than reusing a dead
+// connection_error so the next acquire dials fresh rather than reusing a dead
 // socket. When healthy, the entry is marked available and its idle clock reset.
 func (pl *SessionPool) Return(p Params, s *g.GoSNMP, healthy bool) {
 	key := poolKey{ip: p.IP.String(), profile: p.CredentialProfile}

--- a/internal/discovery/snmp/pool_test.go
+++ b/internal/discovery/snmp/pool_test.go
@@ -64,6 +64,20 @@ func startAgent(t *testing.T, community, profile string) Params {
 	return Params{IP: ip, Port: port, Community: []byte(community), CredentialProfile: profile, Timeout: 3 * time.Second}
 }
 
+// checkout drives the real acquire() state machine for tests, returning the
+// session and its release func. Replaces the deleted Checkout method so tests
+// exercise exactly one acquisition path.
+// NOTE: pool_test.go imports gosnmp as `gsnmp` (not `g`), so the return type is
+// *gsnmp.GoSNMP, not *g.GoSNMP.
+func checkout(t *testing.T, pl *SessionPool, p Params) (*gsnmp.GoSNMP, func()) {
+	t.Helper()
+	s, release, err := pl.acquire(p)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	return s, release
+}
+
 func TestSessionPoolCheckoutReuseSameKey(t *testing.T) {
 	fm := newFakeSessionPoolMetrics()
 	pl := NewSessionPool(SessionPoolOptions{MaxIdle: time.Hour, Metrics: fm})
@@ -71,20 +85,14 @@ func TestSessionPoolCheckoutReuseSameKey(t *testing.T) {
 
 	p := startAgent(t, "public", "profA")
 
-	s1, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("first checkout: %v", err)
-	}
-	pl.Return(p, s1, true)
+	s1, release1 := checkout(t, pl, p)
+	release1()
 
-	s2, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("second checkout: %v", err)
-	}
+	s2, release2 := checkout(t, pl, p)
 	if s1 != s2 {
 		t.Fatalf("expected same session reused on repeat checkout, got different instances")
 	}
-	pl.Return(p, s2, true)
+	release2()
 
 	hits, misses, _, _ := fm.snapshot()
 	if misses != 1 {
@@ -105,19 +113,13 @@ func TestSessionPoolDifferentProfileIsDifferentSession(t *testing.T) {
 	pB := pA
 	pB.CredentialProfile = "profB"
 
-	sA, err := pl.Checkout(pA)
-	if err != nil {
-		t.Fatalf("checkout A: %v", err)
-	}
-	sB, err := pl.Checkout(pB)
-	if err != nil {
-		t.Fatalf("checkout B: %v", err)
-	}
+	sA, releaseA := checkout(t, pl, pA)
+	sB, releaseB := checkout(t, pl, pB)
 	if sA == sB {
 		t.Fatalf("expected distinct sessions for distinct profiles")
 	}
-	pl.Return(pA, sA, true)
-	pl.Return(pB, sB, true)
+	releaseA()
+	releaseB()
 
 	_, misses, size, _ := fm.snapshot()
 	if misses != 2 {
@@ -134,11 +136,8 @@ func TestSessionPoolInvalidateProfile(t *testing.T) {
 	defer pl.Close()
 
 	p := startAgent(t, "public", "rotateme")
-	s1, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("checkout: %v", err)
-	}
-	pl.Return(p, s1, true)
+	s1, release1 := checkout(t, pl, p)
+	release1()
 
 	pl.InvalidateProfile("rotateme")
 
@@ -151,14 +150,11 @@ func TestSessionPoolInvalidateProfile(t *testing.T) {
 	}
 
 	// Subsequent checkout opens fresh (different instance, counted as a miss).
-	s2, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("checkout after invalidate: %v", err)
-	}
+	s2, release2 := checkout(t, pl, p)
 	if s2 == s1 {
 		t.Fatalf("expected a fresh session after InvalidateProfile")
 	}
-	pl.Return(p, s2, true)
+	release2()
 }
 
 func TestSessionPoolIdleEviction(t *testing.T) {
@@ -167,11 +163,8 @@ func TestSessionPoolIdleEviction(t *testing.T) {
 	defer pl.Close()
 
 	p := startAgent(t, "public", "idle")
-	s, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("checkout: %v", err)
-	}
-	pl.Return(p, s, true)
+	_, release := checkout(t, pl, p)
+	release()
 
 	// Force the entry's lastUsed far into the past, then run the evictor.
 	key := poolKey{ip: p.IP.String(), profile: p.CredentialProfile}
@@ -196,10 +189,7 @@ func TestSessionPoolReturnUnhealthyEvicts(t *testing.T) {
 	defer pl.Close()
 
 	p := startAgent(t, "public", "conn")
-	s, err := pl.Checkout(p)
-	if err != nil {
-		t.Fatalf("checkout: %v", err)
-	}
+	s, _ := checkout(t, pl, p)
 	pl.Return(p, s, false) // unhealthy
 
 	_, _, size, ev := fm.snapshot()
@@ -217,11 +207,8 @@ func TestSessionPoolCloseClosesAll(t *testing.T) {
 
 	for _, prof := range []string{"a", "b", "c"} {
 		p := startAgent(t, "public", prof)
-		s, err := pl.Checkout(p)
-		if err != nil {
-			t.Fatalf("checkout %s: %v", prof, err)
-		}
-		pl.Return(p, s, true)
+		_, release := checkout(t, pl, p)
+		release()
 	}
 	_, _, size, _ := fm.snapshot()
 	if size != 3 {
@@ -260,12 +247,8 @@ func TestSessionPoolConcurrentDistinctKeys(t *testing.T) {
 		go func(p Params) {
 			defer wg.Done()
 			for j := 0; j < iters; j++ {
-				s, err := pl.Checkout(p)
-				if err != nil {
-					t.Errorf("checkout: %v", err)
-					return
-				}
-				pl.Return(p, s, true)
+				_, release := checkout(t, pl, p)
+				release()
 			}
 		}(params[i])
 	}

--- a/internal/discovery/snmp/pool_test.go
+++ b/internal/discovery/snmp/pool_test.go
@@ -225,7 +225,7 @@ func TestSessionPoolCloseClosesAll(t *testing.T) {
 	pl.Close()
 }
 
-// TestSessionPoolConcurrentDistinctKeys drives Checkout/Return across many
+// TestSessionPoolConcurrentDistinctKeys drives checkout/release across many
 // goroutines for DIFFERENT keys concurrently and the same key sequentially.
 // Run under -race; the pool map must stay consistent with no data race.
 func TestSessionPoolConcurrentDistinctKeys(t *testing.T) {

--- a/internal/discovery/snmp/snmp_test.go
+++ b/internal/discovery/snmp/snmp_test.go
@@ -100,6 +100,7 @@ func TestPDUIntStrict(t *testing.T) {
 		{int64(11), 11, true},
 		{uint64(13), 13, true},
 		{uint64(64512), 64512, true},
+		{uint32(4294967295), 4294967295, true}, // Gauge32 max — fits int on 64-bit, must not be rejected
 		{int64(math.MaxInt64), math.MaxInt64, true},
 		{uint64(math.MaxInt64) + 1, 0, false},
 		{uint64(math.MaxUint64), 0, false},

--- a/internal/discovery/snmp/snmp_test.go
+++ b/internal/discovery/snmp/snmp_test.go
@@ -266,41 +266,41 @@ func TestWalkToIntMapStrictDecodeFailures(t *testing.T) {
 func TestEvaluateRequiredTablePolicy(t *testing.T) {
 	policy := RequiredTablePolicy{MinValidRows: 1, MaxInvalidRatio: 0.5}
 	cases := []struct {
-		name       string
-		stats      IntMapDecodeStats
-		wantDegrad bool
-		wantFail   string
+		name        string
+		stats       IntMapDecodeStats
+		wantOutcome TableOutcome
+		wantReason  string
 	}{
 		{
-			name:       "clean table",
-			stats:      IntMapDecodeStats{TotalRows: 10, ValidRows: 10, InvalidRows: 0, InvalidRatio: 0},
-			wantDegrad: false,
-			wantFail:   "",
+			name:        "clean table",
+			stats:       IntMapDecodeStats{TotalRows: 10, ValidRows: 10, InvalidRows: 0, InvalidRatio: 0},
+			wantOutcome: TableOK,
+			wantReason:  "",
 		},
 		{
-			name:       "partial anomalies below threshold",
-			stats:      IntMapDecodeStats{TotalRows: 10, ValidRows: 8, InvalidRows: 2, InvalidRatio: 0.2},
-			wantDegrad: true,
-			wantFail:   "",
+			name:        "partial anomalies below threshold",
+			stats:       IntMapDecodeStats{TotalRows: 10, ValidRows: 8, InvalidRows: 2, InvalidRatio: 0.2},
+			wantOutcome: TableDegraded,
+			wantReason:  "",
 		},
 		{
-			name:       "no valid rows",
-			stats:      IntMapDecodeStats{TotalRows: 2, ValidRows: 0, InvalidRows: 2, InvalidRatio: 1.0},
-			wantDegrad: false,
-			wantFail:   "required_table_no_valid_rows",
+			name:        "no valid rows",
+			stats:       IntMapDecodeStats{TotalRows: 2, ValidRows: 0, InvalidRows: 2, InvalidRatio: 1.0},
+			wantOutcome: TableHardFail,
+			wantReason:  "required_table_no_valid_rows",
 		},
 		{
-			name:       "invalid ratio exceeded",
-			stats:      IntMapDecodeStats{TotalRows: 3, ValidRows: 1, InvalidRows: 2, InvalidRatio: 0.666},
-			wantDegrad: false,
-			wantFail:   "required_table_invalid_ratio_exceeded",
+			name:        "invalid ratio exceeded",
+			stats:       IntMapDecodeStats{TotalRows: 3, ValidRows: 1, InvalidRows: 2, InvalidRatio: 0.666},
+			wantOutcome: TableHardFail,
+			wantReason:  "required_table_invalid_ratio_exceeded",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotDegrad, gotFail := EvaluateRequiredTablePolicy(tc.stats, policy)
-			if gotDegrad != tc.wantDegrad || gotFail != tc.wantFail {
-				t.Errorf("EvaluateRequiredTablePolicy(%+v) = (%v,%q), want (%v,%q)", tc.stats, gotDegrad, gotFail, tc.wantDegrad, tc.wantFail)
+			verdict := EvaluateRequiredTablePolicy(tc.stats, policy)
+			if verdict.Outcome != tc.wantOutcome || verdict.Reason != tc.wantReason {
+				t.Errorf("EvaluateRequiredTablePolicy(%+v) = {Outcome:%v Reason:%q}, want {Outcome:%v Reason:%q}", tc.stats, verdict.Outcome, verdict.Reason, tc.wantOutcome, tc.wantReason)
 			}
 		})
 	}

--- a/internal/discovery/snmp/snmp_test.go
+++ b/internal/discovery/snmp/snmp_test.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"context"
+	"math"
 	"net"
 	"strings"
 	"testing"
@@ -98,6 +99,10 @@ func TestPDUIntStrict(t *testing.T) {
 		{uint32(7), 7, true},
 		{int64(11), 11, true},
 		{uint64(13), 13, true},
+		{uint64(64512), 64512, true},
+		{int64(math.MaxInt64), math.MaxInt64, true},
+		{uint64(math.MaxInt64) + 1, 0, false},
+		{uint64(math.MaxUint64), 0, false},
 		{float64(1.0), 0, false},
 		{"7", 0, false},
 	}


### PR DESCRIPTION
Closes #148. Three independent SNMP-core correctness fixes from the thermo-nuclear review. No behavior change for valid data.

## 1. `PDUIntStrict` rejects out-of-range integers instead of truncating
`int64`/`uint`/`uint32`/`uint64` are now range-checked against `math.MinInt`/`math.MaxInt`; an out-of-range value (e.g. a `Counter64` > `MaxInt64`) returns `(0, false)` — a counted decode failure — instead of being mistruncated to a garbage value reported as `ok=true`. Because `WalkToIntMapStrict` feeds `EvaluateRequiredTablePolicy`, this stops a required-table gate from passing on corrupt rows. The `//nolint:gosec` is gone (the conversions are now guarded). `int`/`int32` stay unguarded (always fit).

## 2. `EvaluateRequiredTablePolicy` returns a three-state `TableVerdict`
Replaces the `(degraded bool, hardFailReason string)` foot-gun — where a hard-fail returned `degraded=false`, so a caller checking only `degraded` silently treated a failed table as fine — with `TableVerdict{Outcome: TableOK|TableDegraded|TableHardFail, Reason}` (+ `IsHardFail()`/`IsDegraded()`). `mpls.go` now evaluates its operStats **once** (was twice); `isis.go` updated. Reason strings and `PolicyError` shape unchanged.

## 3. Remove the divergent test-only pool `Checkout`
`Checkout` was a second acquisition state machine missing `acquire`'s closed-check, in-use guard, and cold-key re-check — it could resurrect the map after `Close` and orphan a live session by unconditional overwrite. Deleted; tests now drive the real `acquire` via a `checkout(t, pl, p)` helper. `Return` (correct disposal, backs the unhealthy-eviction test) is kept.

## Process
Spec → one adversarial check (which compiled Fix 1 on amd64 + 386, ran gosec to confirm the `//nolint` removal is safe, and traced every caller) → subagent-driven TDD with spec-compliance + code-quality review (both passed; added a Gauge32-max accept case on review suggestion).

## Test plan
- [x] `go test ./... -race` — green
- [x] `golangci-lint run ./internal/discovery/...` — 0 issues (gosec clean after dropping the nolint)
- [x] `TestPDUIntStrict` — overflow rejected, Gauge32-max + Counter64≤MaxInt64 accepted
- [x] `TestEvaluateRequiredTablePolicy` — all three outcomes + reasons
- [x] mpls/isis package tests — PolicyError/degraded behavior unchanged
- [x] pool tests drive `acquire`; `grep 'func (pl *SessionPool) Checkout'` empty