### PR TITLE
refactor(discovery): canonical walker-outcome layer (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ v1.3.1 lands under this milestone instead, renamed to
   (freshness), `network_topology_federation_spoke_push_drops_total`,
   `network_topology_federation_spoke_push_queue_depth`.
 
+### Internal
+
+- Walker outcome-accounting deduplicated into `internal/discovery/snmp`
+  (`snmputil`) (#149). The per-package `recordWalkerOutcome`/`recordDegraded`
+  forwarders, the five-value `outcome*` constant set, and the four-way terminal
+  classification switch — previously copy-pasted across the FDB, LLDP, CDP,
+  OSPF, IS-IS, and BGP walkers — now live once as
+  `snmputil.RecordProtocolWalkerOutcome` / `RecordBGPWalkerOutcome` /
+  `RecordDegraded` / `ClassifyNeighbourOutcome` and the `snmputil.Outcome*`
+  constants. No behavior change: every emitted `{walker, outcome}` /
+  `{module, reason}` metric label value is byte-identical (BGP keeps its own
+  `no_peers`/`malformed_index` vocabulary and stays on its separate counter).
+
 ### Security & correctness (post-merge hardening)
 
 - **Nightly fuzz no longer false-alarms (#107).** The `fuzz-nightly` workflow ran

--- a/docs/superpowers/specs/2026-06-09-canonical-walker-outcome-design.md
+++ b/docs/superpowers/specs/2026-06-09-canonical-walker-outcome-design.md
@@ -89,14 +89,17 @@ func ClassifyNeighbourOutcome(edgeCount int, hadPDUs, decoded bool) string {
 **isis:** delete local `recordDegraded`; replace calls with `snmputil.RecordDegraded(&p, module, reason)`.
 
 **bgp:**
-- Delete the local `recordWalkerOutcome` func; replace its calls with `snmputil.RecordBGPWalkerOutcome(&p, walker, outcome)` (routes to the SAME `RecordWalkerOutcome` BGP counter — verify by reading bgp.go's call sites).
-- BGP's own outcome constants (`outcomeEdges`, `outcomeMIBUnimplemented`, `outcomeNoPeers`, `outcomeMalformedIndex`, `outcomeWalkerDrift`, `outcomeError`) — **leave these local to bgp.** BGP's vocabulary differs (`no_peers`/`malformed_index`) and its classification is bespoke; merging only the shared subset would split bgp's constants across two homes for little gain and more risk on a recently-touched, hardware-validated walker. (Decision recorded for the adversarial check: scope the constant-dedup to the four neighbour walkers; bgp shares only the forwarder.)
+- Delete the local `recordWalkerOutcome` func; replace ALL its calls with `snmputil.RecordBGPWalkerOutcome(...)` (routes to the SAME `RecordWalkerOutcome` BGP counter). **Call sites are in BOTH `bgp.go` AND `bgp_vendor.go`** (the adversarial check found seven in `bgp_vendor.go` at ~:320,387,393,395,397,403,405). Mind the receiver: bgp.go passes `&p`, but `bgp_vendor.go` already has a `*snmputil.Params` (`p`) at its call sites — match each existing argument exactly (don't add/drop an `&`).
+- BGP's own outcome constants (`outcomeEdges`, `outcomeMIBUnimplemented`, `outcomeNoPeers`, `outcomeMalformedIndex`, `outcomeWalkerDrift`, `outcomeError`) — **leave these local to bgp** (used by `bgp_vendor.go`'s bespoke classification). BGP's vocabulary differs (`no_peers`/`malformed_index`) and merging only the shared subset would split bgp's constants across two homes for little gain and more risk on a recently-touched, hardware-validated walker. (Verified by the adversarial check: the shared string values are coincidental, not a maintained invariant — leaving them is the lower-risk call.)
 
 ## Tests
 
-- New `internal/discovery/snmp/outcome_test.go`: a table test for `ClassifyNeighbourOutcome` covering all four buckets (edges>0; !hadPDUs; decoded-no-edge; drift), and a nil-safety test that `RecordProtocolWalkerOutcome`/`RecordBGPWalkerOutcome`/`RecordDegraded` no-op on nil `Params` and nil `WalkerMetrics` (and forward correctly with a fake sink that records calls).
-- Existing per-walker outcome tests (fdb/lldp/cdp/ospf/bgp/isis `*_outcome_test.go` and friends) must pass UNCHANGED — they assert the emitted label values, which are byte-identical. This is the regression gate proving zero behavior change.
+- New `internal/discovery/snmp/outcome_test.go`: a table test for `ClassifyNeighbourOutcome` covering all four buckets (edges>0; !hadPDUs; decoded-no-edge; drift), and a nil-safety test that `RecordProtocolWalkerOutcome`/`RecordBGPWalkerOutcome`/`RecordDegraded` no-op on nil `Params` and nil `WalkerMetrics` (and forward to the correct sink method with a fake `WalkerMetrics` that records calls — assert the protocol vs BGP routing).
+- **Regression gate — the emitted label VALUES are unchanged** (byte-identical), so the per-walker outcome tests' *assertions* stay the same. But two mechanical, non-semantic edits are required because the tests reference soon-to-be-deleted unexported identifiers (caught by the adversarial check):
+  - The four non-bgp outcome tests (`fdb_outcome_test.go`, `lldp_outcome_test.go`, `cdp_outcome_test.go`, `ospf_outcome_test.go`) reference the local `outcomeEdges`/`outcomeMIBUnimplemented`/`outcomeNoNeighbours`/`outcomeWalkerDrift`/`outcomeError` consts → repoint to `snmputil.OutcomeEdges` etc. (the `walkerFDB`/`walkerLLDP`/… label consts are kept locally, so those references are fine).
+  - `bgp_outcome_test.go`'s `TestRecordWalkerOutcomeNilSafe` calls the unexported `recordWalkerOutcome` → either retarget it to `snmputil.RecordBGPWalkerOutcome` or delete it (nil-safety is now covered canonically in `outcome_test.go`). Prefer retarget to keep bgp-specific coverage.
 - `go test ./... -race`, `gofmt`, `golangci-lint run` clean.
+- **fdb note:** the fdb terminal switch feeds from `hadFdbPDUs` (locally renamed), not `hadPDUs` — write `snmputil.ClassifyNeighbourOutcome(len(edges), hadFdbPDUs, decoded)` for fdb.
 
 ## Cross-cutting
 - One branch (`refactor/149-canonical-walker-outcome`), one PR closing #149. No Co-Authored-By / AI-attribution trailers; author colinedwardwood.
@@ -105,7 +108,7 @@ func ClassifyNeighbourOutcome(edgeCount int, hadPDUs, decoded bool) string {
 
 ## Files touched
 - `internal/discovery/snmp/outcome.go` (new), `internal/discovery/snmp/outcome_test.go` (new)
-- `internal/discovery/{fdb,lldp,cdp,ospf}/*.go` — delete locals, call snmputil
+- `internal/discovery/{fdb,lldp,cdp,ospf}/*.go` — delete local funcs/consts, call snmputil; repoint the four `*_outcome_test.go` const references to `snmputil.Outcome*`
 - `internal/discovery/isis/isis.go` — RecordDegraded
-- `internal/discovery/bgp/bgp.go` — RecordBGPWalkerOutcome (forwarder only)
+- `internal/discovery/bgp/bgp.go` **and `internal/discovery/bgp/bgp_vendor.go`** — RecordBGPWalkerOutcome (forwarder only; keep bgp's local consts); retarget `bgp_outcome_test.go`'s nil-safe test
 - `CHANGELOG.md`

--- a/docs/superpowers/specs/2026-06-09-canonical-walker-outcome-design.md
+++ b/docs/superpowers/specs/2026-06-09-canonical-walker-outcome-design.md
@@ -1,0 +1,111 @@
+# Canonical Walker-Outcome Layer — Design Spec (#149)
+
+**Issue:** #149. **Process:** lighter — spec + one adversarial check + subagent-driven TDD.
+**Goal:** Remove the copy-pasted walker outcome-accounting code across 6 discovery packages by lifting it into the `snmp` (`snmputil`) package once. **Pure refactor — zero metric-value or behavior change.** Every emitted `{walker, outcome}` / `{module, reason}` label stays byte-identical so existing Prometheus series and alerts are untouched.
+
+## The duplication (verified in code)
+
+- **`recordWalkerOutcome(p *snmputil.Params, walker, outcome string)`** — nil-safe forwarder, duplicated in `fdb.go:138`, `lldp.go:64`, `cdp.go:57`, `ospf.go:87` (all forward to `p.WalkerMetrics.RecordProtocolWalkerOutcome`) **and** `bgp.go:66` (forwards to `p.WalkerMetrics.RecordWalkerOutcome` — a **different** sink/counter).
+- **`recordDegraded(p *snmputil.Params, module, reason string)`** — identical in `fdb.go:150` and `isis.go:93` (forward to `p.WalkerMetrics.RecordDegraded`).
+- **Outcome constant set** `{edges, mib_unimplemented, no_neighbours, walker_drift, error}` — duplicated in `fdb.go:117`, `lldp.go:53`, `cdp.go:46`, `ospf.go:76`, each carrying a "Keep in sync" comment (the tell that the compiler should own this). BGP has a **different** vocabulary (`no_peers`, `malformed_index` instead of `no_neighbours`) and is NOT a member of this set.
+- **The 4-way terminal classification switch** `edges>0 → edges; !hadPDUs → mib_unimplemented; decoded → no_neighbours; default → walker_drift` — duplicated in `fdb.go:249`, `lldp.go:155`, `cdp.go:110`, `ospf.go:122`. (The `error` outcome is emitted separately on early walk-error returns, not part of this terminal switch.)
+
+**The trap (do not fall into it):** bgp routes to `RecordWalkerOutcome` (→ `network_topology_bgp_walker_outcome_total`); the other four route to `RecordProtocolWalkerOutcome` (→ `network_topology_walker_outcome_total`). These are deliberately separate (snmp.go:42-46) so the long-standing BGP series is never renamed. A single shared forwarder MUST preserve both routes.
+
+## Canonical layer — new file `internal/discovery/snmp/outcome.go` (package `snmp`)
+
+```go
+package snmp
+
+// Walker outcome label values for the generic per-protocol walker-outcome
+// counter (network_topology_walker_outcome_total, issue #98), shared by the
+// LLDP, CDP, OSPF, and FDB walkers. BGP uses its own vocabulary
+// (network_topology_bgp_walker_outcome_total) and does not share these.
+const (
+	OutcomeEdges            = "edges"
+	OutcomeMIBUnimplemented = "mib_unimplemented"
+	OutcomeNoNeighbours     = "no_neighbours"
+	OutcomeWalkerDrift      = "walker_drift"
+	OutcomeError            = "error"
+)
+
+// RecordProtocolWalkerOutcome forwards a {walker, outcome} observation to the
+// generic per-protocol counter via the metrics sink on Params. nil-safe: a nil
+// Params or nil Params.WalkerMetrics drops the increment rather than panicking.
+func RecordProtocolWalkerOutcome(p *Params, walker, outcome string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
+}
+
+// RecordBGPWalkerOutcome forwards to the BGP-specific counter
+// (network_topology_bgp_walker_outcome_total). Same nil-tolerance.
+func RecordBGPWalkerOutcome(p *Params, walker, outcome string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordWalkerOutcome(walker, outcome)
+}
+
+// RecordDegraded forwards a {module, reason} observation to
+// DiscoveryDegradedTotal. Same nil-tolerance. Zero-edge degraded path (#100).
+func RecordDegraded(p *Params, module, reason string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordDegraded(module, reason)
+}
+
+// ClassifyNeighbourOutcome maps a neighbour-walk result to its terminal outcome
+// label, shared by the LLDP/CDP/OSPF/FDB walkers. edgeCount is the edges built;
+// hadPDUs is whether the MIB returned any rows; decoded is whether rows decoded
+// cleanly even if they produced no edge. (Walk-error early returns emit
+// OutcomeError directly and never reach here.)
+func ClassifyNeighbourOutcome(edgeCount int, hadPDUs, decoded bool) string {
+	switch {
+	case edgeCount > 0:
+		return OutcomeEdges
+	case !hadPDUs:
+		return OutcomeMIBUnimplemented
+	case decoded:
+		return OutcomeNoNeighbours
+	default:
+		return OutcomeWalkerDrift
+	}
+}
+```
+
+## Per-package changes (mechanical; metric values unchanged)
+
+**fdb / lldp / cdp / ospf** (each):
+- Delete the local `recordWalkerOutcome` func and the local `outcome*` constant block (keep the `walkerXxx` label const and any package-specific consts e.g. fdb's `reasonQBridgeWalkFailed`).
+- Replace `recordWalkerOutcome(&p, walkerX, outcomeError)` early-return calls → `snmputil.RecordProtocolWalkerOutcome(&p, walkerX, snmputil.OutcomeError)`.
+- Replace the 4-way terminal switch with one call:
+  `snmputil.RecordProtocolWalkerOutcome(&p, walkerX, snmputil.ClassifyNeighbourOutcome(len(edges), hadPDUs, decoded))`
+  — preserving each walker's existing `hadPDUs`/`decoded` variables. (Confirm each walker's switch is exactly the 4-way shape above; if a walker has an extra arm or different comment-only nuance, keep its behavior — only the bucket strings must match.)
+
+**fdb additionally:** delete local `recordDegraded`; replace calls with `snmputil.RecordDegraded(&p, "fdb", reason)`.
+**isis:** delete local `recordDegraded`; replace calls with `snmputil.RecordDegraded(&p, module, reason)`.
+
+**bgp:**
+- Delete the local `recordWalkerOutcome` func; replace its calls with `snmputil.RecordBGPWalkerOutcome(&p, walker, outcome)` (routes to the SAME `RecordWalkerOutcome` BGP counter — verify by reading bgp.go's call sites).
+- BGP's own outcome constants (`outcomeEdges`, `outcomeMIBUnimplemented`, `outcomeNoPeers`, `outcomeMalformedIndex`, `outcomeWalkerDrift`, `outcomeError`) — **leave these local to bgp.** BGP's vocabulary differs (`no_peers`/`malformed_index`) and its classification is bespoke; merging only the shared subset would split bgp's constants across two homes for little gain and more risk on a recently-touched, hardware-validated walker. (Decision recorded for the adversarial check: scope the constant-dedup to the four neighbour walkers; bgp shares only the forwarder.)
+
+## Tests
+
+- New `internal/discovery/snmp/outcome_test.go`: a table test for `ClassifyNeighbourOutcome` covering all four buckets (edges>0; !hadPDUs; decoded-no-edge; drift), and a nil-safety test that `RecordProtocolWalkerOutcome`/`RecordBGPWalkerOutcome`/`RecordDegraded` no-op on nil `Params` and nil `WalkerMetrics` (and forward correctly with a fake sink that records calls).
+- Existing per-walker outcome tests (fdb/lldp/cdp/ospf/bgp/isis `*_outcome_test.go` and friends) must pass UNCHANGED — they assert the emitted label values, which are byte-identical. This is the regression gate proving zero behavior change.
+- `go test ./... -race`, `gofmt`, `golangci-lint run` clean.
+
+## Cross-cutting
+- One branch (`refactor/149-canonical-walker-outcome`), one PR closing #149. No Co-Authored-By / AI-attribution trailers; author colinedwardwood.
+- CHANGELOG: a brief "Changed/Internal" entry (no user-facing behavior change) noting the dedup. (If CHANGELOG has no internal/changed section, add under a suitable existing heading; this is not a Fixed/Added item.)
+- Net effect: ~5 funcs + 4 constant blocks + 4 switches collapse to one `outcome.go`; the "Keep in sync" comments disappear because the compiler now owns the invariant.
+
+## Files touched
+- `internal/discovery/snmp/outcome.go` (new), `internal/discovery/snmp/outcome_test.go` (new)
+- `internal/discovery/{fdb,lldp,cdp,ospf}/*.go` — delete locals, call snmputil
+- `internal/discovery/isis/isis.go` — RecordDegraded
+- `internal/discovery/bgp/bgp.go` — RecordBGPWalkerOutcome (forwarder only)
+- `CHANGELOG.md`

--- a/internal/discovery/bgp/bgp.go
+++ b/internal/discovery/bgp/bgp.go
@@ -53,23 +53,6 @@ import (
 	snmputil "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 )
 
-// recordWalkerOutcome forwards a {walker, outcome} observation to the
-// metrics sink carried on Params. Walker outcome accounting is dependency-
-// injected — the bgp package no longer holds a package-level counter handle.
-// See snmputil.WalkerMetrics for the interface and cmd/topology-exporter/
-// main.go for the adapter that wraps Metrics.BGPWalkerOutcomeTotal.
-//
-// nil-safety: drop the increment, don't crash. p may be nil in unit tests
-// that exercise recordWalkerOutcome directly, and p.WalkerMetrics may be
-// nil when discovery cycles run before main has finished wiring (or in
-// tests that intentionally inject no sink to verify the drop path).
-func recordWalkerOutcome(p *snmputil.Params, walker, outcome string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordWalkerOutcome(walker, outcome)
-}
-
 // Walker label constants. Keep these in sync with the metric's documented
 // label set in internal/metrics/metrics.go and docs/metrics.md.
 //
@@ -225,18 +208,18 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	// device implements the MIB but BGP is down).
 	peers, hadPDUs, err := walkBgpPeerTable(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerRFC4273, outcomeError)
+		snmputil.RecordBGPWalkerOutcome(&p, walkerRFC4273, outcomeError)
 		return nil, nil, fmt.Errorf("bgp peer table %s: %w", p.IP, err)
 	}
 
 	edges, oos := buildEdges(localDevice, peers, allowedNets)
 	switch {
 	case len(edges) > 0:
-		recordWalkerOutcome(&p, walkerRFC4273, outcomeEdges)
+		snmputil.RecordBGPWalkerOutcome(&p, walkerRFC4273, outcomeEdges)
 	case hadPDUs:
-		recordWalkerOutcome(&p, walkerRFC4273, outcomeNoPeers)
+		snmputil.RecordBGPWalkerOutcome(&p, walkerRFC4273, outcomeNoPeers)
 	default:
-		recordWalkerOutcome(&p, walkerRFC4273, outcomeMIBUnimplemented)
+		snmputil.RecordBGPWalkerOutcome(&p, walkerRFC4273, outcomeMIBUnimplemented)
 	}
 
 	// Promote a stashed vendor-walker error to Warn now that RFC 4273

--- a/internal/discovery/bgp/bgp_outcome_test.go
+++ b/internal/discovery/bgp/bgp_outcome_test.go
@@ -514,7 +514,7 @@ func TestVendorWalkerLabel(t *testing.T) {
 	}
 }
 
-// TestRecordWalkerOutcomeNilSafe verifies that recordWalkerOutcome
+// TestRecordWalkerOutcomeNilSafe verifies that snmputil.RecordBGPWalkerOutcome
 // tolerates both a nil *Params and a Params with nil WalkerMetrics. The
 // original issue #23 concern was that an increment to a nil counter must
 // be DROPPED, not redirected to a stale pointer. With the DI rewrite
@@ -529,17 +529,17 @@ func TestRecordWalkerOutcomeNilSafe(t *testing.T) {
 	t.Parallel()
 
 	// (1) nil Params pointer.
-	recordWalkerOutcome(nil, walkerVendorCisco, outcomeEdges) // must not panic
+	snmputil.RecordBGPWalkerOutcome(nil, walkerVendorCisco, outcomeEdges) // must not panic
 
 	// (2) Params with nil WalkerMetrics — the increment must drop, not
 	// hit any sink.
 	pNoSink := &snmputil.Params{}
-	recordWalkerOutcome(pNoSink, walkerVendorCisco, outcomeEdges) // must not panic
+	snmputil.RecordBGPWalkerOutcome(pNoSink, walkerVendorCisco, outcomeEdges) // must not panic
 
 	// (3) Params with a real sink — the increment lands as expected.
 	fake := &fakeWalkerMetrics{}
 	pWithSink := &snmputil.Params{WalkerMetrics: fake}
-	recordWalkerOutcome(pWithSink, walkerVendorCisco, outcomeEdges)
+	snmputil.RecordBGPWalkerOutcome(pWithSink, walkerVendorCisco, outcomeEdges)
 	if got := fake.count(walkerVendorCisco, outcomeEdges); got != 1 {
 		t.Errorf("real sink: count = %d, want 1", got)
 	}
@@ -548,7 +548,7 @@ func TestRecordWalkerOutcomeNilSafe(t *testing.T) {
 	// stand-ins for the old "SetWalkerOutcomeCounter(nil) must drop"
 	// behaviour from the package-global era.
 	pWithSink.WalkerMetrics = nil
-	recordWalkerOutcome(pWithSink, walkerVendorCisco, outcomeEdges)
+	snmputil.RecordBGPWalkerOutcome(pWithSink, walkerVendorCisco, outcomeEdges)
 	if got := fake.count(walkerVendorCisco, outcomeEdges); got != 1 {
 		t.Errorf("after nil-out: fake count = %d, want 1 (drop must not land on stale sink)", got)
 	}

--- a/internal/discovery/bgp/bgp_vendor.go
+++ b/internal/discovery/bgp/bgp_vendor.go
@@ -317,7 +317,7 @@ func walkVendorPeerTable(ctx context.Context, p *snmputil.Params, client *gsnmp.
 		if peer == nil {
 			peerIP, ok := spec.decodeIndex(rest)
 			if !ok {
-				recordWalkerOutcome(p, vendorWalkerLabel(spec.name), outcomeMalformedIndex)
+				snmputil.RecordBGPWalkerOutcome(p, vendorWalkerLabel(spec.name), outcomeMalformedIndex)
 				failedIndexes[rest] = struct{}{}
 				slog.Debug("bgp vendor: malformed index, dropping row",
 					"walker", vendorWalkerLabel(spec.name),
@@ -384,25 +384,25 @@ func walkAndBuildVendorEdges(
 	walker := vendorWalkerLabel(spec.name)
 	peers, hadPDUs, allRowsMalformed, ok, err := walkVendorPeerTable(ctx, p, client, spec)
 	if err != nil {
-		recordWalkerOutcome(p, walker, outcomeError)
+		snmputil.RecordBGPWalkerOutcome(p, walker, outcomeError)
 		return nil, nil, false, err
 	}
 	if !ok {
 		switch {
 		case !hadPDUs:
-			recordWalkerOutcome(p, walker, outcomeMIBUnimplemented)
+			snmputil.RecordBGPWalkerOutcome(p, walker, outcomeMIBUnimplemented)
 		case allRowsMalformed:
-			recordWalkerOutcome(p, walker, outcomeWalkerDrift)
+			snmputil.RecordBGPWalkerOutcome(p, walker, outcomeWalkerDrift)
 		default:
-			recordWalkerOutcome(p, walker, outcomeNoPeers)
+			snmputil.RecordBGPWalkerOutcome(p, walker, outcomeNoPeers)
 		}
 		return nil, nil, false, nil
 	}
 	edges, oos := buildVendorEdges(localDevice, peers, allowedNets)
 	if len(edges) > 0 {
-		recordWalkerOutcome(p, walker, outcomeEdges)
+		snmputil.RecordBGPWalkerOutcome(p, walker, outcomeEdges)
 	} else {
-		recordWalkerOutcome(p, walker, outcomeNoPeers)
+		snmputil.RecordBGPWalkerOutcome(p, walker, outcomeNoPeers)
 	}
 	return edges, oos, true, nil
 }

--- a/internal/discovery/cdp/cdp.go
+++ b/internal/discovery/cdp/cdp.go
@@ -36,30 +36,10 @@ const (
 	precedenceRank   = 3
 )
 
-// Walker label and outcome constants for network_topology_walker_outcome_total
-// (issue #98). The walker label is fixed per package; the outcome set is closed
-// and mirrors the four-bucket BGP categorisation documented on
-// internal/metrics/metrics.go (Metrics.WalkerOutcomeTotal). Keep in sync.
-const (
-	walkerCDP = "cdp"
-
-	outcomeEdges            = "edges"
-	outcomeMIBUnimplemented = "mib_unimplemented"
-	outcomeNoNeighbours     = "no_neighbours"
-	outcomeWalkerDrift      = "walker_drift"
-	outcomeError            = "error"
-)
-
-// recordWalkerOutcome forwards a {walker, outcome} observation to the generic
-// non-BGP counter via the metrics sink carried on Params. nil-safe: a nil
-// Params or nil Params.WalkerMetrics drops the increment rather than panicking,
-// mirroring bgp.recordWalkerOutcome.
-func recordWalkerOutcome(p *snmputil.Params, walker, outcome string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
-}
+// walkerCDP is the fixed walker label for network_topology_walker_outcome_total
+// (issue #98). The outcome label values and the {walker, outcome} forwarder live
+// in snmputil (snmputil.Outcome*, snmputil.RecordProtocolWalkerOutcome).
+const walkerCDP = "cdp"
 
 // cdpCacheTable column numbers (CISCO-CDP-MIB).
 const (
@@ -83,14 +63,14 @@ type cacheEntry struct {
 func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNets []*net.IPNet) ([]discovery.Edge, []discovery.OutOfScopeNeighbour, error) {
 	client, release, err := snmputil.Acquire(p)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerCDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerCDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("cdp %s: %w", p.IP, err)
 	}
 	defer release()
 
 	ifNames, err := snmputil.WalkIfNamesWithFallback(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerCDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerCDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("cdp ifname %s: %w", p.IP, err)
 	}
 
@@ -99,26 +79,16 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	// devices) from a device that does cache neighbours.
 	entries, hadPDUs, err := walkCacheTable(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerCDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerCDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("cdp cache %s: %w", p.IP, err)
 	}
 
 	edges, oos, decoded := buildEdges(ctx, localDevice, ifNames, entries, allowedNets)
 
-	switch {
-	case len(edges) > 0:
-		recordWalkerOutcome(&p, walkerCDP, outcomeEdges)
-	case !hadPDUs:
-		recordWalkerOutcome(&p, walkerCDP, outcomeMIBUnimplemented)
-	case decoded:
-		// PDUs arrived and at least one cache row decoded cleanly, but no
-		// usable edge resulted (e.g. neighbour filtered out of scope).
-		recordWalkerOutcome(&p, walkerCDP, outcomeNoNeighbours)
-	default:
-		// PDUs arrived but no cache row yielded a usable neighbour identity;
-		// the MIB is implemented but our decoder doesn't match this firmware.
-		recordWalkerOutcome(&p, walkerCDP, outcomeWalkerDrift)
-	}
+	// Terminal outcome classification (edges / mib_unimplemented / no_neighbours
+	// / walker_drift) lives in snmputil.ClassifyNeighbourOutcome, shared with the
+	// LLDP/OSPF/FDB walkers.
+	snmputil.RecordProtocolWalkerOutcome(&p, walkerCDP, snmputil.ClassifyNeighbourOutcome(len(edges), hadPDUs, decoded))
 
 	return edges, oos, nil
 }

--- a/internal/discovery/cdp/cdp_outcome_test.go
+++ b/internal/discovery/cdp/cdp_outcome_test.go
@@ -100,7 +100,7 @@ func TestOutcomeEdges(t *testing.T) {
 	if len(edges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(edges))
 	}
-	if got := fake.count(walkerCDP, outcomeEdges); got != 1 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeEdges); got != 1 {
 		t.Errorf("cdp edges = %d, want 1", got)
 	}
 }
@@ -122,10 +122,10 @@ func TestOutcomeMIBUnimplemented(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerCDP, outcomeMIBUnimplemented); got != 1 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeMIBUnimplemented); got != 1 {
 		t.Errorf("cdp mib_unimplemented = %d, want 1", got)
 	}
-	if got := fake.count(walkerCDP, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("cdp walker_drift = %d, want 0 (zero PDUs is not drift)", got)
 	}
 }
@@ -152,10 +152,10 @@ func TestOutcomeWalkerDrift(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerCDP, outcomeWalkerDrift); got != 1 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeWalkerDrift); got != 1 {
 		t.Errorf("cdp walker_drift = %d, want 1", got)
 	}
-	if got := fake.count(walkerCDP, outcomeNoNeighbours); got != 0 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeNoNeighbours); got != 0 {
 		t.Errorf("cdp no_neighbours = %d, want 0 (no row decoded cleanly)", got)
 	}
 }
@@ -180,10 +180,10 @@ func TestOutcomeNoNeighbours(t *testing.T) {
 	if len(oos) != 1 {
 		t.Fatalf("expected 1 out-of-scope neighbour, got %d", len(oos))
 	}
-	if got := fake.count(walkerCDP, outcomeNoNeighbours); got != 1 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeNoNeighbours); got != 1 {
 		t.Errorf("cdp no_neighbours = %d, want 1", got)
 	}
-	if got := fake.count(walkerCDP, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("cdp walker_drift = %d, want 0 (row decoded cleanly)", got)
 	}
 }
@@ -203,10 +203,10 @@ func TestOutcomeError(t *testing.T) {
 	}
 
 	_, _, _ = Walk(context.Background(), p, "local-sw", nil)
-	if got := fake.count(walkerCDP, outcomeError); got != 1 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeError); got != 1 {
 		t.Errorf("cdp error = %d, want 1", got)
 	}
-	if got := fake.count(walkerCDP, outcomeEdges); got != 0 {
+	if got := fake.count(walkerCDP, snmputil.OutcomeEdges); got != 0 {
 		t.Errorf("cdp edges = %d, want 0 on error path", got)
 	}
 }

--- a/internal/discovery/fdb/fdb.go
+++ b/internal/discovery/fdb/fdb.go
@@ -107,19 +107,10 @@ const (
 	colFdbStatus  = 3
 )
 
-// Walker label and outcome constants for network_topology_walker_outcome_total
-// (issue #98). The walker label is fixed per package; the outcome set is closed
-// and mirrors the four-bucket BGP categorisation documented on
-// internal/metrics/metrics.go (Metrics.WalkerOutcomeTotal). Keep in sync.
-const (
-	walkerFDB = "fdb"
-
-	outcomeEdges            = "edges"
-	outcomeMIBUnimplemented = "mib_unimplemented"
-	outcomeNoNeighbours     = "no_neighbours"
-	outcomeWalkerDrift      = "walker_drift"
-	outcomeError            = "error"
-)
+// walkerFDB is the fixed walker label for network_topology_walker_outcome_total
+// (issue #98). The outcome label values and the {walker, outcome} forwarder live
+// in snmputil (snmputil.Outcome*, snmputil.RecordProtocolWalkerOutcome).
+const walkerFDB = "fdb"
 
 // Degraded reasons for network_topology_discovery_degraded_total{module="fdb"}
 // (issue #100). These signal a sub-walk failure that left the device's
@@ -130,29 +121,6 @@ const (
 	reasonQBridgeWalkFailed = "qbridge_walk_failed"
 	reasonVLANWalkFailed    = "vlan_walk_failed"
 )
-
-// recordWalkerOutcome forwards a {walker, outcome} observation to the generic
-// non-BGP counter via the metrics sink carried on Params. nil-safe: a nil
-// Params or nil Params.WalkerMetrics drops the increment rather than panicking,
-// mirroring bgp.recordWalkerOutcome.
-func recordWalkerOutcome(p *snmputil.Params, walker, outcome string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
-}
-
-// recordDegraded forwards a {module, reason} degraded observation to
-// DiscoveryDegradedTotal via the metrics sink carried on Params. nil-safe like
-// recordWalkerOutcome. This is the zero-edge degraded path (issue #100): a
-// failed sub-walk that yields no edge cannot be carried by the orchestrator's
-// edge-metadata degraded channel, so the module reports it directly.
-func recordDegraded(p *snmputil.Params, module, reason string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordDegraded(module, reason)
-}
 
 // Sub-walk seams (issue #100). Wrapping the two non-fatal sub-walks in
 // package-level function variables lets tests inject a failure that the
@@ -188,7 +156,7 @@ type fdbEntry struct {
 func Walk(ctx context.Context, p snmputil.Params, localDevice string, _ []*net.IPNet) ([]discovery.Edge, []discovery.OutOfScopeNeighbour, error) {
 	client, release, err := snmputil.Acquire(p)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerFDB, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("fdb %s: %w", p.IP, err)
 	}
 	defer release()
@@ -198,7 +166,7 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, _ []*net.I
 	// a learning bridge) from a switch that does populate its forwarding DB.
 	entries, hadFdbPDUs, err := walkFdbTable(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerFDB, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("fdb table %s: %w", p.IP, err)
 	}
 	// Q-BRIDGE walk failures are non-fatal: devices that implement only B-MIB
@@ -216,7 +184,7 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, _ []*net.I
 	if err := walkQBridgeFdbTableFn(ctx, client, entries); err != nil {
 		slog.Debug("fdb: Q-BRIDGE walk failed; using B-MIB only", "device", p.IP, "err", err)
 		if !bmibHadEntries {
-			recordDegraded(&p, walkerFDB, reasonQBridgeWalkFailed)
+			snmputil.RecordDegraded(&p, walkerFDB, reasonQBridgeWalkFailed)
 		}
 	}
 	maxVlans := p.MaxVlans
@@ -230,37 +198,26 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, _ []*net.I
 	hadFdbPDUs = hadFdbPDUs || len(entries) > 0
 	bridgePorts, err := walkBasePortTable(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerFDB, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("fdb baseport %s: %w", p.IP, err)
 	}
 	stpStates, err := walkStpPortStates(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerFDB, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("fdb stpport %s: %w", p.IP, err)
 	}
 	ifNames, err := snmputil.WalkIfNamesWithFallback(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerFDB, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("fdb ifname %s: %w", p.IP, err)
 	}
 
 	edges, decoded := buildEdges(ctx, localDevice, entries, bridgePorts, ifNames, stpStates)
 
-	switch {
-	case len(edges) > 0:
-		recordWalkerOutcome(&p, walkerFDB, outcomeEdges)
-	case !hadFdbPDUs:
-		recordWalkerOutcome(&p, walkerFDB, outcomeMIBUnimplemented)
-	case decoded:
-		// FDB rows decoded cleanly but produced no peer (all entries filtered
-		// by status/STP, or only multi-MAC trunk ports that are suppressed,
-		// or no bridge-port→ifIndex mapping). Bridge is up, nothing to report.
-		recordWalkerOutcome(&p, walkerFDB, outcomeNoNeighbours)
-	default:
-		// PDUs arrived but no entry carried a valid MAC+port; the MIB is
-		// implemented but our decoder doesn't match this firmware.
-		recordWalkerOutcome(&p, walkerFDB, outcomeWalkerDrift)
-	}
+	// Terminal outcome classification (edges / mib_unimplemented / no_neighbours
+	// / walker_drift) lives in snmputil.ClassifyNeighbourOutcome, shared with the
+	// LLDP/CDP/OSPF walkers. fdb feeds it hadFdbPDUs as the "had PDUs" signal.
+	snmputil.RecordProtocolWalkerOutcome(&p, walkerFDB, snmputil.ClassifyNeighbourOutcome(len(edges), hadFdbPDUs, decoded))
 
 	return edges, nil, nil
 }
@@ -519,14 +476,14 @@ func walkVlanCommunityFdbs(ctx context.Context, pp *snmputil.Params, client *gsn
 				// A per-VLAN session that won't open leaves that VLAN's
 				// bridging topology undiscovered (issue #100). Label by reason
 				// only — never by vlan id — to keep cardinality bounded.
-				recordDegraded(pp, walkerFDB, reasonVLANWalkFailed)
+				snmputil.RecordDegraded(pp, walkerFDB, reasonVLANWalkFailed)
 				return
 			}
 			defer func() { _ = vlanClient.Conn.Close() }()
 			vlanEntries := make(map[string]*fdbEntry)
 			if _, err := walkFdbTableIntoFn(ctx, vlanClient, vlanEntries); err != nil {
 				slog.Debug("fdb: VLAN community walk incomplete", "device", vp.IP, "vlan", vlan, "err", err)
-				recordDegraded(pp, walkerFDB, reasonVLANWalkFailed)
+				snmputil.RecordDegraded(pp, walkerFDB, reasonVLANWalkFailed)
 			}
 			results[idx] = result{vlanEntries: vlanEntries}
 		}(i, vlanID)

--- a/internal/discovery/fdb/fdb_outcome_test.go
+++ b/internal/discovery/fdb/fdb_outcome_test.go
@@ -107,7 +107,7 @@ func TestOutcomeEdges(t *testing.T) {
 	if len(edges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(edges))
 	}
-	if got := fake.count(walkerFDB, outcomeEdges); got != 1 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeEdges); got != 1 {
 		t.Errorf("fdb edges = %d, want 1", got)
 	}
 }
@@ -129,10 +129,10 @@ func TestOutcomeMIBUnimplemented(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerFDB, outcomeMIBUnimplemented); got != 1 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeMIBUnimplemented); got != 1 {
 		t.Errorf("fdb mib_unimplemented = %d, want 1", got)
 	}
