### PR TITLE
refactor(config,app): typed config enums + OTLP-publisher collapse (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ v1.3.1 lands under this milestone instead, renamed to
 
 ### Internal
 
+- Config & boundary type cleanliness (#152). The four stringly-typed config
+  enums — `federation.role`, `output.otlp.protocol`, `modules.snmp.version`, and
+  the credential-profile `type` — are now named string types (`Role`,
+  `OTLPProtocol`, `SNMPVersion`, `ProfileType`) with constants and a `Valid()`
+  helper. `LoopConfig`'s three nilable OTLP fields (`OtlpExp`, `OtlpSem`,
+  `OtlpWg`) collapse into one nil-tolerant `*otlpPublisher` whose `Push` no-ops
+  when OTLP is disabled, removing the scattered nil-guards. No behavior change:
+  every YAML wire value, validation error string, metric label, and the OTLP
+  concurrency-cap / shutdown-drain semantics are byte-identical.
+
 - Walker outcome-accounting deduplicated into `internal/discovery/snmp`
   (`snmputil`) (#149). The per-package `recordWalkerOutcome`/`recordDegraded`
   forwarders, the five-value `outcome*` constant set, and the four-way terminal

--- a/cmd/topology-exporter/main_test.go
+++ b/cmd/topology-exporter/main_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,6 +33,7 @@ import (
 	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
 )
 
@@ -638,6 +638,7 @@ func TestRunDiscoveryLoopClearsGraphStale(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1016,6 +1017,7 @@ func TestRunDiscoveryLoopVersionMismatchSnapshot(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1084,6 +1086,7 @@ func TestRunDiscoveryLoopWithSnapshot(t *testing.T) {
 			M:      m1,
 			Status: &s1,
 			Ready:  &r1,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 	// Wait for the snapshot write to complete (SnapshotLastWrittenUnix > 0),
@@ -1122,6 +1125,7 @@ outer:
 			M:      m2,
 			Status: &s2,
 			Ready:  &r2,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1192,6 +1196,7 @@ func TestRunDiscoveryLoopSecondTick(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1266,6 +1271,7 @@ func TestRunDiscoveryLoopContextCancelledDuringCycle(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1320,6 +1326,7 @@ func TestRunDiscoveryLoopCredResolverError(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 
@@ -1805,72 +1812,70 @@ func TestWalkSystemWithCredentialsAllTimeout(t *testing.T) {
 	}
 }
 
-// TestOtlpPushDropsWhenSemaphoreFull verifies that otlpPush increments the
-// dropped counter and returns immediately when the semaphore is full.
+// TestOtlpPushDropsWhenSemaphoreFull verifies that Push increments the
+// dropped counter and returns immediately when the semaphore is full. The
+// publisher is built in its enabled form (a bare non-nil exporter sentinel
+// plus a saturated cap-1 semaphore) so the drop path is exercised.
 func TestOtlpPushDropsWhenSemaphoreFull(t *testing.T) {
-	// Fill the semaphore to capacity.
-	sem := make(chan struct{}, 1)
-	sem <- struct{}{} // occupy the only slot
+	m := metrics.New(false)
+	pub := app.NewOTLPPublisher(&otlp.Exporter{}, 1, slog.Default(), m)
 
-	dropped := make(chan struct{}, 1)
-	lc := app.LoopConfig{
-		Logger:  slog.Default(),
-		M:       metrics.New(false),
-		OtlpSem: sem,
-	}
+	// Saturate the cap by enqueuing one push that blocks until released so the
+	// single semaphore slot stays occupied for the duration of the drop test.
+	unblock := make(chan struct{})
+	pub.Push(func(_ context.Context) error {
+		<-unblock
+		return nil
+	}, "occupier")
 
-	ctx := context.Background()
-	lc.OtlpPush(ctx, func(_ context.Context) error {
+	// The next push must be dropped immediately (semaphore full).
+	pub.Push(func(_ context.Context) error {
+		t.Error("dropped push fn ran")
 		return nil
 	}, "should not be called")
 
-	// otlpPush should have incremented the dropped counter and returned
-	// immediately. Issue #20 widened the label set to {status, reason}.
-	if got := testutil.ToFloat64(lc.M.OTLPPushTotal.WithLabelValues("dropped", metrics.ReasonNA)); got != 1 {
+	// Issue #20 widened the label set to {status, reason}.
+	if got := testutil.ToFloat64(m.OTLPPushTotal.WithLabelValues("dropped", metrics.ReasonNA)); got != 1 {
 		t.Errorf("OTLPPushTotal{dropped,n/a} = %v, want 1", got)
 	}
-	_ = dropped
+
+	close(unblock)
+	pub.Drain()
 }
 
-// TestOtlpPushDrainsOnShutdown verifies that otlpWg.Wait() drains all in-flight
-// goroutines before returning: the goroutine spawned by otlpPush must finish
-// before Wait() unblocks.
+// TestOtlpPushDrainsOnShutdown verifies that Drain blocks until all in-flight
+// goroutines finish: the goroutine spawned by Push must complete before Drain
+// returns.
 func TestOtlpPushDrainsOnShutdown(t *testing.T) {
-	var wg sync.WaitGroup
 	started := make(chan struct{})
 	unblock := make(chan struct{})
 
-	lc := app.LoopConfig{
-		Logger: slog.Default(),
-		M:      metrics.New(false),
-		OtlpWg: &wg,
-	}
+	pub := app.NewOTLPPublisher(&otlp.Exporter{}, 1, slog.Default(), metrics.New(false))
 
-	ctx := context.Background()
-	lc.OtlpPush(ctx, func(_ context.Context) error {
+	pub.Push(func(_ context.Context) error {
 		close(started) // signal that the goroutine has begun
 		<-unblock      // block until the test says go
 		return nil
 	}, "drain test")
 
-	// Wait until the goroutine has started before calling wg.Wait.
+	// Wait until the goroutine has started before draining.
 	select {
 	case <-started:
 	case <-time.After(5 * time.Second):
 		t.Fatal("goroutine did not start within 5s")
 	}
 
-	// Release the goroutine and wait for the WaitGroup to drain.
+	// Release the goroutine and drain.
 	close(unblock)
 
 	done := make(chan struct{})
-	go func() { wg.Wait(); close(done) }()
+	go func() { pub.Drain(); close(done) }()
 
 	select {
 	case <-done:
-		// WaitGroup drained cleanly.
+		// Drain returned cleanly.
 	case <-time.After(5 * time.Second):
-		t.Fatal("otlpWg.Wait() did not return within 5s after goroutine finished")
+		t.Fatal("Drain() did not return within 5s after goroutine finished")
 	}
 }
 
@@ -2223,6 +2228,7 @@ func TestGraphSizeAdmissionControl(t *testing.T) {
 			M:      m,
 			Status: &status,
 			Ready:  &ready,
+			Otlp:   app.NoopOTLPPublisher(),
 		})
 	}()
 

--- a/docs/superpowers/specs/2026-06-09-type-cleanliness-design.md
+++ b/docs/superpowers/specs/2026-06-09-type-cleanliness-design.md
@@ -3,27 +3,13 @@
 **Issue:** #152. **Process:** lighter — spec + one adversarial check + subagent-driven TDD.
 **Status correction:** the originally-claimed `LinkKind` "latent bug" is a FALSE POSITIVE — the federation hub already defaults an empty `link_kind` to `ethernet` at the sole consumption site (`hub.go:880-882`), and validation never rejects it. So #152 is **pure cleanup, no behavior change.** Every YAML wire value and every validation error string stays byte-identical.
 
-Three independent parts, one branch (`refactor/152-type-cleanliness`), one PR. Sequential TDD tasks (B and C touch disjoint files; do not parallelize subagents on the same package).
+Two parts (B + C), one branch (`refactor/152-type-cleanliness`), one PR. Sequential TDD tasks (they touch disjoint files).
 
 ---
 
-## Part A — relocate the `InterDomainLink.LinkKind` default to `applyDefaults`
+## Part A — DROPPED (do not implement)
 
-**Not a bug fix** — a single-source-of-defaults consistency cleanup. Today the default lives at the consumer (`hub.go:881-882`: `if linkKind == "" { linkKind = LinkKindEthernet }`). Other config defaults all live in `applyDefaults`. 
-
-**Change:** in `applyDefaults` (config.go), add a loop that sets the default eagerly:
-```go
-for i := range c.Federation.KnownInterDomainLinks {
-	if c.Federation.KnownInterDomainLinks[i].LinkKind == "" {
-		c.Federation.KnownInterDomainLinks[i].LinkKind = string(discovery.LinkKindEthernet)
-	}
-}
-```
-(Check whether config.go already imports `internal/discovery`; if not, use the literal `"ethernet"` with a comment rather than add an import just for one constant — match the file's existing style. The field stays `string`.)
-
-**Keep the hub guard at `hub.go:881-882` as defense-in-depth** (it's cheap and `applyDefaults` running before hub use is a Load() invariant, not a hub-local one). Update the `InterDomainLink.LinkKind` doc comment to note the default is applied at load.
-
-**Test:** a config-load test that a `KnownInterDomainLinks` entry with omitted `link_kind` has `LinkKind == "ethernet"` after `Load`/`applyDefaults`.
+The original plan relocated the `InterDomainLink.LinkKind` `""`→`"ethernet"` default from the consumer (`hub.go:881-882`) into `applyDefaults`. The adversarial check found this is **not** a stray default: `config_test.go:1257 TestFederationKnownLinkOptionalLinkKind` *explicitly asserts* `LinkKind == ""` after `Load()` with the comment "default applied by hub at injection time" — i.e. keeping the loaded-config field empty and defaulting at the single hub consumer is a **deliberate, tested design**. Relocating it would change the post-`Load` config state, fight that test, and deliver zero functional change (the hub output is identical either way). That is exactly the kind of "fixing" a non-problem we declined for #150. **No change to LinkKind handling.** (#152 is therefore Parts B + C only.)
 
 ---
 
@@ -58,13 +44,13 @@ func (t ProfileType) Valid() bool { return t == ProfileTypeSNMPv2c || t == Profi
 - The existing `ProfileTypeSNMPv2c`/`ProfileTypeSNMPv3` are currently UNTYPED string consts (config.go:387-390) — retype them to `ProfileType` (callers using them in `switch p.Type` still compile since `p.Type` is now `ProfileType`).
 - `applyDefaults`: the `== ""` / assignment lines stay but compare/assign typed values — e.g. `if c.Modules.SNMP.Version == "" { c.Modules.SNMP.Version = SNMPVersionV2c }` (untyped `""` compares fine; assign the typed const). Same for Role/Protocol.
 - Validation: keep the existing error strings EXACTLY. Either keep the switches (now over typed values — `case RoleStandalone, RoleUncoordinated:` etc.) or call `.Valid()`; the error messages (`"federation.role must be standalone, uncoordinated, spoke, or hub; got %q"`, `"modules.snmp.version must be v2c or v3, got %q"`, `"output.otlp.protocol must be http or grpc, got %q"`, `"profile %q has unknown type %q"`) must remain byte-identical (the `%q` of a named string type prints the same as the bare string).
-- **Consumer sites** (small blast radius — update comparisons to typed constants):
-  - `internal/app/app.go` — Role checks (e.g. `cfg.Federation.Role == "hub"` → `== config.RoleHub`) and OTLP Protocol use.
-  - `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go` — Protocol use (these likely pass `string(protocol)` to SDK constructors; convert at the boundary with `string(...)`).
-  - `internal/app/probe.go` — `CredentialProfile.Type` use.
-  - Anywhere a typed value crosses into a `string`-typed API (gosnmp, OTLP SDK), convert explicitly with `string(...)` at the call site.
+- **Consumer sites** (small blast radius — verified exhaustively by the adversarial check):
+  - `internal/app/app.go` — Role comparisons against untyped string literals (`== "uncoordinated"/"spoke"/"hub"`) still compile unchanged; the OTLP Protocol is passed to `tracing.Protocol(...)` / `otlp.Protocol(...)`, which are themselves named string types — `tracing.Protocol(cfg.Output.OTLP.Protocol)` is a single valid conversion, **no inner `string(...)` needed** (don't add spurious casts).
+  - `internal/app/probe.go` — the `switch p.Type` compiles once `ProfileType` consts are retyped.
+  - `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go` — no change needed (they receive their own `Protocol` named type).
+  - **`internal/app/watchdog_test.go:39` (REQUIRED — the one missed call site that breaks the build):** it assigns a `string` *variable* (`tc.role`) to `Federation.Role`. Once `Role` is a named type this is a compile error. Fix: change the test table field from `role string` to `role config.Role` (the case literals stay untyped constants and assign fine).
 
-**Tests:** existing config validation tests must pass unchanged (error strings identical). Add a small `Valid()` table test per type. Existing example-config load tests are the wire-value regression gate.
+**Tests:** existing config validation tests pass unchanged — verified they assert only `err != nil`, never the exact string, and no path marshals these config structs to JSON/YAML (so a named type changes no wire output). Add a small `Valid()` table test per type. Existing example-config load tests are the wire-value regression gate.
 
 ---
 
@@ -94,9 +80,10 @@ func (p *otlpPublisher) drain() { if p.wg != nil { p.wg.Wait() } }
 ```
 - Replace the three `LoopConfig` fields with one `Otlp *otlpPublisher` (always non-nil; constructed disabled in tests/standalone).
 - `OtlpPush` becomes a thin `lc.Otlp.push(...)` (or move callers directly to `lc.Otlp.push`). The publish path (loop.go ~398-416) calls `lc.Otlp.push(func(ctx) error { return lc.Otlp.exp.PushChanges(ctx, ch) }, …)` etc. — but since `push` no-ops when disabled, the outer `if lc.OtlpExp != nil` guards are removed. (Keep the `len(changes)>0 || heartbeat` gate — that's logic, not a nil-check.)
+- **CRITICAL invariant the collapse depends on (from the adversarial check):** the "no-op when `exp==nil`, otherwise sem+wg non-nil" model means the **enabled publisher MUST allocate `sem` AND `wg` together as a unit** (and the disabled publisher leaves all three nil and `push` early-returns on `exp==nil` BEFORE touching sem/wg). This is true in production wiring, but the current TESTS deliberately set partial combinations against `OtlpPush` directly with `exp==nil` (e.g. `loop_test.go:51`+`main_test.go:1819` set sem-only; `loop_test.go:90`+`main_test.go:1846` set wg-only, sem nil). If `push` drops the sem/wg nil-checks, those fixtures would send on a nil channel (deadlock) / `Done()` a nil wg (panic). **Resolution:** rewrite those four tests to construct an *enabled* `otlpPublisher` (exp+sem+wg together) — which is what they were really exercising (the cap/drain behavior). `push` keeps exactly ONE guard: `if p.exp == nil { return }` at the top; everything after assumes sem+wg are set.
 - **Preserve EXACTLY:** the sem-full drop path + `OTLPPushTotal{dropped, n/a}` increment; the `wg.Add(1)` before goroutine + `defer wg.Done()`; `recoverGoroutine("otlp_push", …)` ordering (runs last); the background-ctx + `OTLPPushTimeout`; the `ok`/`error`+`ClassifyPushError` metric. The defer ORDER (recover registered first → runs last, after sem release + wg.Done) is load-bearing for the concurrency cap + drain correctness on panic.
-- `app.go`: construct one `otlpPublisher` (enabled with exp+sem+wg when OTLP configured, else a no-op publisher); the shutdown drain at app.go:440 (`otlpWg.Wait()`) becomes `pub.drain()` (the publisher owns the wg).
-- Update tests that set `OtlpExp/OtlpSem/OtlpWg` to construct an `otlpPublisher` instead. `goleak` tests for the OTLP push/drain must stay green (the drain semantics are unchanged).
+- `app.go`: **declare `pub *otlpPublisher` BEFORE the role switch as a no-op (`&otlpPublisher{}`)**, and assign the enabled one (exp+sem+wg) inside the OTLP-enabled branch — so hub mode (which never enables OTLP) has a non-nil no-op `pub` and the shared shutdown-drain at app.go:440 (`otlpWg.Wait()` → `pub.drain()`) never nil-panics. `drain()` no-ops when `wg==nil`.
+- `goleak` tests for the OTLP push/drain must stay green (the drain semantics are unchanged).
 
 **Tests:** existing OTLP push tests (drop-on-full, success/error classification, shutdown drain, goleak) must pass with the publisher; add a no-op-publisher test asserting `push` is a no-op when `exp == nil` (no goroutine, no metric).
 
@@ -105,12 +92,13 @@ func (p *otlpPublisher) drain() { if p.wg != nil { p.wg.Wait() } }
 ## Cross-cutting
 - No Co-Authored-By / AI-attribution trailers; author colinedwardwood.
 - `go test ./... -race`, `gofmt`, `golangci-lint run` clean.
-- CHANGELOG `### Internal` entry: typed config enums + LoopConfig OTLP-publisher collapse + LinkKind default relocated to applyDefaults (no behavior change).
-- **No behavior change anywhere:** YAML values, validation errors, metric labels, and OTLP concurrency/drain semantics all identical.
+- CHANGELOG `### Internal` entry: typed config enums + LoopConfig OTLP-publisher collapse (no behavior change). (Part A dropped — no LinkKind change.)
+- **No behavior change anywhere:** YAML values, validation errors, metric labels, and OTLP concurrency/drain semantics all identical. (Verified: no config struct is marshaled to JSON/YAML, and validation tests assert only `err != nil`.)
 
 ## Files touched
-- `internal/config/config.go` (+ maybe `config/enums.go`) — Part A defaults loop, Part B types/Validate/field changes/validation.
+- `internal/config/config.go` (+ maybe `config/enums.go`) — Part B types/Validate/field changes/validation switches over typed values.
 - `internal/app/app.go`, `internal/app/loop.go`, new `internal/app/otlp_publisher.go` — Part C.
-- `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go`, `internal/app/probe.go` — Part B consumer sites.
-- `internal/federation/hub.go` — Part A doc note (guard kept).
-- Tests in config/app packages; `CHANGELOG.md`.
+- `internal/app/probe.go` — Part B `CredentialProfile.Type` consumer.
+- `internal/app/watchdog_test.go` — Part B: type the test's `role` field (REQUIRED for compilation).
+- Tests in config/app packages (incl. rewriting the four `OtlpPush` tests to the enabled-publisher form); `CHANGELOG.md`.
+- NOT touched: `internal/federation/hub.go`, `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go` (Part A dropped; the named-type conversions at the tracing/otlp boundary need no edits).

--- a/docs/superpowers/specs/2026-06-09-type-cleanliness-design.md
+++ b/docs/superpowers/specs/2026-06-09-type-cleanliness-design.md
@@ -1,0 +1,116 @@
+# Config & Boundary Type Cleanliness — Design Spec (#152)
+
+**Issue:** #152. **Process:** lighter — spec + one adversarial check + subagent-driven TDD.
+**Status correction:** the originally-claimed `LinkKind` "latent bug" is a FALSE POSITIVE — the federation hub already defaults an empty `link_kind` to `ethernet` at the sole consumption site (`hub.go:880-882`), and validation never rejects it. So #152 is **pure cleanup, no behavior change.** Every YAML wire value and every validation error string stays byte-identical.
+
+Three independent parts, one branch (`refactor/152-type-cleanliness`), one PR. Sequential TDD tasks (B and C touch disjoint files; do not parallelize subagents on the same package).
+
+---
+
+## Part A — relocate the `InterDomainLink.LinkKind` default to `applyDefaults`
+
+**Not a bug fix** — a single-source-of-defaults consistency cleanup. Today the default lives at the consumer (`hub.go:881-882`: `if linkKind == "" { linkKind = LinkKindEthernet }`). Other config defaults all live in `applyDefaults`. 
+
+**Change:** in `applyDefaults` (config.go), add a loop that sets the default eagerly:
+```go
+for i := range c.Federation.KnownInterDomainLinks {
+	if c.Federation.KnownInterDomainLinks[i].LinkKind == "" {
+		c.Federation.KnownInterDomainLinks[i].LinkKind = string(discovery.LinkKindEthernet)
+	}
+}
+```
+(Check whether config.go already imports `internal/discovery`; if not, use the literal `"ethernet"` with a comment rather than add an import just for one constant — match the file's existing style. The field stays `string`.)
+
+**Keep the hub guard at `hub.go:881-882` as defense-in-depth** (it's cheap and `applyDefaults` running before hub use is a Load() invariant, not a hub-local one). Update the `InterDomainLink.LinkKind` doc comment to note the default is applied at load.
+
+**Test:** a config-load test that a `KnownInterDomainLinks` entry with omitted `link_kind` has `LinkKind == "ethernet"` after `Load`/`applyDefaults`.
+
+---
+
+## Part B — type the four stringly-typed config enums
+
+Promote four `string` fields to named types with constants + a `Validate()` method. **Wire-value identity is mandatory** (these are YAML contract values): the underlying string constants stay byte-identical, YAML unmarshals into a named string type unchanged, and the existing validation error strings are preserved verbatim.
+
+Define (in config.go or a new `config/enums.go`):
+```go
+type Role string
+const (
+	RoleStandalone    Role = "standalone"
+	RoleUncoordinated Role = "uncoordinated"
+	RoleSpoke         Role = "spoke"
+	RoleHub           Role = "hub"
+)
+func (r Role) Valid() bool { switch r { case RoleStandalone, RoleUncoordinated, RoleSpoke, RoleHub: return true }; return false }
+
+type OTLPProtocol string
+const ( OTLPProtocolHTTP OTLPProtocol = "http"; OTLPProtocolGRPC OTLPProtocol = "grpc" )
+func (p OTLPProtocol) Valid() bool { return p == OTLPProtocolHTTP || p == OTLPProtocolGRPC }
+
+type SNMPVersion string
+const ( SNMPVersionV2c SNMPVersion = "v2c"; SNMPVersionV3 SNMPVersion = "v3" )
+func (v SNMPVersion) Valid() bool { return v == SNMPVersionV2c || v == SNMPVersionV3 }
+
+type ProfileType string
+const ( ProfileTypeSNMPv2c ProfileType = "snmp_v2c"; ProfileTypeSNMPv3 ProfileType = "snmp_v3" )
+func (t ProfileType) Valid() bool { return t == ProfileTypeSNMPv2c || t == ProfileTypeSNMPv3 }
+```
+- Change the struct fields: `FederationConfig.Role Role` (yaml unchanged), `OTLPOutputConfig.Protocol OTLPProtocol`, `ModuleSNMP.Version SNMPVersion`, `CredentialProfile.Type ProfileType`.
+- The existing `ProfileTypeSNMPv2c`/`ProfileTypeSNMPv3` are currently UNTYPED string consts (config.go:387-390) — retype them to `ProfileType` (callers using them in `switch p.Type` still compile since `p.Type` is now `ProfileType`).
+- `applyDefaults`: the `== ""` / assignment lines stay but compare/assign typed values — e.g. `if c.Modules.SNMP.Version == "" { c.Modules.SNMP.Version = SNMPVersionV2c }` (untyped `""` compares fine; assign the typed const). Same for Role/Protocol.
+- Validation: keep the existing error strings EXACTLY. Either keep the switches (now over typed values — `case RoleStandalone, RoleUncoordinated:` etc.) or call `.Valid()`; the error messages (`"federation.role must be standalone, uncoordinated, spoke, or hub; got %q"`, `"modules.snmp.version must be v2c or v3, got %q"`, `"output.otlp.protocol must be http or grpc, got %q"`, `"profile %q has unknown type %q"`) must remain byte-identical (the `%q` of a named string type prints the same as the bare string).
+- **Consumer sites** (small blast radius — update comparisons to typed constants):
+  - `internal/app/app.go` — Role checks (e.g. `cfg.Federation.Role == "hub"` → `== config.RoleHub`) and OTLP Protocol use.
+  - `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go` — Protocol use (these likely pass `string(protocol)` to SDK constructors; convert at the boundary with `string(...)`).
+  - `internal/app/probe.go` — `CredentialProfile.Type` use.
+  - Anywhere a typed value crosses into a `string`-typed API (gosnmp, OTLP SDK), convert explicitly with `string(...)` at the call site.
+
+**Tests:** existing config validation tests must pass unchanged (error strings identical). Add a small `Valid()` table test per type. Existing example-config load tests are the wire-value regression gate.
+
+---
+
+## Part C — collapse `LoopConfig`'s three nilable OTLP fields into one publisher
+
+Today `LoopConfig` carries `OtlpExp *otlp.Exporter`, `OtlpSem chan struct{}`, `OtlpWg *sync.WaitGroup` (loop.go:63-65), all nil when OTLP is disabled, producing scattered `if lc.Otlp* != nil` guards in `OtlpPush` (loop.go:95-122) and the publish path (loop.go:398-416). The three are always all-set or all-nil (app.go:188, 355-365 wire them together only when OTLP is enabled).
+
+**Change:** introduce one always-non-nil publisher (app package, e.g. `otlp_publisher.go`):
+```go
+// otlpPublisher owns the OTLP exporter plus the concurrency cap and in-flight
+// tracking for async pushes. A publisher whose exp is nil is a no-op (OTLP
+// disabled), so callers never nil-check.
+type otlpPublisher struct {
+	exp    *otlp.Exporter // nil ⇒ disabled, push() is a no-op
+	sem    chan struct{}
+	wg     *sync.WaitGroup
+	logger *slog.Logger
+	m      *metrics.Metrics
+}
+
+// push runs fn asynchronously under the concurrency cap, tracked for shutdown
+// drain, with panic recovery and #20 error classification. No-op when disabled.
+func (p *otlpPublisher) push(fn func(context.Context) error, warnMsg string) { /* the current OtlpPush body, minus the nil-checks (sem/wg are non-nil iff exp != nil) */ }
+
+// drain blocks until in-flight pushes finish (shutdown). No-op when disabled.
+func (p *otlpPublisher) drain() { if p.wg != nil { p.wg.Wait() } }
+```
+- Replace the three `LoopConfig` fields with one `Otlp *otlpPublisher` (always non-nil; constructed disabled in tests/standalone).
+- `OtlpPush` becomes a thin `lc.Otlp.push(...)` (or move callers directly to `lc.Otlp.push`). The publish path (loop.go ~398-416) calls `lc.Otlp.push(func(ctx) error { return lc.Otlp.exp.PushChanges(ctx, ch) }, …)` etc. — but since `push` no-ops when disabled, the outer `if lc.OtlpExp != nil` guards are removed. (Keep the `len(changes)>0 || heartbeat` gate — that's logic, not a nil-check.)
+- **Preserve EXACTLY:** the sem-full drop path + `OTLPPushTotal{dropped, n/a}` increment; the `wg.Add(1)` before goroutine + `defer wg.Done()`; `recoverGoroutine("otlp_push", …)` ordering (runs last); the background-ctx + `OTLPPushTimeout`; the `ok`/`error`+`ClassifyPushError` metric. The defer ORDER (recover registered first → runs last, after sem release + wg.Done) is load-bearing for the concurrency cap + drain correctness on panic.
+- `app.go`: construct one `otlpPublisher` (enabled with exp+sem+wg when OTLP configured, else a no-op publisher); the shutdown drain at app.go:440 (`otlpWg.Wait()`) becomes `pub.drain()` (the publisher owns the wg).
+- Update tests that set `OtlpExp/OtlpSem/OtlpWg` to construct an `otlpPublisher` instead. `goleak` tests for the OTLP push/drain must stay green (the drain semantics are unchanged).
+
+**Tests:** existing OTLP push tests (drop-on-full, success/error classification, shutdown drain, goleak) must pass with the publisher; add a no-op-publisher test asserting `push` is a no-op when `exp == nil` (no goroutine, no metric).
+
+---
+
+## Cross-cutting
+- No Co-Authored-By / AI-attribution trailers; author colinedwardwood.
+- `go test ./... -race`, `gofmt`, `golangci-lint run` clean.
+- CHANGELOG `### Internal` entry: typed config enums + LoopConfig OTLP-publisher collapse + LinkKind default relocated to applyDefaults (no behavior change).
+- **No behavior change anywhere:** YAML values, validation errors, metric labels, and OTLP concurrency/drain semantics all identical.
+
+## Files touched
+- `internal/config/config.go` (+ maybe `config/enums.go`) — Part A defaults loop, Part B types/Validate/field changes/validation.
+- `internal/app/app.go`, `internal/app/loop.go`, new `internal/app/otlp_publisher.go` — Part C.
+- `internal/tracing/tracing.go`, `internal/output/otlp/otlp.go`, `internal/app/probe.go` — Part B consumer sites.
+- `internal/federation/hub.go` — Part A doc note (guard kept).
+- Tests in config/app packages; `CHANGELOG.md`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, args []string) int {
 		logger.Warn("FDB is enabled but ARP enrichment is off; DstPort backfill on FDB-only edges will be unavailable. Set modules.arp.enabled: true to re-enable.")
 	}
 
-	m := metrics.New(cfg.Federation.Role == "uncoordinated")
+	m := metrics.New(cfg.Federation.Role == config.RoleUncoordinated)
 	m.SnapshotLastWrittenUnix.SetToCurrentTime()
 
 	// walkerMetrics adapts m.BGPWalkerOutcomeTotal to the snmputil.WalkerMetrics
@@ -221,7 +221,7 @@ func Run(ctx context.Context, args []string) int {
 	pub := NoopOTLPPublisher()
 
 	switch cfg.Federation.Role {
-	case "hub":
+	case config.RoleHub:
 		// Hub mode: pure aggregator — no local SNMP discovery. The hub server
 		// exposes /spoke/push on a separate mTLS listener (LD-20).
 		hub := federation.NewHub(cfg.Federation, m, logger, cfg.Snapshot.Path)
@@ -276,7 +276,7 @@ func Run(ctx context.Context, args []string) int {
 		// Build the spoke client now so TLS errors surface at startup, not
 		// mid-cycle.
 		var spoke *federation.Spoke
-		if cfg.Federation.Role == "spoke" {
+		if cfg.Federation.Role == config.RoleSpoke {
 			var err error
 			spoke, err = federation.NewSpoke(cfg.Federation, logger, warnLimiter, m)
 			if err != nil {
@@ -473,7 +473,7 @@ func Run(ctx context.Context, args []string) int {
 // and no watchdog goroutine), which is exactly what hub mode and an explicit
 // opt-out both want.
 func livenessMaxStale(cfg *config.Config) time.Duration {
-	if cfg.Federation.Role == "hub" {
+	if cfg.Federation.Role == config.RoleHub {
 		return 0
 	}
 	cycles := cfg.Discovery.LivenessMaxStaleCyclesValue()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -185,7 +185,6 @@ func Run(ctx context.Context, args []string) int {
 	defer cancel()
 
 	var workerDone sync.WaitGroup
-	var otlpWg sync.WaitGroup
 
 	// Issue #68: opt-in OpenTelemetry tracing of the discovery cycle. Built
 	// before the role switch so both hub mode (which records hub.handlePush on
@@ -214,6 +213,12 @@ func Run(ctx context.Context, args []string) int {
 		}
 		logger.Info("tracing enabled", "sample_rate", sampleRate, "protocol", cfg.Output.OTLP.Protocol)
 	}
+
+	// OTLP publisher: a no-op by default (hub mode never enables OTLP), so the
+	// shared shutdown drain below never nil-panics. The default branch replaces
+	// this with an enabled publisher (exp + sem + wg allocated together) when
+	// output.otlp.enabled is true.
+	pub := NoopOTLPPublisher()
 
 	switch cfg.Federation.Role {
 	case "hub":
@@ -280,10 +285,8 @@ func Run(ctx context.Context, args []string) int {
 			}
 		}
 
-		var otlpExp *otlp.Exporter
 		if cfg.Output.OTLP.Enabled {
-			var err error
-			otlpExp, err = otlp.New(ctx, otlp.Config{
+			otlpExp, err := otlp.New(ctx, otlp.Config{
 				Endpoint:   cfg.Output.OTLP.Endpoint,
 				Timeout:    cfg.Output.OTLP.Timeout,
 				InstanceID: cfg.Federation.Spoke.SpokeID, // empty in non-spoke roles → falls back to hostname
@@ -293,11 +296,7 @@ func Run(ctx context.Context, args []string) int {
 				logger.Error("building OTLP exporter", "error", err)
 				return 1
 			}
-		}
-
-		var otlpSem chan struct{}
-		if cfg.Output.OTLP.Enabled {
-			otlpSem = make(chan struct{}, MaxOTLPPushConcurrency)
+			pub = NewOTLPPublisher(otlpExp, MaxOTLPPushConcurrency, logger, m)
 		}
 
 		// Issue #73: admin out-of-cycle re-discovery. cycleMu serialises forced
@@ -357,9 +356,7 @@ func Run(ctx context.Context, args []string) int {
 				Status:        &status,
 				Ready:         &ready,
 				Spoke:         spoke,
-				OtlpExp:       otlpExp,
-				OtlpSem:       otlpSem,
-				OtlpWg:        &otlpWg,
+				Otlp:          pub,
 				CycleMu:       &cycleMu,
 				Pool:          sessionPool,
 			})
@@ -437,7 +434,7 @@ func Run(ctx context.Context, args []string) int {
 	// stuck OTLP push cannot hang shutdown indefinitely (the discovery drain is
 	// bounded but this Wait previously was not).
 	otlpDone := make(chan struct{})
-	go func() { otlpWg.Wait(); close(otlpDone) }()
+	go func() { pub.Drain(); close(otlpDone) }()
 	select {
 	case <-otlpDone:
 		logger.Info("otlp push goroutines drained")

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -22,7 +22,6 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
-	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snapshot"
 	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
 )
@@ -60,9 +59,10 @@ type LoopConfig struct {
 	Status        *atomic.Pointer[httpx.CycleStatus]
 	Ready         *atomic.Bool
 	Spoke         *federation.Spoke
-	OtlpExp       *otlp.Exporter
-	OtlpSem       chan struct{}   // semaphore bounding concurrent OTLP pushes; nil when OTLP disabled
-	OtlpWg        *sync.WaitGroup // tracks in-flight OTLP push goroutines for clean shutdown
+	// Otlp owns the OTLP exporter plus the concurrency cap and in-flight
+	// tracking for async pushes. Always non-nil; a disabled publisher (OTLP
+	// off) makes push a no-op, so the loop never nil-checks.
+	Otlp *otlpPublisher
 	// CycleMu serialises each regular discovery cycle against forced
 	// out-of-cycle walks triggered via POST /admin/rediscover (issue #73).
 	// Held only for the duration of RunCycle's SNMP work; the Rediscoverer
@@ -88,50 +88,6 @@ func (lc LoopConfig) WarnSnapshot(ctx context.Context, site, msg string, attrs .
 		return
 	}
 	lc.Logger.WarnContext(ctx, msg, attrs...)
-}
-
-// OtlpPush enqueues an OTLP push function under the configured concurrency cap.
-// Drops the push (and increments the dropped counter) if the OtlpSem is full.
-func (lc LoopConfig) OtlpPush(ctx context.Context, fn func(context.Context) error, warnMsg string) {
-	if lc.OtlpSem != nil {
-		select {
-		case lc.OtlpSem <- struct{}{}:
-		default:
-			lc.Logger.Warn("otlp push dropped: concurrent limit reached")
-			// status="dropped" never carries a failure reason — use the
-			// shared n/a sentinel. Issue #20.
-			lc.M.OTLPPushTotal.WithLabelValues("dropped", metrics.ReasonNA).Inc()
-			return
-		}
-	}
-	if lc.OtlpWg != nil {
-		lc.OtlpWg.Add(1)
-	}
-	go func() { //nolint:gosec // G118: OTLP push must survive the originating cycle's context — the push is a side-effect of a completed cycle and should reach the collector even if the cycle's deadline already expired
-		// Recover a panic in the push body so a bug in the OTLP exporter
-		// cannot crash the process. Registered first so it runs LAST in the
-		// defer chain — after the semaphore release and OtlpWg.Done below —
-		// keeping the concurrency cap and shutdown drain correct on panic.
-		// One-shot: the push goroutine exits on recovery.
-		defer recoverGoroutine("otlp_push", lc.Logger, lc.M)
-		if lc.OtlpWg != nil {
-			defer lc.OtlpWg.Done()
-		}
-		if lc.OtlpSem != nil {
-			defer func() { <-lc.OtlpSem }()
-		}
-		pushCtx, cancel := context.WithTimeout(context.Background(), OTLPPushTimeout)
-		defer cancel()
-		if err := fn(pushCtx); err != nil {
-			lc.Logger.Warn(warnMsg, "error", err)
-			// Issue #20: partition status="error" by the OTLP sub-reason
-			// derived from the error (timeout / tls_error / http_4xx /
-			// http_5xx / network).
-			lc.M.OTLPPushTotal.WithLabelValues("error", string(otlp.ClassifyPushError(err))).Inc()
-		} else {
-			lc.M.OTLPPushTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
-		}
-	}()
 }
 
 // RunStaleWatchdog re-asserts the network_topology_graph_stale gauge when a
@@ -395,12 +351,10 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 				}
 				lc.M.TopologyChangeTotal.WithLabelValues(string(c.Kind), string(proto)).Inc()
 			}
-			if lc.OtlpExp != nil {
-				ch := changes
-				lc.OtlpPush(ctx, func(ctx context.Context) error {
-					return lc.OtlpExp.PushChanges(ctx, ch)
-				}, "otlp push changes failed")
-			}
+			ch := changes
+			lc.Otlp.Push(func(ctx context.Context) error {
+				return lc.Otlp.exp.PushChanges(ctx, ch)
+			}, "otlp push changes failed")
 		}
 		if len(conflicts) > 0 {
 			evLogger.EmitConflicts(ctx, conflicts)
@@ -410,10 +364,10 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 		}
 		prevGraph = newGraph
 		ages = newAges
-		if lc.OtlpExp != nil && (len(changes) > 0 || cycleNum%lc.Cfg.Output.OTLP.HeartbeatCycles == 0) {
+		if lc.Otlp.Enabled() && (len(changes) > 0 || cycleNum%lc.Cfg.Output.OTLP.HeartbeatCycles == 0) {
 			g := newGraph
-			lc.OtlpPush(ctx, func(ctx context.Context) error {
-				return lc.OtlpExp.PushGraph(ctx, g)
+			lc.Otlp.Push(func(ctx context.Context) error {
+				return lc.Otlp.exp.PushGraph(ctx, g)
 			}, "otlp push failed")
 		}
 		lc.M.GraphStale.Set(0)

--- a/internal/app/loop_test.go
+++ b/internal/app/loop_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
 )
 
@@ -41,15 +42,29 @@ func TestWarnSnapshotFallback(t *testing.T) {
 	lc.WarnSnapshot(context.Background(), "site-a", "limiter path")
 }
 
+// enabledPublisher constructs an otlpPublisher in its enabled form (exp + sem +
+// wg allocated together as a unit) for tests exercising the cap/drain behavior.
+// The exp is a bare non-nil sentinel: push runs the supplied fn directly and
+// never calls exp's methods, so a zero-value Exporter is sufficient to pass the
+// disabled-guard.
+func enabledPublisher(m *metrics.Metrics, semCap int) *otlpPublisher {
+	return &otlpPublisher{
+		exp:    &otlp.Exporter{},
+		sem:    make(chan struct{}, semCap),
+		wg:     &sync.WaitGroup{},
+		logger: slogDiscard(),
+		m:      m,
+	}
+}
+
 // TestOtlpPushDropsWhenSemFull drops the push (and increments the dropped
 // counter) when the concurrency semaphore is already saturated.
 func TestOtlpPushDropsWhenSemFull(t *testing.T) {
 	m := metrics.New(false)
-	sem := make(chan struct{}, 1)
-	sem <- struct{}{} // saturate
+	p := enabledPublisher(m, 1)
+	p.sem <- struct{}{} // saturate
 	var ran atomic.Bool
-	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpSem: sem}
-	lc.OtlpPush(context.Background(), func(context.Context) error {
+	p.Push(func(context.Context) error {
 		ran.Store(true)
 		return nil
 	}, "should not run")
@@ -62,22 +77,20 @@ func TestOtlpPushDropsWhenSemFull(t *testing.T) {
 // the WaitGroup, asserting the goroutine completed and the semaphore drained.
 func TestOtlpPushRunsAndCountsOK(t *testing.T) {
 	m := metrics.New(false)
-	sem := make(chan struct{}, 1)
-	var wg sync.WaitGroup
+	p := enabledPublisher(m, 1)
 	var ran atomic.Bool
-	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpSem: sem, OtlpWg: &wg}
-	lc.OtlpPush(context.Background(), func(context.Context) error {
+	p.Push(func(context.Context) error {
 		ran.Store(true)
 		return nil
 	}, "push ok")
-	wg.Wait()
+	p.Drain()
 	if !ran.Load() {
 		t.Error("push fn did not run")
 	}
 	// Semaphore must have drained so a follow-up push can proceed.
 	select {
-	case sem <- struct{}{}:
-		<-sem
+	case p.sem <- struct{}{}:
+		<-p.sem
 	default:
 		t.Error("semaphore not released after push completed")
 	}
@@ -86,12 +99,27 @@ func TestOtlpPushRunsAndCountsOK(t *testing.T) {
 // TestOtlpPushCountsError runs a failing push and waits for completion.
 func TestOtlpPushCountsError(t *testing.T) {
 	m := metrics.New(false)
-	var wg sync.WaitGroup
-	lc := LoopConfig{Logger: slogDiscard(), M: m, OtlpWg: &wg}
-	lc.OtlpPush(context.Background(), func(context.Context) error {
+	p := enabledPublisher(m, 1)
+	p.Push(func(context.Context) error {
 		return errors.New("boom")
 	}, "push failed")
-	wg.Wait()
+	p.Drain()
+}
+
+// TestOtlpPushNoOpWhenDisabled asserts a disabled publisher (exp == nil, all
+// fields nil) never runs the fn, spawns no goroutine, and drains cleanly — the
+// invariant that lets callers drop the nil-checks.
+func TestOtlpPushNoOpWhenDisabled(t *testing.T) {
+	var p otlpPublisher // zero value: exp/sem/wg all nil
+	var ran atomic.Bool
+	p.Push(func(context.Context) error {
+		ran.Store(true)
+		return nil
+	}, "should not run")
+	if ran.Load() {
+		t.Error("push fn ran on a disabled publisher")
+	}
+	p.Drain() // must not panic on a nil wg
 }
 
 // TestRunDiscoveryLoopShutsDownCleanly drives the full loop against an
@@ -123,6 +151,9 @@ func TestRunDiscoveryLoopShutsDownCleanly(t *testing.T) {
 		M:      m,
 		Status: &status,
 		Ready:  &ready,
+		// Otlp is always non-nil in production wiring; a disabled (no-op)
+		// publisher makes Push a no-op so the loop never nil-derefs.
+		Otlp: &otlpPublisher{},
 	}
 
 	done := make(chan struct{})

--- a/internal/app/otlp_publisher.go
+++ b/internal/app/otlp_publisher.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
+)
+
+// otlpPublisher owns the OTLP exporter plus the concurrency cap and in-flight
+// tracking for async pushes. A publisher whose exp is nil is a no-op (OTLP
+// disabled), so callers never nil-check. The enabled publisher allocates exp,
+// sem, and wg together as a unit; the disabled publisher leaves all three nil
+// and push early-returns before touching sem/wg.
+type otlpPublisher struct {
+	exp    *otlp.Exporter  // nil ⇒ disabled, push() is a no-op
+	sem    chan struct{}   // semaphore bounding concurrent OTLP pushes
+	wg     *sync.WaitGroup // tracks in-flight push goroutines for clean shutdown
+	logger *slog.Logger
+	m      *metrics.Metrics
+}
+
+// NoopOTLPPublisher returns a disabled (no-op) publisher: Push is a no-op and
+// Drain returns immediately. This is the publisher used when OTLP output is
+// off, so callers always hold a non-nil LoopConfig.Otlp and never nil-check.
+func NoopOTLPPublisher() *otlpPublisher { //nolint:revive // unexported-return: intentional, the type is package-internal and callers store it in LoopConfig.Otlp
+	return &otlpPublisher{}
+}
+
+// NewOTLPPublisher builds an enabled publisher: exp, sem, and wg are allocated
+// together as a unit so push never has to nil-check sem/wg after the exp guard.
+// cap bounds the concurrent in-flight pushes. The returned publisher is suitable
+// for LoopConfig.Otlp; a disabled (no-op) publisher is the zero value
+// &otlpPublisher{}.
+func NewOTLPPublisher(exp *otlp.Exporter, cap int, logger *slog.Logger, m *metrics.Metrics) *otlpPublisher { //nolint:revive // unexported-return: intentional, the type is package-internal and callers store it in LoopConfig.Otlp
+	return &otlpPublisher{
+		exp:    exp,
+		sem:    make(chan struct{}, cap),
+		wg:     &sync.WaitGroup{},
+		logger: logger,
+		m:      m,
+	}
+}
+
+// Enabled reports whether OTLP output is on (exp != nil). Callers use this only
+// to skip work that is pointless when disabled — e.g. evaluating the heartbeat
+// gate — and never to nil-check before Push (which is itself a no-op when off).
+func (p *otlpPublisher) Enabled() bool { return p.exp != nil }
+
+// Push enqueues fn under the configured concurrency cap and runs it
+// asynchronously, tracked for shutdown drain, with panic recovery and #20 error
+// classification. It drops the push (and increments the dropped counter) if the
+// semaphore is full. No-op when the publisher is disabled (exp == nil).
+func (p *otlpPublisher) Push(fn func(context.Context) error, warnMsg string) {
+	if p.exp == nil {
+		return
+	}
+	select {
+	case p.sem <- struct{}{}:
+	default:
+		p.logger.Warn("otlp push dropped: concurrent limit reached")
+		// status="dropped" never carries a failure reason — use the
+		// shared n/a sentinel. Issue #20.
+		p.m.OTLPPushTotal.WithLabelValues("dropped", metrics.ReasonNA).Inc()
+		return
+	}
+	p.wg.Add(1)
+	go func() { //nolint:gosec // G118: OTLP push must survive the originating cycle's context — the push is a side-effect of a completed cycle and should reach the collector even if the cycle's deadline already expired
+		// Recover a panic in the push body so a bug in the OTLP exporter
+		// cannot crash the process. Registered first so it runs LAST in the
+		// defer chain — after the semaphore release and wg.Done below —
+		// keeping the concurrency cap and shutdown drain correct on panic.
+		// One-shot: the push goroutine exits on recovery.
+		defer recoverGoroutine("otlp_push", p.logger, p.m)
+		defer p.wg.Done()
+		defer func() { <-p.sem }()
+		pushCtx, cancel := context.WithTimeout(context.Background(), OTLPPushTimeout)
+		defer cancel()
+		if err := fn(pushCtx); err != nil {
+			p.logger.Warn(warnMsg, "error", err)
+			// Issue #20: partition status="error" by the OTLP sub-reason
+			// derived from the error (timeout / tls_error / http_4xx /
+			// http_5xx / network).
+			p.m.OTLPPushTotal.WithLabelValues("error", string(otlp.ClassifyPushError(err))).Inc()
+		} else {
+			p.m.OTLPPushTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
+		}
+	}()
+}
+
+// Drain blocks until in-flight pushes finish (shutdown). No-op when disabled.
+func (p *otlpPublisher) Drain() {
+	if p.wg != nil {
+		p.wg.Wait()
+	}
+}

--- a/internal/app/watchdog_test.go
+++ b/internal/app/watchdog_test.go
@@ -23,7 +23,7 @@ func TestLivenessMaxStale(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		role     string
+		role     config.Role
 		interval time.Duration
 		cycles   *int
 		want     time.Duration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ type OTLPOutputConfig struct {
 	// is always protobuf — the OpenTelemetry Go SDK exporters do not implement
 	// OTLP/JSON. This is a wire-format change from the pre-v1.5.0 hand-rolled
 	// JSON path; OTLP receivers must accept protobuf (the OTLP default).
-	Protocol string `yaml:"protocol"`
+	Protocol OTLPProtocol `yaml:"protocol"`
 
 	// Traces configures opt-in OpenTelemetry tracing of the exporter's own
 	// discovery cycle (issue #68). It reuses Endpoint, Protocol, and auth from
@@ -112,7 +112,7 @@ type FederationConfig struct {
 	// single-instance behaviour. "uncoordinated" adds boundary-observation
 	// metrics for Mimir recording-rule stitching (LD-15). "spoke" and "hub"
 	// configure the H-PCE-style push hierarchy (LD-16).
-	Role string `yaml:"role"` // standalone | uncoordinated | spoke | hub
+	Role Role `yaml:"role"` // standalone | uncoordinated | spoke | hub
 
 	// SpokeTimeout governs spoke eviction on the hub per LD-18: a spoke that
 	// has not pushed within this duration has its edges removed from the
@@ -366,9 +366,9 @@ type ModuleToggle struct {
 // for the dev-time single-profile path; production deployments should use
 // credentials.profiles.
 type ModuleSNMP struct {
-	Enabled      bool   `yaml:"enabled"`
-	Version      string `yaml:"version"` // v2c | v3
-	CommunityEnv string `yaml:"community_env"`
+	Enabled      bool        `yaml:"enabled"`
+	Version      SNMPVersion `yaml:"version"` // v2c | v3
+	CommunityEnv string      `yaml:"community_env"`
 }
 
 // CredentialsConfig encodes LD-12: named profiles, per-device assignments,
@@ -383,23 +383,20 @@ type CredentialsConfig struct {
 	TrialRatePerSecond int                    `yaml:"trial_rate_per_second"`
 }
 
-// Profile type constants for CredentialProfile.Type.
-const (
-	ProfileTypeSNMPv2c = "snmp_v2c"
-	ProfileTypeSNMPv3  = "snmp_v3"
-)
+// Profile type constants for CredentialProfile.Type are defined as the named
+// ProfileType enum in enums.go.
 
 // CredentialProfile is one named credential the exporter can try against
 // a device. Type selects which *Env fields are consulted.
 type CredentialProfile struct {
-	Name         string `yaml:"name"`
-	Type         string `yaml:"type"` // snmp_v2c | snmp_v3
-	CommunityEnv string `yaml:"community_env,omitempty"`
-	UsernameEnv  string `yaml:"username_env,omitempty"`
-	AuthProtocol string `yaml:"auth_protocol,omitempty"` // SHA (recommended) | SHA-256 | SHA-384 | SHA-512 | MD5 (deprecated, broken)
-	AuthKeyEnv   string `yaml:"auth_key_env,omitempty"`
-	PrivProtocol string `yaml:"priv_protocol,omitempty"` // AES (recommended) | AES-192 | AES-256 | DES (deprecated, broken)
-	PrivKeyEnv   string `yaml:"priv_key_env,omitempty"`
+	Name         string      `yaml:"name"`
+	Type         ProfileType `yaml:"type"` // snmp_v2c | snmp_v3
+	CommunityEnv string      `yaml:"community_env,omitempty"`
+	UsernameEnv  string      `yaml:"username_env,omitempty"`
+	AuthProtocol string      `yaml:"auth_protocol,omitempty"` // SHA (recommended) | SHA-256 | SHA-384 | SHA-512 | MD5 (deprecated, broken)
+	AuthKeyEnv   string      `yaml:"auth_key_env,omitempty"`
+	PrivProtocol string      `yaml:"priv_protocol,omitempty"` // AES (recommended) | AES-192 | AES-256 | DES (deprecated, broken)
+	PrivKeyEnv   string      `yaml:"priv_key_env,omitempty"`
 	// Retries is the number of SNMP retries per request. Defaults to 1.
 	Retries int `yaml:"retries"`
 	// ContextName is the SNMPv3 context name. Empty string means no context (default).
@@ -492,7 +489,7 @@ func (c *Config) applyDefaults() {
 		c.Discovery.SNMP.SessionPool.MaxIdle = 5 * c.Discovery.Interval
 	}
 	if c.Modules.SNMP.Version == "" {
-		c.Modules.SNMP.Version = "v2c"
+		c.Modules.SNMP.Version = SNMPVersionV2c
 	}
 	if c.Credentials.TrialRatePerSecond == 0 {
 		c.Credentials.TrialRatePerSecond = 5
@@ -514,7 +511,7 @@ func (c *Config) applyDefaults() {
 		}
 	}
 	if c.Federation.Role == "" {
-		c.Federation.Role = "standalone"
+		c.Federation.Role = RoleStandalone
 	}
 	if c.Federation.SpokeTimeout == 0 {
 		c.Federation.SpokeTimeout = 3 * c.Discovery.Interval
@@ -529,7 +526,7 @@ func (c *Config) applyDefaults() {
 		c.Output.OTLP.Timeout = 10 * time.Second
 	}
 	if c.Output.OTLP.Protocol == "" {
-		c.Output.OTLP.Protocol = "http"
+		c.Output.OTLP.Protocol = OTLPProtocolHTTP
 	}
 	if c.Output.OTLP.Traces.SampleRate == nil {
 		def := 0.1
@@ -597,7 +594,7 @@ func (c *Config) validate() error {
 	}
 	if c.Modules.SNMP.Enabled {
 		switch c.Modules.SNMP.Version {
-		case "v2c", "v3":
+		case SNMPVersionV2c, SNMPVersionV3:
 		default:
 			return fmt.Errorf("modules.snmp.version must be v2c or v3, got %q", c.Modules.SNMP.Version)
 		}
@@ -621,7 +618,7 @@ func (c *Config) validate() error {
 		return errors.New("output.otlp.heartbeat_cycles must be >= 1")
 	}
 	switch c.Output.OTLP.Protocol {
-	case "", "http", "grpc":
+	case "", OTLPProtocolHTTP, OTLPProtocolGRPC:
 	default:
 		return fmt.Errorf("output.otlp.protocol must be http or grpc, got %q", c.Output.OTLP.Protocol)
 	}
@@ -631,7 +628,7 @@ func (c *Config) validate() error {
 	if c.Output.OTLP.Enabled {
 		// gRPC endpoints are bare host:port authorities (or a URL); HTTP
 		// endpoints must be a full http/https URL as before.
-		if c.Output.OTLP.Protocol == "grpc" {
+		if c.Output.OTLP.Protocol == OTLPProtocolGRPC {
 			if c.Output.OTLP.Endpoint == "" {
 				return errors.New("output.otlp.endpoint: endpoint is required")
 			}
@@ -849,9 +846,9 @@ func (c *Config) validateFederation() error {
 		return fmt.Errorf("federation.spoke_timeout must be >= 0 (0 uses the default of 3× discovery.interval)")
 	}
 	switch c.Federation.Role {
-	case "standalone", "uncoordinated":
+	case RoleStandalone, RoleUncoordinated:
 		// no extra required fields
-	case "spoke":
+	case RoleSpoke:
 		if c.Federation.Spoke.SpokeID == "" {
 			return errors.New("federation.spoke.spoke_id is required for spoke role")
 		}
@@ -870,7 +867,7 @@ func (c *Config) validateFederation() error {
 				return fmt.Errorf("%s: %w", pair.field, err)
 			}
 		}
-	case "hub":
+	case RoleHub:
 		if c.Federation.Hub.TLSCACert == "" || c.Federation.Hub.TLSCert == "" || c.Federation.Hub.TLSKey == "" {
 			return errors.New("federation.hub.tls_ca_cert, tls_cert, and tls_key are all required for hub role (LD-20)")
 		}

--- a/internal/config/enums.go
+++ b/internal/config/enums.go
@@ -1,0 +1,68 @@
+package config
+
+// This file defines the named string types for the four config enums. The
+// underlying string values are YAML wire-contract values and MUST stay
+// byte-identical; the named types add compile-time safety and a Valid() helper
+// without changing any unmarshalled wire value.
+
+// Role selects the federation operating mode (LD-15–LD-20).
+type Role string
+
+// Federation role wire values.
+const (
+	RoleStandalone    Role = "standalone"
+	RoleUncoordinated Role = "uncoordinated"
+	RoleSpoke         Role = "spoke"
+	RoleHub           Role = "hub"
+)
+
+// Valid reports whether r is a recognized federation role.
+func (r Role) Valid() bool {
+	switch r {
+	case RoleStandalone, RoleUncoordinated, RoleSpoke, RoleHub:
+		return true
+	}
+	return false
+}
+
+// OTLPProtocol selects the OTLP transport.
+type OTLPProtocol string
+
+// OTLP transport wire values.
+const (
+	OTLPProtocolHTTP OTLPProtocol = "http"
+	OTLPProtocolGRPC OTLPProtocol = "grpc"
+)
+
+// Valid reports whether p is a recognized OTLP transport.
+func (p OTLPProtocol) Valid() bool {
+	return p == OTLPProtocolHTTP || p == OTLPProtocolGRPC
+}
+
+// SNMPVersion selects the SNMP protocol version.
+type SNMPVersion string
+
+// SNMP version wire values.
+const (
+	SNMPVersionV2c SNMPVersion = "v2c"
+	SNMPVersionV3  SNMPVersion = "v3"
+)
+
+// Valid reports whether v is a recognized SNMP version.
+func (v SNMPVersion) Valid() bool {
+	return v == SNMPVersionV2c || v == SNMPVersionV3
+}
+
+// ProfileType selects which credential fields a CredentialProfile consults.
+type ProfileType string
+
+// Credential profile type wire values.
+const (
+	ProfileTypeSNMPv2c ProfileType = "snmp_v2c"
+	ProfileTypeSNMPv3  ProfileType = "snmp_v3"
+)
+
+// Valid reports whether t is a recognized credential profile type.
+func (t ProfileType) Valid() bool {
+	return t == ProfileTypeSNMPv2c || t == ProfileTypeSNMPv3
+}

--- a/internal/config/enums_test.go
+++ b/internal/config/enums_test.go
@@ -1,0 +1,73 @@
+package config
+
+import "testing"
+
+func TestRoleValid(t *testing.T) {
+	cases := []struct {
+		in   Role
+		want bool
+	}{
+		{RoleStandalone, true},
+		{RoleUncoordinated, true},
+		{RoleSpoke, true},
+		{RoleHub, true},
+		{"", false},
+		{"bogus", false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.Valid(); got != tc.want {
+			t.Errorf("Role(%q).Valid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestOTLPProtocolValid(t *testing.T) {
+	cases := []struct {
+		in   OTLPProtocol
+		want bool
+	}{
+		{OTLPProtocolHTTP, true},
+		{OTLPProtocolGRPC, true},
+		{"", false},
+		{"tcp", false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.Valid(); got != tc.want {
+			t.Errorf("OTLPProtocol(%q).Valid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestSNMPVersionValid(t *testing.T) {
+	cases := []struct {
+		in   SNMPVersion
+		want bool
+	}{
+		{SNMPVersionV2c, true},
+		{SNMPVersionV3, true},
+		{"", false},
+		{"v1", false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.Valid(); got != tc.want {
+			t.Errorf("SNMPVersion(%q).Valid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestProfileTypeValid(t *testing.T) {
+	cases := []struct {
+		in   ProfileType
+		want bool
+	}{
+		{ProfileTypeSNMPv2c, true},
+		{ProfileTypeSNMPv3, true},
+		{"", false},
+		{"snmp_v1", false},
+	}
+	for _, tc := range cases {
+		if got := tc.in.Valid(); got != tc.want {
+			t.Errorf("ProfileType(%q).Valid() = %v, want %v", string(tc.in), got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #152. **Pure cleanup — zero behavior change** (verified: YAML values, validation error strings, metric labels, and OTLP concurrency/drain semantics all byte-identical).

### Part A — dropped (false positive)
The originally-claimed `LinkKind` "latent bug" isn't one: the federation hub already defaults an empty `link_kind` to `ethernet` at the sole consumer (`hub.go:881`), and `TestFederationKnownLinkOptionalLinkKind` *explicitly asserts* `LinkKind == ""` after `Load` with the comment "default applied by hub at injection time" — i.e. the current placement is intentional and tested. Relocating it would change loaded-config state and fight that test for no functional gain, so it was dropped.

### Part B — typed config enums
`FederationConfig.Role`, `OTLPOutputConfig.Protocol`, `ModuleSNMP.Version`, `CredentialProfile.Type` are now named string types (`Role`/`OTLPProtocol`/`SNMPVersion`/`ProfileType`) with constants + `Valid()`. YAML values and the four validation error strings are byte-identical (`%q` of a named string type prints the same). Consumers use the constants; the one missed call site (`watchdog_test.go`, which assigned a `string` variable to the field) is fixed.

### Part C — collapse LoopConfig's three nilable OTLP fields into one publisher
`OtlpExp`/`OtlpSem`/`OtlpWg` → one always-non-nil `*otlpPublisher` that no-ops when disabled, killing the scattered `if lc.Otlp* != nil` guards. The push path (drop-on-full + `{dropped,ok,error}` metrics + panic-recover + background-ctx timeout) and the shutdown drain (`Drain()` = the same `wg.Wait()`, bounded by the existing timeout select) are preserved verbatim. The enabled publisher allocates sem+wg as a unit, so `push` needs exactly one `if exp==nil` guard.

## Process
Spec → one adversarial check (which caught: the `LinkKind` false positive → Part A dropped; a build-breaking missed call site in `watchdog_test.go`; and that the "sem/wg non-nil iff exp!=nil" invariant was false in the existing tests → would deadlock) → subagent-driven implementation → spec-compliance + code-quality review (both passed; finished by migrating the last bare-string Role comparisons to constants).

## Test plan
- [x] `go test ./... -race` — green (incl. app goleak + rewritten OTLP push/drain tests)
- [x] `golangci-lint run` — 0 issues; `gofmt` clean
- [x] Error-string / metric-label / drain-semantic identity verified by both reviewers
- [x] `Valid()` table tests per enum; `TestOtlpPushNoOpWhenDisabled`