### PR TITLE
docs(discovery): document intentional output-projection divergence + label-schema guards (#150)

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -101,6 +101,14 @@ func JoinReasonCodes(reasons []string) string {
 }
 
 // Device is the inventory record for one network node.
+//
+// Output projections (issue #150) diverge intentionally, like Edge above:
+// Prometheus network_topology_device_info carries {device_id, vendor, model,
+// os_version, site} unconditionally (Uptime is a separate metric, Labels are not
+// emitted as series), guarded by TestDeviceInfoLabelSchemaStable; OTLP deviceAttrs
+// emits the same fields but OMITS empty ones and uses the key "device" (not
+// "device_id"); YANG maps to RFC 8345 node attributes. Do not unify the three —
+// decide per output when adding a field.
 type Device struct {
 	ID        string // sysName (normalised lowercase); fallback: management IP
 	Vendor    string
@@ -257,6 +265,29 @@ func (a Adjacency) Valid() bool {
 // Edge serves as both a raw protocol observation (with MAC/IP DstDevice values)
 // and a canonical graph edge (with resolved sysName DstDevice). The synthesis
 // step in runCycle converts observations to canonical form before reconciliation.
+//
+// Output projections (issue #150 — read before "unifying" them). An Edge is
+// projected to three outputs that DELIBERATELY carry different field subsets;
+// this divergence is intentional, not drift, and the three mappers are kept
+// separate on purpose:
+//   - Prometheus network_topology_edge_info (internal/metrics/topology_collector.go):
+//     a fixed, minimal label schema {src_device, src_port, dst_device, dst_port,
+//     discovery_proto, link_kind, direction}. It deliberately OMITS Confidence,
+//     Adjacency, PrecedenceRank, and Metadata to bound label cardinality — these
+//     vary per-edge and would multiply series. Adding a label here is a conscious
+//     cardinality decision (guarded by TestEdgeInfoLabelSchemaStable in metrics).
+//   - OTLP edgeAttrs (internal/output/otlp): the full attribute set including
+//     confidence/adjacency/precedence_rank and every Metadata key (attribute
+//     budgets, not label cardinality, govern there). Note the proto attribute key
+//     is "proto", not "discovery_proto".
+//   - YANG (internal/output/yang): RFC 8345 nested structure — a bidirectional
+//     Edge becomes two directed links, fields map to specific YANG leaves.
+//
+// A single shared projection was assessed and rejected (#150): the outputs differ
+// in selection, attribute-key names, conditional emission, sanitization semantics,
+// and structure, so a common abstraction would need more knobs than the three
+// direct mappers and would risk silently changing a wire contract. When adding a
+// field to Edge, decide PER OUTPUT whether it belongs.
 type Edge struct {
 	SrcDevice string
 	SrcPort   string

--- a/internal/metrics/output_schema_guard_test.go
+++ b/internal/metrics/output_schema_guard_test.go
@@ -1,0 +1,89 @@
+package metrics_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// The Prometheus edge_info / device_info label schemas are deliberately MINIMAL
+// (issue #150): they omit high-cardinality Edge fields (Confidence, Adjacency,
+// PrecedenceRank, Metadata) that the OTLP and YANG outputs DO carry. The three
+// outputs diverge on purpose — see the projection notes on discovery.Edge /
+// discovery.Device. These tests pin the Prometheus label-name sets so that
+// adding a label is a conscious cardinality decision (and a prompt to review
+// whether OTLP/YANG should change too), rather than silent drift.
+
+func gatheredLabelNames(t *testing.T, m *metrics.Metrics, metricName string) []string {
+	t.Helper()
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != metricName {
+			continue
+		}
+		if len(mf.GetMetric()) == 0 {
+			t.Fatalf("%s has no series to inspect", metricName)
+		}
+		var names []string
+		for _, lp := range mf.GetMetric()[0].GetLabel() {
+			names = append(names, lp.GetName())
+		}
+		sort.Strings(names)
+		return names
+	}
+	t.Fatalf("metric %q not found in gather output", metricName)
+	return nil
+}
+
+func TestEdgeInfoLabelSchemaStable(t *testing.T) {
+	m := metrics.New(false)
+	// Populate the high-cardinality fields too, to prove they do NOT leak into
+	// the Prometheus label set (they are intentionally dropped; OTLP carries them).
+	m.Topology.Update(discovery.Graph{
+		Edges: []discovery.Edge{{
+			SrcDevice: "dev-a", SrcPort: "Gi0/1",
+			DstDevice: "dev-b", DstPort: "Gi0/2",
+			DiscoveryProto: discovery.DiscoveryProtocolLLDP,
+			Direction:      discovery.DirectionBidirectional,
+			LinkKind:       discovery.LinkKind("ethernet"),
+			Confidence:     discovery.Confidence("confirmed"),
+			Adjacency:      discovery.Adjacency("direct"),
+			PrecedenceRank: 3,
+			Metadata:       map[string]string{"remote_as": "64512"},
+		}},
+	})
+
+	want := []string{
+		"direction", "discovery_proto", "dst_device", "dst_port",
+		"link_kind", "src_device", "src_port",
+	}
+	got := gatheredLabelNames(t, m, "network_topology_edge_info")
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("network_topology_edge_info label schema changed.\n got: %v\nwant: %v\n"+
+			"This is a cardinality-sensitive change (#150). If intentional, update this test, "+
+			"and review whether the OTLP/YANG projections need the same field — see discovery.Edge.", got, want)
+	}
+}
+
+func TestDeviceInfoLabelSchemaStable(t *testing.T) {
+	m := metrics.New(false)
+	m.Topology.Update(discovery.Graph{
+		Devices: []discovery.Device{{
+			ID: "dev-1", Vendor: "cisco", Model: "C9300", OSVersion: "17.6.4", Site: "lab",
+			Labels: map[string]string{"team": "neteng"}, // free-form labels must NOT become series labels
+		}},
+	})
+
+	want := []string{"device_id", "model", "os_version", "site", "vendor"}
+	got := gatheredLabelNames(t, m, "network_topology_device_info")
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("network_topology_device_info label schema changed.\n got: %v\nwant: %v\n"+
+			"Conscious cardinality change (#150); review the OTLP/YANG device projections too — see discovery.Device.", got, want)
+	}
+}


### PR DESCRIPTION
Addresses #150. **Assessment outcome: the proposed "single canonical projection" was rejected as a net-negative abstraction; this PR captures the safe, valuable subset instead.**

## Why not the projection
The review flagged the three outputs (Prometheus / OTLP / YANG) as "divergent field lists that should be unified." Reading the code, they diverge for deliberate, load-bearing reasons:
- **Prometheus** `edge_info`/`device_info` — fixed minimal label schema; deliberately drops `Confidence`/`Adjacency`/`PrecedenceRank`/`Metadata` to bound **label cardinality**.
- **OTLP** — full attribute set incl. Metadata; omit-if-empty device attrs; different attribute keys (`proto`, `device`).
- **YANG** — RFC 8345 nested structure (bidirectional edge → two directed links).

A shared projection would need to be parameterized on selection **and** key names **and** conditional emission **and** sanitizer per output — more knobs than the three direct mappers it replaces (the "indirection without clarity" anti-pattern), and forcing agreement would change Prometheus cardinality or rename OTLP wire attributes (a regression). The explicit per-output mappers are the correct design.

## What this PR does instead
- Documents the intentional divergence on `discovery.Edge` and `discovery.Device` (which output carries which field, and **why**), so a future reader doesn't "unify" them and silently regress cardinality or a wire contract.
- Adds `TestEdgeInfoLabelSchemaStable` / `TestDeviceInfoLabelSchemaStable` — self-documenting guards that pin the Prometheus label-name sets (populating the high-cardinality fields to prove they do *not* leak as labels). Changing a label now fails loudly with a message pointing to the per-output review.

No behavior change; no metric values touched.

## Test plan
- [x] `go test ./... -race` (metrics+discovery) — green; new guards pass
- [x] `golangci-lint run` — 0 issues; `gofmt` clean