-	if got := fake.count(walkerFDB, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("fdb walker_drift = %d, want 0 (zero PDUs is not drift)", got)
 	}
 }
@@ -160,10 +160,10 @@ func TestOutcomeWalkerDrift(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerFDB, outcomeWalkerDrift); got != 1 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeWalkerDrift); got != 1 {
 		t.Errorf("fdb walker_drift = %d, want 1", got)
 	}
-	if got := fake.count(walkerFDB, outcomeNoNeighbours); got != 0 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeNoNeighbours); got != 0 {
 		t.Errorf("fdb no_neighbours = %d, want 0 (no entry decoded cleanly)", got)
 	}
 }
@@ -195,10 +195,10 @@ func TestOutcomeNoNeighbours(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerFDB, outcomeNoNeighbours); got != 1 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeNoNeighbours); got != 1 {
 		t.Errorf("fdb no_neighbours = %d, want 1", got)
 	}
-	if got := fake.count(walkerFDB, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("fdb walker_drift = %d, want 0 (entry decoded cleanly)", got)
 	}
 }
@@ -216,10 +216,10 @@ func TestOutcomeError(t *testing.T) {
 	}
 
 	_, _, _ = Walk(context.Background(), p, "sw-01", nil)
-	if got := fake.count(walkerFDB, outcomeError); got != 1 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeError); got != 1 {
 		t.Errorf("fdb error = %d, want 1", got)
 	}
-	if got := fake.count(walkerFDB, outcomeEdges); got != 0 {
+	if got := fake.count(walkerFDB, snmputil.OutcomeEdges); got != 0 {
 		t.Errorf("fdb edges = %d, want 0 on error path", got)
 	}
 }

--- a/internal/discovery/isis/isis.go
+++ b/internal/discovery/isis/isis.go
@@ -79,22 +79,9 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	// would be nothing to stamp (same zero-edge problem as FDB, issue #100).
 	// Once per walk regardless of how many IPv6 rows were skipped.
 	if sawIPv6 {
-		recordDegraded(&p, "isis", discovery.DegradedReasonUnsupportedIPVersion)
+		snmputil.RecordDegraded(&p, "isis", discovery.DegradedReasonUnsupportedIPVersion)
 	}
 	return edges, oos, nil
-}
-
-// recordDegraded forwards a {module, reason} degraded observation to
-// DiscoveryDegradedTotal via the metrics sink carried on Params. nil-safe: a
-// nil Params or nil WalkerMetrics drops the increment rather than panicking.
-// This is the zero-edge degraded path (issue #100): an IPv6-only IS-IS device
-// returns no IPv4 edge to carry the signal through the orchestrator's
-// edge-metadata channel, so the module reports it directly.
-func recordDegraded(p *snmputil.Params, module, reason string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordDegraded(module, reason)
 }
 
 func walkAdjStates(ctx context.Context, client *gsnmp.GoSNMP) (map[string]int, bool, error) {

--- a/internal/discovery/lldp/lldp.go
+++ b/internal/discovery/lldp/lldp.go
@@ -43,30 +43,10 @@ const (
 	precedenceRank  = 2
 )
 
-// Walker label and outcome constants for network_topology_walker_outcome_total
-// (issue #98). The walker label is fixed per package; the outcome set is closed
-// and mirrors the four-bucket BGP categorisation documented on
-// internal/metrics/metrics.go (Metrics.WalkerOutcomeTotal). Keep in sync.
-const (
-	walkerLLDP = "lldp"
-
-	outcomeEdges            = "edges"
-	outcomeMIBUnimplemented = "mib_unimplemented"
-	outcomeNoNeighbours     = "no_neighbours"
-	outcomeWalkerDrift      = "walker_drift"
-	outcomeError            = "error"
-)
-
-// recordWalkerOutcome forwards a {walker, outcome} observation to the generic
-// non-BGP counter via the metrics sink carried on Params. nil-safe: a nil
-// Params or nil Params.WalkerMetrics drops the increment rather than panicking,
-// mirroring bgp.recordWalkerOutcome.
-func recordWalkerOutcome(p *snmputil.Params, walker, outcome string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
-}
+// walkerLLDP is the fixed walker label for network_topology_walker_outcome_total
+// (issue #98). The outcome label values and the {walker, outcome} forwarder live
+// in snmputil (snmputil.Outcome*, snmputil.RecordProtocolWalkerOutcome).
+const walkerLLDP = "lldp"
 
 // LldpPortIdSubtype values from IEEE 802.1AB Table 8-3.
 const (
@@ -124,14 +104,14 @@ type remEntry struct {
 func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNets []*net.IPNet) ([]discovery.Edge, []discovery.OutOfScopeNeighbour, error) {
 	client, release, err := snmputil.Acquire(p)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerLLDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerLLDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("lldp %s: %w", p.IP, err)
 	}
 	defer release()
 
 	locPorts, err := walkLocPorts(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerLLDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerLLDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("lldp locport %s: %w", p.IP, err)
 	}
 
@@ -140,32 +120,20 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	// advertise neighbours.
 	remEntries, hadPDUs, err := walkRemEntries(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerLLDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerLLDP, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("lldp remtable %s: %w", p.IP, err)
 	}
 
 	edges, oos, decoded, err := buildEdges(ctx, localDevice, locPorts, remEntries, allowedNets)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerLLDP, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerLLDP, snmputil.OutcomeError)
 		return nil, nil, err
 	}
 
-	switch {
-	case len(edges) > 0:
-		recordWalkerOutcome(&p, walkerLLDP, outcomeEdges)
-	case !hadPDUs:
-		recordWalkerOutcome(&p, walkerLLDP, outcomeMIBUnimplemented)
-	case decoded:
-		// PDUs arrived and at least one row decoded cleanly, but no usable
-		// edge resulted (e.g. all neighbours filtered out of scope, or
-		// unresolvable device/port). Protocol up, nothing to report.
-		recordWalkerOutcome(&p, walkerLLDP, outcomeNoNeighbours)
-	default:
-		// PDUs arrived but every assembled row was rejected by the decoder
-		// (invalid subtype/length, unparseable IDs). The MIB is implemented;
-		// our decoder doesn't match this firmware.
-		recordWalkerOutcome(&p, walkerLLDP, outcomeWalkerDrift)
-	}
+	// Terminal outcome classification (edges / mib_unimplemented / no_neighbours
+	// / walker_drift) lives in snmputil.ClassifyNeighbourOutcome, shared with the
+	// CDP/OSPF/FDB walkers.
+	snmputil.RecordProtocolWalkerOutcome(&p, walkerLLDP, snmputil.ClassifyNeighbourOutcome(len(edges), hadPDUs, decoded))
 
 	return edges, oos, nil
 }

--- a/internal/discovery/lldp/lldp_outcome_test.go
+++ b/internal/discovery/lldp/lldp_outcome_test.go
@@ -89,7 +89,7 @@ func TestOutcomeEdges(t *testing.T) {
 	if len(edges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(edges))
 	}
-	if got := fake.count(walkerLLDP, outcomeEdges); got != 1 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeEdges); got != 1 {
 		t.Errorf("lldp edges = %d, want 1", got)
 	}
 }
@@ -111,10 +111,10 @@ func TestOutcomeMIBUnimplemented(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerLLDP, outcomeMIBUnimplemented); got != 1 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeMIBUnimplemented); got != 1 {
 		t.Errorf("lldp mib_unimplemented = %d, want 1", got)
 	}
-	if got := fake.count(walkerLLDP, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("lldp walker_drift = %d, want 0 (zero PDUs is not drift)", got)
 	}
 }
@@ -142,10 +142,10 @@ func TestOutcomeWalkerDrift(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerLLDP, outcomeWalkerDrift); got != 1 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeWalkerDrift); got != 1 {
 		t.Errorf("lldp walker_drift = %d, want 1", got)
 	}
-	if got := fake.count(walkerLLDP, outcomeNoNeighbours); got != 0 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeNoNeighbours); got != 0 {
 		t.Errorf("lldp no_neighbours = %d, want 0 (every row rejected)", got)
 	}
 }
@@ -181,10 +181,10 @@ func TestOutcomeNoNeighbours(t *testing.T) {
 	if len(oos) != 1 {
 		t.Fatalf("expected 1 out-of-scope neighbour, got %d", len(oos))
 	}
-	if got := fake.count(walkerLLDP, outcomeNoNeighbours); got != 1 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeNoNeighbours); got != 1 {
 		t.Errorf("lldp no_neighbours = %d, want 1", got)
 	}
-	if got := fake.count(walkerLLDP, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("lldp walker_drift = %d, want 0 (row decoded cleanly)", got)
 	}
 }
@@ -205,10 +205,10 @@ func TestOutcomeError(t *testing.T) {
 	}
 
 	_, _, _ = Walk(context.Background(), p, "leaf-01", nil)
-	if got := fake.count(walkerLLDP, outcomeError); got != 1 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeError); got != 1 {
 		t.Errorf("lldp error = %d, want 1", got)
 	}
-	if got := fake.count(walkerLLDP, outcomeEdges); got != 0 {
+	if got := fake.count(walkerLLDP, snmputil.OutcomeEdges); got != 0 {
 		t.Errorf("lldp edges = %d, want 0 on error path", got)
 	}
 }

--- a/internal/discovery/ospf/ospf.go
+++ b/internal/discovery/ospf/ospf.go
@@ -66,30 +66,10 @@ const (
 	stateFull   = 8
 )
 
-// Walker label and outcome constants for network_topology_walker_outcome_total
-// (issue #98). The walker label is fixed per package; the outcome set is closed
-// and mirrors the four-bucket BGP categorisation documented on
-// internal/metrics/metrics.go (Metrics.WalkerOutcomeTotal). Keep in sync.
-const (
-	walkerOSPF = "ospf"
-
-	outcomeEdges            = "edges"
-	outcomeMIBUnimplemented = "mib_unimplemented"
-	outcomeNoNeighbours     = "no_neighbours"
-	outcomeWalkerDrift      = "walker_drift"
-	outcomeError            = "error"
-)
-
-// recordWalkerOutcome forwards a {walker, outcome} observation to the generic
-// non-BGP counter via the metrics sink carried on Params. nil-safe: a nil
-// Params or nil Params.WalkerMetrics drops the increment rather than panicking,
-// mirroring bgp.recordWalkerOutcome.
-func recordWalkerOutcome(p *snmputil.Params, walker, outcome string) {
-	if p == nil || p.WalkerMetrics == nil {
-		return
-	}
-	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
-}
+// walkerOSPF is the fixed walker label for network_topology_walker_outcome_total
+// (issue #98). The outcome label values and the {walker, outcome} forwarder live
+// in snmputil (snmputil.Outcome*, snmputil.RecordProtocolWalkerOutcome).
+const walkerOSPF = "ospf"
 
 type nbrRow struct {
 	nbrIP net.IP
@@ -102,7 +82,7 @@ type nbrRow struct {
 func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNets []*net.IPNet) ([]discovery.Edge, []discovery.OutOfScopeNeighbour, error) {
 	client, release, err := snmputil.Acquire(p)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerOSPF, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerOSPF, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("ospf %s: %w", p.IP, err)
 	}
 	defer release()
@@ -112,26 +92,15 @@ func Walk(ctx context.Context, p snmputil.Params, localDevice string, allowedNet
 	// don't ship the RFC 4750 MIB) from a device that does report neighbours.
 	rows, hadPDUs, err := walkOspfNbrTable(ctx, client)
 	if err != nil {
-		recordWalkerOutcome(&p, walkerOSPF, outcomeError)
+		snmputil.RecordProtocolWalkerOutcome(&p, walkerOSPF, snmputil.OutcomeError)
 		return nil, nil, fmt.Errorf("ospf nbrTable %s: %w", p.IP, err)
 	}
 	edges, oos, decoded := buildEdges(localDevice, rows, allowedNets)
 
-	switch {
-	case len(edges) > 0:
-		recordWalkerOutcome(&p, walkerOSPF, outcomeEdges)
-	case !hadPDUs:
-		recordWalkerOutcome(&p, walkerOSPF, outcomeMIBUnimplemented)
-	case decoded:
-		// PDUs arrived and at least one neighbour row decoded cleanly, but no
-		// usable edge resulted (e.g. every neighbour is below full/twoWay, or
-		// all filtered out of scope). Protocol up, nothing to report.
-		recordWalkerOutcome(&p, walkerOSPF, outcomeNoNeighbours)
-	default:
-		// PDUs arrived but no row carried a usable neighbour IP; the MIB is
-		// implemented but our decoder doesn't match this firmware.
-		recordWalkerOutcome(&p, walkerOSPF, outcomeWalkerDrift)
-	}
+	// Terminal outcome classification (edges / mib_unimplemented / no_neighbours
+	// / walker_drift) lives in snmputil.ClassifyNeighbourOutcome, shared with the
+	// LLDP/CDP/FDB walkers.
+	snmputil.RecordProtocolWalkerOutcome(&p, walkerOSPF, snmputil.ClassifyNeighbourOutcome(len(edges), hadPDUs, decoded))
 
 	return edges, oos, nil
 }

--- a/internal/discovery/ospf/ospf_outcome_test.go
+++ b/internal/discovery/ospf/ospf_outcome_test.go
@@ -84,7 +84,7 @@ func TestOutcomeEdges(t *testing.T) {
 	if len(edges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(edges))
 	}
-	if got := fake.count(walkerOSPF, outcomeEdges); got != 1 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeEdges); got != 1 {
 		t.Errorf("ospf edges = %d, want 1", got)
 	}
 }
@@ -106,10 +106,10 @@ func TestOutcomeMIBUnimplemented(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerOSPF, outcomeMIBUnimplemented); got != 1 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeMIBUnimplemented); got != 1 {
 		t.Errorf("ospf mib_unimplemented = %d, want 1", got)
 	}
-	if got := fake.count(walkerOSPF, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("ospf walker_drift = %d, want 0 (zero PDUs is not drift)", got)
 	}
 }
@@ -134,10 +134,10 @@ func TestOutcomeWalkerDrift(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerOSPF, outcomeWalkerDrift); got != 1 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeWalkerDrift); got != 1 {
 		t.Errorf("ospf walker_drift = %d, want 1", got)
 	}
-	if got := fake.count(walkerOSPF, outcomeNoNeighbours); got != 0 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeNoNeighbours); got != 0 {
 		t.Errorf("ospf no_neighbours = %d, want 0 (no row decoded a usable IP)", got)
 	}
 }
@@ -162,10 +162,10 @@ func TestOutcomeNoNeighbours(t *testing.T) {
 	if len(edges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(edges))
 	}
-	if got := fake.count(walkerOSPF, outcomeNoNeighbours); got != 1 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeNoNeighbours); got != 1 {
 		t.Errorf("ospf no_neighbours = %d, want 1", got)
 	}
-	if got := fake.count(walkerOSPF, outcomeWalkerDrift); got != 0 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeWalkerDrift); got != 0 {
 		t.Errorf("ospf walker_drift = %d, want 0 (row decoded a usable IP)", got)
 	}
 }
@@ -183,10 +183,10 @@ func TestOutcomeError(t *testing.T) {
 	}
 
 	_, _, _ = Walk(context.Background(), p, "router-x", nil)
-	if got := fake.count(walkerOSPF, outcomeError); got != 1 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeError); got != 1 {
 		t.Errorf("ospf error = %d, want 1", got)
 	}
-	if got := fake.count(walkerOSPF, outcomeEdges); got != 0 {
+	if got := fake.count(walkerOSPF, snmputil.OutcomeEdges); got != 0 {
 		t.Errorf("ospf edges = %d, want 0 on error path", got)
 	}
 }

--- a/internal/discovery/snmp/outcome.go
+++ b/internal/discovery/snmp/outcome.go
@@ -1,0 +1,59 @@
+package snmp
+
+// Walker outcome label values for the generic per-protocol walker-outcome
+// counter (network_topology_walker_outcome_total, issue #98), shared by the
+// LLDP, CDP, OSPF, and FDB walkers. BGP uses its own vocabulary
+// (network_topology_bgp_walker_outcome_total) and does not share these.
+const (
+	OutcomeEdges            = "edges"
+	OutcomeMIBUnimplemented = "mib_unimplemented"
+	OutcomeNoNeighbours     = "no_neighbours"
+	OutcomeWalkerDrift      = "walker_drift"
+	OutcomeError            = "error"
+)
+
+// RecordProtocolWalkerOutcome forwards a {walker, outcome} observation to the
+// generic per-protocol counter via the metrics sink on Params. nil-safe: a nil
+// Params or nil Params.WalkerMetrics drops the increment rather than panicking.
+func RecordProtocolWalkerOutcome(p *Params, walker, outcome string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordProtocolWalkerOutcome(walker, outcome)
+}
+
+// RecordBGPWalkerOutcome forwards to the BGP-specific counter
+// (network_topology_bgp_walker_outcome_total). Same nil-tolerance.
+func RecordBGPWalkerOutcome(p *Params, walker, outcome string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordWalkerOutcome(walker, outcome)
+}
+
+// RecordDegraded forwards a {module, reason} observation to
+// DiscoveryDegradedTotal. Same nil-tolerance. Zero-edge degraded path (#100).
+func RecordDegraded(p *Params, module, reason string) {
+	if p == nil || p.WalkerMetrics == nil {
+		return
+	}
+	p.WalkerMetrics.RecordDegraded(module, reason)
+}
+
+// ClassifyNeighbourOutcome maps a neighbour-walk result to its terminal outcome
+// label, shared by the LLDP/CDP/OSPF/FDB walkers. edgeCount is the edges built;
+// hadPDUs is whether the MIB returned any rows; decoded is whether rows decoded
+// cleanly even if they produced no edge. (Walk-error early returns emit
+// OutcomeError directly and never reach here.)
+func ClassifyNeighbourOutcome(edgeCount int, hadPDUs, decoded bool) string {
+	switch {
+	case edgeCount > 0:
+		return OutcomeEdges
+	case !hadPDUs:
+		return OutcomeMIBUnimplemented
+	case decoded:
+		return OutcomeNoNeighbours
+	default:
+		return OutcomeWalkerDrift
+	}
+}

--- a/internal/discovery/snmp/outcome_test.go
+++ b/internal/discovery/snmp/outcome_test.go
@@ -1,0 +1,111 @@
+package snmp
+
+import "testing"
+
+func TestClassifyNeighbourOutcome(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		edgeCount int
+		hadPDUs   bool
+		decoded   bool
+		want      string
+	}{
+		{name: "edges built", edgeCount: 3, hadPDUs: true, decoded: true, want: OutcomeEdges},
+		{name: "edges win even if no PDUs flagged", edgeCount: 1, hadPDUs: false, decoded: false, want: OutcomeEdges},
+		{name: "no PDUs is mib_unimplemented", edgeCount: 0, hadPDUs: false, decoded: false, want: OutcomeMIBUnimplemented},
+		{name: "decoded but no edge is no_neighbours", edgeCount: 0, hadPDUs: true, decoded: true, want: OutcomeNoNeighbours},
+		{name: "PDUs but undecoded is walker_drift", edgeCount: 0, hadPDUs: true, decoded: false, want: OutcomeWalkerDrift},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyNeighbourOutcome(c.edgeCount, c.hadPDUs, c.decoded); got != c.want {
+				t.Errorf("ClassifyNeighbourOutcome(%d, %t, %t) = %q, want %q",
+					c.edgeCount, c.hadPDUs, c.decoded, got, c.want)
+			}
+		})
+	}
+}
+
+// recordingSink captures which WalkerMetrics method was invoked with which
+// (walker, outcome) / (module, reason) args, so the forwarders' routing can be
+// asserted: RecordProtocolWalkerOutcome → protocol counter, RecordWalkerOutcome
+// → BGP counter, RecordDegraded → degraded counter.
+type recordingSink struct {
+	protocol [][2]string
+	bgp      [][2]string
+	degraded [][2]string
+}
+
+func (s *recordingSink) RecordProtocolWalkerOutcome(walker, outcome string) {
+	s.protocol = append(s.protocol, [2]string{walker, outcome})
+}
+
+func (s *recordingSink) RecordWalkerOutcome(walker, outcome string) {
+	s.bgp = append(s.bgp, [2]string{walker, outcome})
+}
+
+func (s *recordingSink) RecordDegraded(module, reason string) {
+	s.degraded = append(s.degraded, [2]string{module, reason})
+}
+
+func (s *recordingSink) RecordSystemWalkAnomaly(string) {}
+
+func TestRecordProtocolWalkerOutcomeRoutesToProtocolSink(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	RecordProtocolWalkerOutcome(&Params{WalkerMetrics: sink}, "lldp", OutcomeEdges)
+
+	if len(sink.protocol) != 1 || sink.protocol[0] != [2]string{"lldp", OutcomeEdges} {
+		t.Errorf("protocol sink = %v, want one {lldp, edges}", sink.protocol)
+	}
+	if len(sink.bgp) != 0 || len(sink.degraded) != 0 {
+		t.Errorf("unexpected routing: bgp=%v degraded=%v", sink.bgp, sink.degraded)
+	}
+}
+
+func TestRecordBGPWalkerOutcomeRoutesToBGPSink(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	RecordBGPWalkerOutcome(&Params{WalkerMetrics: sink}, "rfc4273", OutcomeEdges)
+
+	if len(sink.bgp) != 1 || sink.bgp[0] != [2]string{"rfc4273", OutcomeEdges} {
+		t.Errorf("bgp sink = %v, want one {rfc4273, edges}", sink.bgp)
+	}
+	if len(sink.protocol) != 0 || len(sink.degraded) != 0 {
+		t.Errorf("unexpected routing: protocol=%v degraded=%v", sink.protocol, sink.degraded)
+	}
+}
+
+func TestRecordDegradedRoutesToDegradedSink(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	RecordDegraded(&Params{WalkerMetrics: sink}, "fdb", "qbridge_walk_failed")
+
+	if len(sink.degraded) != 1 || sink.degraded[0] != [2]string{"fdb", "qbridge_walk_failed"} {
+		t.Errorf("degraded sink = %v, want one {fdb, qbridge_walk_failed}", sink.degraded)
+	}
+	if len(sink.protocol) != 0 || len(sink.bgp) != 0 {
+		t.Errorf("unexpected routing: protocol=%v bgp=%v", sink.protocol, sink.bgp)
+	}
+}
+
+func TestOutcomeForwardersNilSafe(t *testing.T) {
+	t.Parallel()
+
+	// nil *Params must drop, not panic.
+	RecordProtocolWalkerOutcome(nil, "lldp", OutcomeEdges)
+	RecordBGPWalkerOutcome(nil, "rfc4273", OutcomeEdges)
+	RecordDegraded(nil, "fdb", "reason")
+
+	// Params with nil WalkerMetrics must drop, not panic.
+	p := &Params{}
+	RecordProtocolWalkerOutcome(p, "lldp", OutcomeEdges)
+	RecordBGPWalkerOutcome(p, "rfc4273", OutcomeEdges)
+	RecordDegraded(p, "fdb", "reason")
+}

--- a/internal/discovery/snmp/snmp.go
+++ b/internal/discovery/snmp/snmp.go
@@ -36,16 +36,16 @@ import (
 // way around, and makes test injection a single struct literal.
 //
 // Walkers MUST tolerate a nil Params.WalkerMetrics by dropping the increment
-// (no panic). The bgp module's recordWalkerOutcome helper encapsulates that
-// nil-check; other modules wanting the same observability should mirror the
-// pattern rather than calling Inc directly on a possibly-nil handle.
+// (no panic). The nil-tolerant snmputil.Record*WalkerOutcome forwarders (see
+// outcome.go) encapsulate that nil-check; modules call them rather than calling
+// Inc directly on a possibly-nil handle.
 // RecordWalkerOutcome routes to the BGP-specific counter
 // (network_topology_bgp_walker_outcome_total); RecordProtocolWalkerOutcome
 // routes to the generic counter (network_topology_walker_outcome_total) used
 // by the LLDP, CDP, OSPF, and FDB walkers (issue #98). The two are kept
 // separate so the long-standing BGP series operators alert on is never
-// renamed. As with RecordWalkerOutcome, callers reach these through the
-// nil-tolerant helper in their own package (see bgp.recordWalkerOutcome): a
+// renamed. Callers reach these through the nil-tolerant forwarders
+// snmputil.RecordBGPWalkerOutcome / RecordProtocolWalkerOutcome (outcome.go): a
 // nil Params or nil Params.WalkerMetrics drops the increment rather than
 // panicking.
 //
@@ -216,7 +216,7 @@ const (
 
 // recordSystemWalkAnomaly routes a system-walk anomaly to the injected
 // WalkerMetrics sink, tolerating a nil Params.WalkerMetrics by dropping the
-// increment (mirrors the bgp.recordWalkerOutcome nil-check pattern so the
+// increment (mirrors the snmputil.Record*WalkerOutcome nil-check pattern so the
 // discovery layer never panics when observability is not wired).
 func recordSystemWalkAnomaly(p Params, reason string) {
 	if p.WalkerMetrics == nil {


### PR DESCRIPTION
Closes #149. **Pure refactor — zero metric-value or behavior change.** Every emitted Prometheus label is byte-identical; the regression gate is the existing per-walker outcome tests passing with unchanged assertions.

## What
Lifts the copy-pasted walker outcome-accounting into one `internal/discovery/snmp/outcome.go`:
- `RecordProtocolWalkerOutcome` → generic `network_topology_walker_outcome_total` (fdb/lldp/cdp/ospf)
- `RecordBGPWalkerOutcome` → `network_topology_bgp_walker_outcome_total` (bgp) — **kept routed to the separate BGP counter**
- `RecordDegraded` → `network_topology_discovery_degraded_total` (fdb/isis)
- `ClassifyNeighbourOutcome(edgeCount, hadPDUs, decoded)` — the 4-way terminal classifier shared by the neighbour walkers
- Shared `Outcome*` constants

Deletes the 5 duplicated `recordWalkerOutcome` forwarders, 2 duplicated `recordDegraded`, the 4 duplicated `{edges, mib_unimplemented, no_neighbours, walker_drift, error}` const blocks, and the 4 duplicated classification switches — and the "Keep in sync" comments the compiler now enforces. BGP keeps its own `no_peers`/`malformed_index` vocabulary (different counter, bespoke classification); it shares only the forwarder.

## The trap this avoided
bgp's forwarder routes to a **different** counter (`RecordWalkerOutcome`) than the other four (`RecordProtocolWalkerOutcome`). A naive single-forwarder merge would have silently renamed the long-standing BGP series. The canonical layer preserves both routes; a routing test (mutation-verified — swapping the two forwarders makes it fail) guards it.

## Process
Spec → one adversarial check (caught a build-breaker: 7 unlisted `bgp_vendor.go` call sites, and corrected the test-update plan) → subagent-driven implementation → spec-compliance + code-quality review (both passed; code-quality mutation-tested the routing).

## Test plan
- [x] `go test ./... -race` — green; per-walker outcome tests pass with unchanged assertions
- [x] `golangci-lint run` — 0 issues; `gofmt` clean
- [x] New `outcome_test.go` — `ClassifyNeighbourOutcome` buckets + routing/nil-safety (asserts protocol vs BGP sink)
- [x] `grep 'func recordWalkerOutcome|func recordDegraded' internal/discovery` — empty (all moved)