### PR TITLE
refactor(app): decompose RunCycle + dedup cycle/rediscover walk path (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ v1.3.1 lands under this milestone instead, renamed to
 
 ### Internal
 
+- Decomposed RunCycle (probeTarget + shared walkModules) and de-duplicated the
+  cycle/rediscover module-walk; extracted loop publish(). No behavior change;
+  rediscover's minimal instrumentation is intentional and now explicit (#153).
 - File decomposition along responsibility (#151). `internal/config/config.go`
   is split into `types.go` (struct/type definitions), `defaults.go`
   (`applyDefaults`), `validate.go` (the validation family), and

--- a/docs/superpowers/specs/2026-06-09-orchestration-decomposition-design.md
+++ b/docs/superpowers/specs/2026-06-09-orchestration-decomposition-design.md
@@ -1,0 +1,50 @@
+# Orchestration Decomposition + Walk-Path Dedup — Design Spec (#153)
+
+**Issue:** #153. **Process:** full treatment — brainstorm → 2 adversarial design reviews (done) → spec → plan → subagent-driven TDD with per-task reviews.
+**Scope decision (post-adversarial):** **PURE REFACTOR — zero behavior change for BOTH the cycle and `/admin/rediscover`.** The adversarial review established that "closing rediscover's instrumentation gap" is mostly a *regression* (feeding the cycle's per-cycle, source-unlabeled metric series would corrupt `rate(...)` dashboards) or *intentional isolation* (the #72 rate limiter is deliberately skipped so the diagnostic endpoint stays fast; adding it would also lengthen the `CycleMu` hold). So we dedup the duplicated module-walk **structure** via a helper *parameterized on instrumentation* — cycle passes full sinks, rediscover passes its current minimal set — making future drift structurally visible while preserving each caller's exact behavior. **Target 4 (bgp decoder/edge-builder dedup) is dropped** (assessed clarity-reducing, #150-style).
+
+## Load-bearing constraints from the adversarial reviews (the spec exists to honor these)
+
+**C1 — params/credential lifetime boundary (reviewer 1, the #1 condition).** `params` is built by the credential walk, mutated for module config (Vendor/MaxVlans/Pool/CredentialProfile/UseBGPV2MIB/WalkerMetrics/WarnLimiter/PanicReporter), consumed by **both** the module loop **and** the ARP step, and zeroized by a `defer params.Zeroize()` that must outlive both. Therefore `walkModules` **MUST NOT** build `params` or own its `Zeroize`. It **receives** the already-mutated `params`, returns only `(edges, oos, perModuleStatus)`; `params`-build + `defer Zeroize` + ARP stay in `probeTarget`. (Get this wrong → #83 session-reuse regression or use-after-zeroize in ARP.)
+
+**C2 — instrumentation is parameterized, not owned (reviewer 2).** `walkModules` does NOT unconditionally emit per-module metrics or spans. Per-module span creation, `DiscoveryModuleDuration`/`SNMPWalksTotal`/`DiscoveryHardFailTotal`/`DiscoveryDegradedTotal` emission, and the walker-outcome sink (`params.WalkerMetrics`) are supplied by the caller. Cycle supplies them all → byte-identical. Rediscover supplies none (nil metrics, nil tracer, `params.WalkerMetrics` unset) → byte-identical to today's instrumentation-free `walkOne`. **Rediscover must NOT start emitting `walker_outcome_total`/decode/module-duration metrics or spans, and must NOT install the #72 rate limiter.**
+
+**C3 — output-only helper preserves the read-only invariant (reviewer 2).** `walkModules` returns `(edges, oos, perModuleStatus)` and takes no graph/ages/snapshot/`prevGraph` handle, so rediscover (which calls it) can never mutate the published graph. Graph mutation stays exclusively in `RunCycle`'s tail.
+
+**C4 — span parenting + ctx (reviewer 1).** Per-module spans descend from the per-*target* span. `walkModules` receives the per-device `ctx` (already descended from `targetCtx`) as its `ctx` arg; when its caller supplies a tracer it starts per-module child spans from that ctx. Rediscover passes a ctx with no span → no orphaning (and no spans created, per C2).
+
+**C5 — keep the #74 per-IP override inside the loop (reviewer 1).** `enabledModules(cfg)` returns the module list gated by `cfg.Modules.*.Enabled` only. The per-IP `cfg.ModulesForIP(ip)` intersection (`overrideMatched && !allowedMods[proto]`) stays **inside** `walkModules` (it needs `ip`). Do not pre-filter it away.
+
+**C6 — dep completeness (reviewer 1).** `walkModules` needs `cfg` (whole — for `TimeoutPerModule`, `ModulesForIP`, FDB/BGP knobs already baked into `params`), `logger`, `allowedNets`, `dev`, the per-device `ctx`, the mutated `params`, and an optional instrumentation set. It does NOT capture `mu`/`results`/`okCount`/`failByReason`/`allARPMACs` (all caller-side aggregation).
+
+**C7 — T3 panic-recover stays caller-side (reviewer 1).** A `recover()` only catches its own goroutine. The probe goroutine's `defer recover` and the `sem`/cycle-budget admission `select` and the `mu`-guarded `results`/`okCount`/`failByReason` append stay in the `RunCycle` closure; `probeTarget` returns a small `(probeResult, ok, failReason)` the caller aggregates.
+
+**C8 — T4 caller owns prevGraph/ages reassignment (reviewer 1).** `publish(...)` must not internally reassign `prevGraph` before the caller diffs. Keep `Diff(prevGraph, newGraph)` → … → `prevGraph = newGraph` ordering; the size-budget early return's `ages = newAges` side effect must fire on BOTH the reject and happy paths. `publish` receives `prevGraph`/`ages` and returns the new values (or takes pointers) so the caller owns the reassignment on both paths.
+
+**C9 — ARP merge ordering (reviewer 1).** `allARPMACs` is merged under `mu` at probe time (first-wins by goroutine scheduling). `probeTarget` returns its per-device `arpMACToIP`; the caller merges under `mu`. Preserve merge-at-collection (do not move it to the sorted aggregation pass — that would change which IP wins a MAC conflict).
+
+## New file: `internal/app/device_walk.go`
+- `enabledModules(cfg *config.Config) []Module` — the single 7-element list (kills the duplicated slice; the one genuine "can't drift" win).
+- `type moduleInstrumentation struct { metrics *metrics.Metrics; tracer trace.Tracer; logger *slog.Logger }` (or equivalent) — any field nil ⇒ that instrumentation is skipped. (The walker-outcome sink rides on `params.WalkerMetrics`, set by the caller, not here.)
+- `func walkModules(ctx context.Context, cfg *config.Config, dev discovery.Device, ip net.IP, params snmputil.Params, allowedNets []*net.IPNet, inst moduleInstrumentation) (edges []discovery.Edge, oos []discovery.OutOfScopeNeighbour, perModuleStatus map[string]moduleStatus)` — the shared loop: `enabledModules` → per-IP #74 intersection → per-module (optional span) → `mod.Walk(ctx, params, dev.ID, allowedNets)` → outcome classify (error/degraded/ok) → (optional) per-module metrics → accumulate. Output-only.
+
+## Tasks (sequential TDD; each behavior-identical)
+- **T1** — add `enabledModules` + `walkModules`; refactor `RunCycle`'s probe closure to call it with FULL instrumentation. Behavior-identical for cycle (regression gate: existing cycle tests).
+- **T2** — route `rediscover.walkOne` through `walkModules` with MINIMAL instrumentation (nil metrics/tracer, `params.WalkerMetrics` unset). Delete rediscover's duplicated module slice + loop. **Behavior-identical** — rediscover emits no new metrics/spans, no rate limiter. Add a test asserting `/admin/rediscover` still emits NO `walker_outcome_total` increments (pins the no-regression). Document the intentional instrumentation difference in a comment on `walkOne`/`walkModules`.
+- **T3** — extract `probeTarget(...)` for the rest of the closure (DNS, allow-list, system-walk, params-build + `defer Zeroize`, ARP, returning `probeResult`); `RunCycle` keeps the goroutine's `defer recover`, `sem`/budget admission, and `mu`-guarded aggregation (C7), reading as walk→synthesize→reconcile→age.
+- **T4** — extract `loop.go`'s publish sequence into `publish(...)` honoring C8 (caller owns prevGraph/ages reassignment; size-budget early-return `ages=newAges` on both paths).
+
+## Testing
+- Regression gate: all existing `internal/app` cycle + rediscover + goleak + `-race` tests pass unchanged.
+- T1: a `-race` test that cycle still produces identical edges/metrics (existing tests cover this).
+- T2: assert `walkOne` through the shared helper yields the same `(outcome, edgeCount)` as before AND emits zero `network_topology_walker_outcome_total` / module-duration increments (the no-regression pin). A `-race` test that cycle + rediscover sharing `walkModules` under `CycleMu` is race-clean.
+- T4: unit-test `publish()` ordering (diff-before-reassign; ages advanced on size-reject).
+
+## Cross-cutting
+- One branch (`refactor/153-orchestration-dedup`), one PR closing #153. No Co-Authored-By / AI-attribution trailers; author colinedwardwood.
+- CHANGELOG `### Internal`: decompose RunCycle (probeTarget + shared walkModules), dedup the cycle/rediscover module list+loop, extract loop.publish() — **no behavior change**; the rediscover instrumentation differences are intentional and now explicit.
+- Files: new `internal/app/device_walk.go`; modified `internal/app/cycle.go`, `internal/app/rediscover.go`, `internal/app/loop.go`, `CHANGELOG.md`. (No `NewRediscoverer` signature change needed — rediscover passes minimal instrumentation it can build from its existing `m`/`logger`, or nil.)
+
+## Out of scope
+- Closing rediscover's instrumentation gap (metrics/spans/rate-limiter) — declined as regression/intentional.
+- Target 4 (bgp decoder/edge-builder dedup) — declined as clarity-reducing.

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -18,13 +18,6 @@ import (
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
 	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/bgp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/cdp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/fdb"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/isis"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/lldp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/mpls"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/ospf"
 	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
@@ -291,100 +284,15 @@ func RunCycle(
 			params.Pool = pool
 			params.CredentialProfile = profileName
 
-			mods := []Module{
-				{"lldp", cfg.Modules.LLDP.Enabled, lldp.Walk},
-				{"cdp", cfg.Modules.CDP.Enabled, cdp.Walk},
-				{"fdb", cfg.Modules.FDB.Enabled, fdb.Walk},
-				{"ospf", cfg.Modules.OSPF.Enabled, ospf.Walk},
-				{"bgp", cfg.Modules.BGP.Enabled, bgp.Walk},
-				{"isis", cfg.Modules.ISIS.Enabled, isis.Walk},
-				{"mpls_te", cfg.Modules.MPLSTE.Enabled, mpls.Walk},
-			}
-			// Issue #74: resolve this target's per-protocol scope once. When an
-			// override matches, only the listed modules run (intersected with
-			// the global mod.Enabled gate below); when none matches, allowed is
-			// nil/overrideMatched=false and ALL enabled modules run — today's
-			// unchanged default. The headline case: bgp.Walk only fires where
-			// bgp is in the override's module set, so the walker outcome
-			// counters partition naturally.
-			allowedMods, overrideMatched := cfg.ModulesForIP(ip)
-			modStatus := map[string]int{}
-			for _, mod := range mods {
-				if !mod.Enabled {
-					continue
-				}
-				// Per-target protocol scoping: an override never widens beyond
-				// mod.Enabled (intersection), it only narrows.
-				if overrideMatched && !allowedMods[mod.Proto] {
-					continue
-				}
-				modStart := time.Now()
-				// Issue #68: per-module span, child of target.poll. Span name
-				// is "<proto>.walk" (e.g. lldp.walk, bgp.walk; the MPLS module
-				// uses its mpls_te proto identifier → mpls_te.walk). No-op when
-				// tracing is disabled.
-				modCtx, modSpan := tracing.Tracer().Start(devCtx, mod.Proto+".walk")
-				var modCancel context.CancelFunc = func() {}
-				if cfg.Discovery.TimeoutPerModule > 0 {
-					modCtx, modCancel = context.WithTimeout(modCtx, cfg.Discovery.TimeoutPerModule)
-				}
-				edges, oos, err := mod.Walk(modCtx, params, dev.ID, allowedNets)
-				modCancel()
-				m.DiscoveryModuleDuration.WithLabelValues(mod.Proto).Observe(time.Since(modStart).Seconds())
-				modSpan.SetAttributes(attribute.Int("walk.pdu_count", len(edges)))
-				if err != nil {
-					logger.Debug(mod.Proto+" walk failed", "target", target.Host, "error", err)
-					modSpan.SetAttributes(attribute.String("walk.outcome", "failed"))
-					modSpan.RecordError(err)
-					modSpan.SetStatus(codes.Error, "module walk failed")
-					modSpan.End()
-					reason := "module_walk_error"
-					var policyErr *discovery.PolicyError
-					if errors.As(err, &policyErr) && policyErr.Reason != "" {
-						reason = policyErr.Reason
-					}
-					m.DiscoveryHardFailTotal.WithLabelValues(mod.Proto, reason).Inc()
-					// Issue #20: partition by walk sub-reason. Timeouts
-					// keep reason=n/a; module-level non-timeout errors
-					// are tagged WalkReasonModuleError. Per-module richer
-					// breakdowns (auth_failed at the module layer is
-					// already excluded — credentials succeeded for the
-					// system walk above) would require module-walker
-					// changes and are not in #20's scope.
-					if errors.Is(err, context.DeadlineExceeded) {
-						m.SNMPWalksTotal.WithLabelValues("timeout", metrics.ReasonNA).Inc()
-					} else {
-						m.SNMPWalksTotal.WithLabelValues("error", string(metrics.WalkReasonModuleError)).Inc()
-					}
-					modStatus[mod.Proto] = 2
-					continue
-				}
-				m.SNMPWalksTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
-				degradedReasons := CollectDegradedReasons(edges)
-				for _, reason := range degradedReasons {
-					m.DiscoveryDegradedTotal.WithLabelValues(mod.Proto, reason).Inc()
-				}
-				if len(degradedReasons) > 0 {
-					modSpan.SetAttributes(attribute.String("walk.outcome", "degraded"))
-					if _, ok := modStatus[mod.Proto]; !ok {
-						modStatus[mod.Proto] = 1
-					}
-				} else {
-					modSpan.SetAttributes(attribute.String("walk.outcome", "ok"))
-					if _, ok := modStatus[mod.Proto]; !ok {
-						modStatus[mod.Proto] = 0
-					}
-				}
-				modSpan.End()
-				allEdges = append(allEdges, edges...)
-				// Tag each OOS entry with the protocol that reported it so the
-				// boundary_observation_info metric and hub OOS matching have a
-				// proto label.
-				for i := range oos {
-					oos[i].Proto = mod.Proto
-				}
-				allOOS = append(allOOS, oos...)
-			}
+			// Issue #153: the per-module walk loop (module list → #74 per-IP
+			// scope intersection → per-module span/metrics → outcome classify)
+			// is shared with /admin/rediscover via walkModules. The cycle
+			// supplies FULL instrumentation (metrics + tracer + logger) so its
+			// behaviour is byte-identical to the pre-extraction inline loop.
+			mEdges, mOOS, modStatus := walkModules(devCtx, cfg, *dev, ip, params, allowedNets,
+				moduleInstrumentation{metrics: m, tracer: tracing.Tracer(), logger: logger})
+			allEdges = append(allEdges, mEdges...)
+			allOOS = append(allOOS, mOOS...)
 
 			// Walk ARP table for MAC→IP enrichment when modules.arp.enabled
 			// is true (default). The map feeds SynthesizeEdges below as a

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -290,7 +290,7 @@ func RunCycle(
 			// supplies FULL instrumentation (metrics + tracer + logger) so its
 			// behaviour is byte-identical to the pre-extraction inline loop.
 			mEdges, mOOS, modStatus := walkModules(devCtx, cfg, *dev, ip, params, allowedNets,
-				moduleInstrumentation{metrics: m, tracer: tracing.Tracer(), logger: logger})
+				moduleInstrumentation{metrics: m, tracer: tracing.Tracer(), logger: logger, host: target.Host})
 			allEdges = append(allEdges, mEdges...)
 			allOOS = append(allOOS, mOOS...)
 

--- a/internal/app/cycle.go
+++ b/internal/app/cycle.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"maps"
 	"net"
@@ -11,9 +10,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/time/rate"
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
@@ -84,15 +80,6 @@ func RunCycle(
 	prevAges map[graph.EdgeKey]int,
 	pool *snmpwalk.SessionPool,
 ) (discovery.Graph, map[graph.EdgeKey]int, []graph.Conflict, int) {
-	type probeResult struct {
-		targetIdx    int
-		device       *discovery.Device
-		edges        []discovery.Edge
-		outOfScope   []discovery.OutOfScopeNeighbour
-		mgmtIP       string
-		moduleStatus map[string]int // proto -> 0 ok | 1 degraded | 2 failed
-	}
-
 	cycleCtx := ctx
 	cycleCancel := func() {}
 	if cfg.Discovery.CycleBudgetFraction > 0 {
@@ -119,18 +106,37 @@ func RunCycle(
 		mu.Unlock()
 	}
 
+	// Read-only deps shared by every probe goroutine. probeTarget captures
+	// none of the cycle's mutable aggregation state (mu/results/okCount/
+	// failByReason/allARPMACs) and no graph/ages handle (C6/C7).
+	deps := probeDeps{
+		cfg:           cfg,
+		m:             m,
+		walkerMetrics: walkerMetrics,
+		warnLimiter:   warnLimiter,
+		resolver:      resolver,
+		allowedNets:   allowedNets,
+		pool:          pool,
+		logger:        logger,
+	}
+
 	for i, t := range cfg.Targets {
 		target := t
 		idx := i
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// A recover() only catches its own goroutine's panics, so the
+			// per-device panic-recover MUST wrap the probeTarget call here
+			// rather than living inside probeTarget (C7).
 			defer func() {
 				if r := recover(); r != nil {
 					logger.Error("per-device probe panicked", "target", target.Host, "panic", r)
 					recordFail(metrics.DiscoveryReasonPanic)
 				}
 			}()
+			// Cycle-budget admission. The budget early-exit is an
+			// admission-shell concern and stays in the closure (C7).
 			select {
 			case sem <- struct{}{}:
 			case <-cycleCtx.Done():
@@ -140,196 +146,29 @@ func RunCycle(
 			}
 			defer func() { <-sem }()
 
-			// Issue #68: per-target span, child of discovery.cycle. targetCtx
-			// flows into the credential resolve and every module walk so they
-			// nest under target.poll. No-op when tracing is disabled.
-			targetStart := time.Now()
-			targetCtx, targetSpan := tracing.Tracer().Start(cycleCtx, "target.poll",
-				trace.WithAttributes(attribute.String("target.ip", target.Host)))
-			defer func() {
-				targetSpan.SetAttributes(
-					attribute.Float64("target.latency_seconds", time.Since(targetStart).Seconds()))
-				targetSpan.End()
-			}()
+			res, arp, ok, failReason := probeTarget(cycleCtx, deps, target, idx)
 
-			ip := net.ParseIP(target.Host)
-			if ip == nil {
-				addrs, err := net.DefaultResolver.LookupHost(targetCtx, target.Host)
-				if err != nil || len(addrs) == 0 {
-					logger.Warn("host resolution failed", "host", target.Host, "error", err)
-					recordFail(metrics.DiscoveryReasonDNSFailed)
-					targetSpan.SetStatus(codes.Error, "dns resolution failed")
-					return
-				}
-				ip = net.ParseIP(addrs[0])
-			}
-
-			// LD-11: enforce CIDR allow-list for hostname-based targets whose
-			// IP is only known after DNS resolution.
-			if len(allowedNets) > 0 && !snmpwalk.IPInNets(ip, allowedNets) {
-				logger.Warn("resolved target outside allow-list, skipping",
-					"host", target.Host, "ip", ip)
-				recordFail(metrics.DiscoveryReasonOutsideAllowList)
-				targetSpan.SetStatus(codes.Error, "outside allow-list")
-				return
-			}
-
-			dev, params, profileName, err := WalkSystemWithCredentials(targetCtx, cfg, resolver, ip, target, logger)
-			targetSpan.SetAttributes(attribute.String("credential.profile", profileName))
-			if err != nil {
-				logger.Warn("snmp walk failed", "target", target.Host, "error", err)
-				targetSpan.RecordError(err)
-				targetSpan.SetStatus(codes.Error, "credential resolve / system walk failed")
-				m.DiscoveryHardFailTotal.WithLabelValues("system", "system_group_walk_error").Inc()
-				m.CredentialTrialsTotal.WithLabelValues("failed").Inc()
-				// Issue #20: partition the walk-failure counter by
-				// sub-reason. Timeouts surface via status="timeout"
-				// (reason=n/a — the status is the reason). Non-timeout
-				// failures from this layer are attributed to auth: the
-				// credential-rotation loop in WalkSystemWithCredentials
-				// only returns a non-timeout error when at least one
-				// candidate was rejected non-silently (DeadlineExceeded
-				// is the silent-drop / unreachable case).
-				if errors.Is(err, context.DeadlineExceeded) {
-					m.SNMPWalksTotal.WithLabelValues("timeout", metrics.ReasonNA).Inc()
-					recordFail(metrics.DiscoveryReasonTimeout)
-				} else {
-					m.SNMPWalksTotal.WithLabelValues("error", string(metrics.WalkReasonAuthFailed)).Inc()
-					recordFail(metrics.DiscoveryReasonAuthFailed)
-				}
-				return
-			}
-			// Zeroize the winning credential bytes as soon as this device's
-			// modules are finished, before the goroutine exits and params
-			// becomes unreachable to a sensible cleanup. Issue #5.
-			defer params.Zeroize()
-
-			devCtx, cancel := context.WithTimeout(targetCtx, cfg.Discovery.TimeoutPerDevice)
-			defer cancel()
-			devCtx = snmpwalk.ContextWithDecodeIssueReporter(devCtx, func(issue snmpwalk.DecodeIssue) {
-				m.DiscoveryDecodeIssues.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
-				m.DiscoveryQuarantinedRowsTotal.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
-			})
-			// Nil-tolerant panic-reporter seam for the raw SNMP transport
-			// goroutines (snmpwalk.BulkWalk / Walk spawn their own goroutine
-			// stacks for BulkWalkAll/WalkAll/Get; this per-device recover does
-			// not cover them). On a recovered transport panic the walk returns a
-			// normal error and bumps network_topology_panics_total{site="snmp_walk"}
-			// without the discovery package importing the prometheus client.
-			devCtx = snmpwalk.ContextWithPanicReporter(devCtx, func(site string) {
-				m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
-			})
-
-			// Issue #72: per-target SNMP PDU rate limiter. When configured, cap
-			// the steady-state request rate against this single device so a high
-			// parallelism + all-modules run cannot self-DoS its SNMP daemon. One
-			// limiter per device per cycle (per-target isolation — never shared
-			// across devices). Burst is set equal to the rate so a freshly-built
-			// limiter starts with a full 1-second bucket (no artificial stall on
-			// the first walk) while still pacing sustained throughput to the
-			// configured ceiling. Unset/0 injects nothing — zero overhead,
-			// unchanged behaviour.
-			if rps := cfg.Discovery.PerTargetPDURatePerSecond; rps > 0 {
-				lim := rate.NewLimiter(rate.Limit(rps), rps)
-				devCtx = snmpwalk.ContextWithRateLimiter(devCtx, lim)
-				devCtx = snmpwalk.ContextWithRateLimitWaitObserver(devCtx, func(d time.Duration) {
-					m.SNMPRateLimitWaitSeconds.Observe(d.Seconds())
-				})
-			}
-
-			resolver.RecordSuccess(ip.String(), profileName)
-			m.CredentialTrialsTotal.WithLabelValues("ok").Inc()
-			m.SNMPWalksTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
-
-			dev.Site = target.Site
-			for k, v := range target.Labels {
-				if dev.Labels == nil {
-					dev.Labels = make(map[string]string)
-				}
-				dev.Labels[k] = v
-			}
-
-			var allEdges []discovery.Edge
-			var allOOS []discovery.OutOfScopeNeighbour
-
-			// Propagate module-specific tuning into params. MaxVlans is only
-			// consumed by fdb.Walk; Vendor and UseBGPV2MIB are only consumed
-			// by bgp.Walk; other modules ignore them. UseBGPV2MIB is the
-			// inverse of the operator-facing DisableV2MIB knob (default false
-			// = v2 enabled). WalkerMetrics is read by bgp.Walk via the
-			// recordWalkerOutcome helper; nil is tolerated (drops the
-			// increment) so unit tests that build Params inline don't need
-			// to wire a fake sink unless they care about the counter.
-			params.MaxVlans = cfg.Modules.FDB.MaxVlans
-			params.Vendor = dev.Vendor
-			params.UseBGPV2MIB = !cfg.Modules.BGP.DisableV2MIB
-			params.WalkerMetrics = walkerMetrics
-			params.WarnLimiter = warnLimiter
-			// Nil-tolerant panic-reporter seam (ops hardening): the FDB module
-			// spawns one goroutine per VLAN and recovers a panic locally so one
-			// bad VLAN can't crash discovery; this closure lets it bump
-			// network_topology_panics_total{site} without the discovery package
-			// importing the prometheus client (mirrors the WalkerMetrics seam).
-			params.PanicReporter = func(site string) {
-				m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
-			}
-			// Issue #83: opt-in per-target SNMP session pool. When pool is nil
-			// (the default), params.Pool stays nil and snmpwalk.Acquire uses the
-			// fresh open+close path — byte-identical to pre-#83 behaviour. When a
-			// pool is wired, the (IP, CredentialProfile) key lets a target reuse
-			// one session across its sequential module walks. CredentialProfile
-			// is the winning profile from WalkSystemWithCredentials above; it
-			// must be part of the key so a credential change yields a new entry
-			// and InvalidateProfile can evict a rotated profile's sessions.
-			params.Pool = pool
-			params.CredentialProfile = profileName
-
-			// Issue #153: the per-module walk loop (module list → #74 per-IP
-			// scope intersection → per-module span/metrics → outcome classify)
-			// is shared with /admin/rediscover via walkModules. The cycle
-			// supplies FULL instrumentation (metrics + tracer + logger) so its
-			// behaviour is byte-identical to the pre-extraction inline loop.
-			mEdges, mOOS, modStatus := walkModules(devCtx, cfg, *dev, ip, params, allowedNets,
-				moduleInstrumentation{metrics: m, tracer: tracing.Tracer(), logger: logger, host: target.Host})
-			allEdges = append(allEdges, mEdges...)
-			allOOS = append(allOOS, mOOS...)
-
-			// Walk ARP table for MAC→IP enrichment when modules.arp.enabled
-			// is true (default). The map feeds SynthesizeEdges below as a
-			// fallback for FDB-only edges where LLDP did not provide the
-			// neighbour identity. Failures are non-fatal: LLDP-based
-			// correlation still works without ARP data.
-			if cfg.Modules.ARP.Enabled {
-				arpClient, arpRelease, arpErr := snmpwalk.Acquire(params)
-				if arpErr != nil {
-					logger.Debug("ARP table walk failed; MAC→IP resolution unavailable for this device",
-						"device", dev.ID, "err", arpErr)
-				} else {
-					arpMACToIP, arpErr := snmpwalk.WalkARPTable(devCtx, arpClient)
-					arpRelease()
-					if arpErr != nil {
-						logger.Debug("ARP table walk failed; MAC→IP resolution unavailable for this device",
-							"device", dev.ID, "err", arpErr)
-					} else {
-						mu.Lock()
-						for mac, ip := range arpMACToIP {
-							if existing, exists := allARPMACs[mac]; exists {
-								if existing != ip {
-									logger.Debug("arp: MAC seen with conflicting IPs across devices; keeping first",
-										"mac", mac, "kept_ip", existing, "discarded_ip", ip)
-								}
-								continue
-							}
-							allARPMACs[mac] = ip
-						}
-						mu.Unlock()
-					}
-				}
-			}
-
+			// mu-guarded aggregation (C7/C9). The allARPMACs merge is
+			// performed here, at collection time, first-wins by goroutine
+			// scheduling — NOT in the post-fan-out sorted pass — so which IP
+			// wins a MAC conflict is unchanged.
 			mu.Lock()
-			results = append(results, probeResult{targetIdx: idx, device: dev, edges: allEdges, outOfScope: allOOS, mgmtIP: ip.String(), moduleStatus: modStatus})
-			okCount++
+			if ok {
+				results = append(results, res)
+				okCount++
+			} else {
+				failByReason[failReason]++
+			}
+			for mac, ip := range arp {
+				if existing, exists := allARPMACs[mac]; exists {
+					if existing != ip {
+						logger.Debug("arp: MAC seen with conflicting IPs across devices; keeping first",
+							"mac", mac, "kept_ip", existing, "discarded_ip", ip)
+					}
+					continue
+				}
+				allARPMACs[mac] = ip
+			}
 			mu.Unlock()
 		}()
 	}

--- a/internal/app/device_walk.go
+++ b/internal/app/device_walk.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/bgp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/cdp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/fdb"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/isis"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/lldp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/mpls"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/ospf"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+)
+
+// enabledModules returns the canonical 7-element protocol-walker list, gated
+// only by cfg.Modules.<X>.Enabled. The per-IP #74 scope intersection is NOT
+// applied here (it needs the target IP and lives inside walkModules). This is
+// the single source of truth for the module set shared by the regular cycle
+// and the /admin/rediscover forced walk, so the slice can no longer drift
+// between the two call sites.
+func enabledModules(cfg *config.Config) []Module {
+	return []Module{
+		{"lldp", cfg.Modules.LLDP.Enabled, lldp.Walk},
+		{"cdp", cfg.Modules.CDP.Enabled, cdp.Walk},
+		{"fdb", cfg.Modules.FDB.Enabled, fdb.Walk},
+		{"ospf", cfg.Modules.OSPF.Enabled, ospf.Walk},
+		{"bgp", cfg.Modules.BGP.Enabled, bgp.Walk},
+		{"isis", cfg.Modules.ISIS.Enabled, isis.Walk},
+		{"mpls_te", cfg.Modules.MPLSTE.Enabled, mpls.Walk},
+	}
+}
+
+// moduleInstrumentation parameterizes the per-module observability sinks of
+// walkModules. Each field is independently optional:
+//   - metrics nil  ⇒ skip every per-module metric (DiscoveryModuleDuration,
+//     SNMPWalksTotal, DiscoveryHardFailTotal, DiscoveryDegradedTotal).
+//   - tracer  nil  ⇒ skip every per-module span (<proto>.walk).
+//   - logger  is required (the per-module failure log always fires).
+//
+// The regular discovery cycle supplies all three (full instrumentation, so its
+// behaviour is byte-identical to the pre-extraction inline loop). The
+// /admin/rediscover forced walk intentionally supplies nil metrics + nil tracer
+// (and leaves params.WalkerMetrics unset) so it emits no per-cycle metric
+// series or spans — see the comment on Rediscoverer.walkOne. The walker-outcome
+// sink rides on params.WalkerMetrics, set by the caller, not here.
+type moduleInstrumentation struct {
+	metrics *metrics.Metrics
+	tracer  trace.Tracer
+	logger  *slog.Logger
+}
+
+// walkModules runs every enabled-and-in-scope module against one device and
+// returns the union of edges, the out-of-scope neighbours (each tagged with the
+// reporting protocol), and the per-protocol status map (0 ok | 1 degraded | 2
+// failed). It is OUTPUT-ONLY: it neither builds nor zeroizes params, performs
+// the ARP walk, nor touches any caller-side aggregation; those stay with the
+// caller (C1/C3). The per-device ctx is supplied by the caller so per-module
+// spans descend from the per-target span (C4).
+func walkModules(
+	ctx context.Context,
+	cfg *config.Config,
+	dev discovery.Device,
+	ip net.IP,
+	params snmpwalk.Params,
+	allowedNets []*net.IPNet,
+	inst moduleInstrumentation,
+) (edges []discovery.Edge, oos []discovery.OutOfScopeNeighbour, moduleStatus map[string]int) {
+	mods := enabledModules(cfg)
+	// Issue #74: resolve this target's per-protocol scope once. When an
+	// override matches, only the listed modules run (intersected with
+	// the global mod.Enabled gate below); when none matches, allowed is
+	// nil/overrideMatched=false and ALL enabled modules run — today's
+	// unchanged default. The headline case: bgp.Walk only fires where
+	// bgp is in the override's module set, so the walker outcome
+	// counters partition naturally.
+	allowedMods, overrideMatched := cfg.ModulesForIP(ip)
+	moduleStatus = map[string]int{}
+	for _, mod := range mods {
+		if !mod.Enabled {
+			continue
+		}
+		// Per-target protocol scoping: an override never widens beyond
+		// mod.Enabled (intersection), it only narrows.
+		if overrideMatched && !allowedMods[mod.Proto] {
+			continue
+		}
+		modStart := time.Now()
+		// Issue #68: per-module span, child of target.poll. Span name
+		// is "<proto>.walk" (e.g. lldp.walk, bgp.walk; the MPLS module
+		// uses its mpls_te proto identifier → mpls_te.walk). No-op when
+		// tracing is disabled.
+		modCtx := ctx
+		var modSpan trace.Span
+		if inst.tracer != nil {
+			modCtx, modSpan = inst.tracer.Start(ctx, mod.Proto+".walk")
+		}
+		var modCancel context.CancelFunc = func() {}
+		if cfg.Discovery.TimeoutPerModule > 0 {
+			modCtx, modCancel = context.WithTimeout(modCtx, cfg.Discovery.TimeoutPerModule)
+		}
+		mEdges, mOOS, err := mod.Walk(modCtx, params, dev.ID, allowedNets)
+		modCancel()
+		if inst.metrics != nil {
+			inst.metrics.DiscoveryModuleDuration.WithLabelValues(mod.Proto).Observe(time.Since(modStart).Seconds())
+		}
+		if modSpan != nil {
+			modSpan.SetAttributes(attribute.Int("walk.pdu_count", len(mEdges)))
+		}
+		if err != nil {
+			inst.logger.Debug(mod.Proto+" walk failed", "target", ip.String(), "error", err)
+			if modSpan != nil {
+				modSpan.SetAttributes(attribute.String("walk.outcome", "failed"))
+				modSpan.RecordError(err)
+				modSpan.SetStatus(codes.Error, "module walk failed")
+				modSpan.End()
+			}
+			reason := "module_walk_error"
+			var policyErr *discovery.PolicyError
+			if errors.As(err, &policyErr) && policyErr.Reason != "" {
+				reason = policyErr.Reason
+			}
+			if inst.metrics != nil {
+				inst.metrics.DiscoveryHardFailTotal.WithLabelValues(mod.Proto, reason).Inc()
+				// Issue #20: partition by walk sub-reason. Timeouts
+				// keep reason=n/a; module-level non-timeout errors
+				// are tagged WalkReasonModuleError. Per-module richer
+				// breakdowns (auth_failed at the module layer is
+				// already excluded — credentials succeeded for the
+				// system walk above) would require module-walker
+				// changes and are not in #20's scope.
+				if errors.Is(err, context.DeadlineExceeded) {
+					inst.metrics.SNMPWalksTotal.WithLabelValues("timeout", metrics.ReasonNA).Inc()
+				} else {
+					inst.metrics.SNMPWalksTotal.WithLabelValues("error", string(metrics.WalkReasonModuleError)).Inc()
+				}
+			}
+			moduleStatus[mod.Proto] = 2
+			continue
+		}
+		if inst.metrics != nil {
+			inst.metrics.SNMPWalksTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
+		}
+		degradedReasons := CollectDegradedReasons(mEdges)
+		if inst.metrics != nil {
+			for _, reason := range degradedReasons {
+				inst.metrics.DiscoveryDegradedTotal.WithLabelValues(mod.Proto, reason).Inc()
+			}
+		}
+		if len(degradedReasons) > 0 {
+			if modSpan != nil {
+				modSpan.SetAttributes(attribute.String("walk.outcome", "degraded"))
+			}
+			if _, ok := moduleStatus[mod.Proto]; !ok {
+				moduleStatus[mod.Proto] = 1
+			}
+		} else {
+			if modSpan != nil {
+				modSpan.SetAttributes(attribute.String("walk.outcome", "ok"))
+			}
+			if _, ok := moduleStatus[mod.Proto]; !ok {
+				moduleStatus[mod.Proto] = 0
+			}
+		}
+		if modSpan != nil {
+			modSpan.End()
+		}
+		edges = append(edges, mEdges...)
+		// Tag each OOS entry with the protocol that reported it so the
+		// boundary_observation_info metric and hub OOS matching have a
+		// proto label.
+		for i := range mOOS {
+			mOOS[i].Proto = mod.Proto
+		}
+		oos = append(oos, mOOS...)
+	}
+	return edges, oos, moduleStatus
+}

--- a/internal/app/device_walk.go
+++ b/internal/app/device_walk.go
@@ -59,6 +59,11 @@ type moduleInstrumentation struct {
 	metrics *metrics.Metrics
 	tracer  trace.Tracer
 	logger  *slog.Logger
+	// host is the display label for logs — the configured target host
+	// (cycle) or the resolved IP (rediscover). The per-module failure log
+	// uses it so a hostname target surfaces its configured name rather than
+	// the resolved IP.
+	host string
 }
 
 // walkModules runs every enabled-and-in-scope module against one device and
@@ -119,7 +124,7 @@ func walkModules(
 			modSpan.SetAttributes(attribute.Int("walk.pdu_count", len(mEdges)))
 		}
 		if err != nil {
-			inst.logger.Debug(mod.Proto+" walk failed", "target", ip.String(), "error", err)
+			inst.logger.Debug(mod.Proto+" walk failed", "target", inst.host, "error", err)
 			if modSpan != nil {
 				modSpan.SetAttributes(attribute.String("walk.outcome", "failed"))
 				modSpan.RecordError(err)

--- a/internal/app/device_walk_test.go
+++ b/internal/app/device_walk_test.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/snmptest"
+)
+
+// walkModulesTestSetup walks the credential ladder against an in-process agent
+// and returns the resolved device + mutated params ready for walkModules, the
+// same way RunCycle/walkOne build them. The caller is responsible for
+// params.Zeroize().
+func walkModulesTestSetup(t *testing.T, cfg *config.Config, addr string) (discovery.Device, net.IP, snmpwalk.Params) {
+	t.Helper()
+	ip, port := snmptest.ParseAddr(addr)
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	tc := config.TargetConfig{Host: ip.String(), Port: int(port)}
+	dev, params, _, err := WalkSystemWithCredentials(context.Background(), cfg, resolver, ip, tc, slogDiscard())
+	if err != nil {
+		t.Fatalf("WalkSystemWithCredentials: %v", err)
+	}
+	params.MaxVlans = cfg.Modules.FDB.MaxVlans
+	params.Vendor = dev.Vendor
+	params.UseBGPV2MIB = !cfg.Modules.BGP.DisableV2MIB
+	return *dev, ip, params
+}
+
+// TestWalkModulesEdgesAndStatus drives walkModules against a live in-process
+// agent advertising one LLDP neighbour and asserts: the returned edge union,
+// per-proto status classification, and — with a zero-value
+// moduleInstrumentation (nil metrics + nil tracer, logger set) — that it does
+// not panic and emits no metrics.
+func TestWalkModulesEdgesAndStatus(t *testing.T) {
+	t.Setenv("WM_COMM", "public")
+	cfg := testConfig(t, "WM_COMM")
+	// Enable a couple of modules: lldp answers (one edge), cdp has no fixture
+	// (walks clean / zero edges, status ok).
+	cfg.Modules.LLDP.Enabled = true
+	cfg.Modules.CDP.Enabled = true
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+
+	dev, ip, params := walkModulesTestSetup(t, cfg, addr)
+	defer params.Zeroize()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	// Zero-value instrumentation: nil metrics + nil tracer, logger required.
+	inst := moduleInstrumentation{logger: slogDiscard()}
+
+	edges, _, status := walkModules(ctx, cfg, dev, ip, params, snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"}), inst)
+
+	if len(edges) != 1 {
+		t.Fatalf("edges = %d, want 1 (one LLDP neighbour)", len(edges))
+	}
+	if got, ok := status["lldp"]; !ok || got != 0 {
+		t.Errorf("lldp status = %d (present=%v), want 0 (ok)", got, ok)
+	}
+	if got, ok := status["cdp"]; !ok || got != 0 {
+		t.Errorf("cdp status = %d (present=%v), want 0 (ok, no fixture)", got, ok)
+	}
+	// Disabled modules must not appear in the status map.
+	if _, ok := status["bgp"]; ok {
+		t.Errorf("bgp present in status map but module is disabled")
+	}
+}
+
+// TestWalkModulesNilInstrumentationNoPanic confirms a fully nil-sink
+// instrumentation set (the rediscover minimal case) does not panic even when a
+// module walk fails — the failure path touches every metric/span site.
+func TestWalkModulesNilInstrumentationNoPanic(t *testing.T) {
+	t.Setenv("WM_COMM2", "public")
+	cfg := testConfig(t, "WM_COMM2")
+	cfg.Modules.LLDP.Enabled = true
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+
+	dev, ip, params := walkModulesTestSetup(t, cfg, addr)
+	defer params.Zeroize()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	inst := moduleInstrumentation{logger: slogDiscard()}
+	// Must not panic with nil metrics + nil tracer.
+	edges, oos, status := walkModules(ctx, cfg, dev, ip, params, snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"}), inst)
+	_ = edges
+	_ = oos
+	if len(status) == 0 {
+		t.Error("expected at least one module status entry")
+	}
+}

--- a/internal/app/device_walk_test.go
+++ b/internal/app/device_walk_test.go
@@ -78,8 +78,10 @@ func TestWalkModulesEdgesAndStatus(t *testing.T) {
 }
 
 // TestWalkModulesNilInstrumentationNoPanic confirms a fully nil-sink
-// instrumentation set (the rediscover minimal case) does not panic even when a
-// module walk fails — the failure path touches every metric/span site.
+// instrumentation set (the rediscover minimal case) does not panic on the OK
+// path. This covers the success-side metric/span sites only; the failure
+// (status=2) nil-guard cluster is exercised separately by
+// TestWalkModulesNilInstrumentationFailureNoPanic.
 func TestWalkModulesNilInstrumentationNoPanic(t *testing.T) {
 	t.Setenv("WM_COMM2", "public")
 	cfg := testConfig(t, "WM_COMM2")
@@ -102,4 +104,70 @@ func TestWalkModulesNilInstrumentationNoPanic(t *testing.T) {
 	if len(status) == 0 {
 		t.Error("expected at least one module status entry")
 	}
+}
+
+// TestWalkModulesNilInstrumentationFailureNoPanic drives a module into a
+// FAILURE (status=2) with nil metrics + nil tracer and asserts: no panic, the
+// failing module's status is 2, and no metrics are recorded. This is the
+// nil-guard cluster the #153 extraction risks (the failure branch touches
+// DiscoveryHardFailTotal, SNMPWalksTotal, the failure span attrs, and the
+// per-module failure log) — TestWalkModulesNilInstrumentationNoPanic only
+// covers the OK side.
+//
+// The failure is forced deterministically: the system-group walk succeeds
+// against the live agent (so dev/params resolve), then params is redirected to
+// a closed port with a short timeout so the LLDP module walk errors.
+func TestWalkModulesNilInstrumentationFailureNoPanic(t *testing.T) {
+	t.Setenv("WM_COMM3", "public")
+	cfg := testConfig(t, "WM_COMM3")
+	cfg.Modules.LLDP.Enabled = true
+	// Bound the failing walk so the test stays fast.
+	cfg.Discovery.TimeoutPerModule = 500 * time.Millisecond
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+
+	dev, ip, params := walkModulesTestSetup(t, cfg, addr)
+	defer params.Zeroize()
+
+	// Redirect the per-module walk at a closed UDP port so LLDP's SNMP walk
+	// fails fast and the module is classified status=2. The system walk above
+	// already succeeded against the real agent.
+	closedPort := closedUDPPort(t)
+	params.Port = closedPort
+	params.Timeout = 150 * time.Millisecond
+	params.Retries = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	// Sentinel metrics: nil here so a stray metric write would panic; we also
+	// assert below that the nil-metrics path recorded nothing observable.
+	inst := moduleInstrumentation{logger: slogDiscard()}
+
+	edges, _, status := walkModules(ctx, cfg, dev, ip, params, snmpwalk.ParseCIDRs([]string{"127.0.0.0/8"}), inst)
+
+	if got, ok := status["lldp"]; !ok || got != 2 {
+		t.Fatalf("lldp status = %d (present=%v), want 2 (failed)", got, ok)
+	}
+	if len(edges) != 0 {
+		t.Errorf("edges = %d, want 0 on a failed walk", len(edges))
+	}
+}
+
+// closedUDPPort returns a UDP port that is not being listened on, by binding a
+// socket to an ephemeral port and immediately closing it. There is an inherent
+// TOCTOU window, but for a single-threaded test against localhost it is
+// effectively always still closed when the walk dials it.
+func closedUDPPort(t *testing.T) uint16 {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	_ = conn.Close()
+	// Mask to 16 bits to satisfy gosec G115; a UDP port is always 0..65535
+	// so the mask is a no-op on every real value.
+	return uint16(port & 0xFFFF)
 }

--- a/internal/app/loop.go
+++ b/internal/app/loop.go
@@ -136,6 +136,140 @@ func RunStaleWatchdog(ctx context.Context, status *atomic.Pointer[httpx.CycleSta
 	}
 }
 
+// publishState carries the large-topology warning bookkeeping (issue #9)
+// across cycles. publish reads it, may advance it via MaybeWarnLargeTopology,
+// and returns the updated value the caller stores for the next cycle. On the
+// size-budget reject path it is returned unchanged (no warn evaluation).
+type publishState struct {
+	prevAboveThreshold bool
+	lastWarnCycle      int
+}
+
+// publish runs the post-reconcile side-effects for one cycle and returns the
+// prevGraph + ages the caller MUST assign on BOTH the size-budget-reject path
+// and the happy path. The diff is computed against the passed prevGraph BEFORE
+// any reassignment (condition C8). On size-budget reject it returns
+// (prevGraph unchanged, newAges, ps unchanged) — ages still advance so
+// unconfirmed edges can expire — and publishes nothing. On the happy path it
+// returns (newGraph, newAges, advanced warn-state).
+//
+// The publish ordering is load-bearing and preserved verbatim: Diff against the
+// OLD prevGraph → change events + per-proto counters → OTLP push-changes →
+// conflict events + counters → prevGraph reassignment → OTLP push-graph →
+// GraphStale.Set(0) → Topology.Update → Ready CAS → MaybeWarnLargeTopology →
+// cycle-duration metric → snapshot enqueue → spoke enqueue.
+func (lc LoopConfig) publish(
+	ctx, cycleCtx context.Context,
+	evLogger *events.Logger,
+	resolver *credentials.Resolver,
+	snapshotCh chan snapshot.File,
+	pusher *spokePusher,
+	prevGraph, newGraph discovery.Graph,
+	newAges map[graph.EdgeKey]int,
+	conflicts []graph.Conflict,
+	cycleNum int,
+	start time.Time,
+	ps publishState,
+) (nextPrev discovery.Graph, nextAges map[graph.EdgeKey]int, nextPS publishState) {
+	// Admission control: reject local graph updates that exceed the
+	// configured size budget (mirrors hub-mode MaxGraph* enforcement).
+	maxDevices := lc.Cfg.Discovery.MaxGraphDevices
+	maxEdges := lc.Cfg.Discovery.MaxGraphEdges
+	if (maxDevices > 0 && len(newGraph.Devices) > maxDevices) ||
+		(maxEdges > 0 && len(newGraph.Edges) > maxEdges) {
+		lc.Logger.Warn("local graph update rejected: exceeds size budget",
+			"devices", len(newGraph.Devices), "max_devices", maxDevices,
+			"edges", len(newGraph.Edges), "max_edges", maxEdges)
+		lc.M.GraphUpdatesRejectedTotal.WithLabelValues(string(metrics.RejectReasonSizeBudgetExceeded)).Inc()
+		// Keep prevGraph as the published graph; advance ages so unconfirmed
+		// edges can still expire; skip all downstream updates.
+		return prevGraph, newAges, ps
+	}
+
+	changes := graph.Diff(prevGraph.Edges, newGraph.Edges)
+	if len(changes) > 0 {
+		evLogger.Emit(ctx, changes)
+		for _, c := range changes {
+			var proto discovery.DiscoveryProtocol
+			if c.After != nil {
+				proto = c.After.DiscoveryProto
+			} else if c.Before != nil {
+				proto = c.Before.DiscoveryProto
+			}
+			lc.M.TopologyChangeTotal.WithLabelValues(string(c.Kind), string(proto)).Inc()
+		}
+		ch := changes
+		lc.Otlp.Push(func(ctx context.Context) error {
+			return lc.Otlp.exp.PushChanges(ctx, ch)
+		}, "otlp push changes failed")
+	}
+	if len(conflicts) > 0 {
+		evLogger.EmitConflicts(ctx, conflicts)
+		for _, c := range conflicts {
+			lc.M.TopologyConflictTotal.WithLabelValues(string(c.Kind)).Inc()
+		}
+	}
+	prevGraph = newGraph
+	ages := newAges
+	if lc.Otlp.Enabled() && (len(changes) > 0 || cycleNum%lc.Cfg.Output.OTLP.HeartbeatCycles == 0) {
+		g := newGraph
+		lc.Otlp.Push(func(ctx context.Context) error {
+			return lc.Otlp.exp.PushGraph(ctx, g)
+		}, "otlp push failed")
+	}
+	lc.M.GraphStale.Set(0)
+	lc.M.Topology.Update(newGraph)
+	if lc.Ready != nil {
+		lc.Ready.CompareAndSwap(false, true)
+	}
+	ps.prevAboveThreshold, ps.lastWarnCycle = MaybeWarnLargeTopology(
+		lc.Logger, len(newGraph.Edges), len(newGraph.Devices),
+		ps.prevAboveThreshold, cycleNum, ps.lastWarnCycle)
+	lc.M.DiscoveryCycleDuration.Observe(time.Since(start).Seconds())
+
+	// LD-13: write snapshot via the bounded writer channel so an NFS stall
+	// cannot accumulate goroutines across cycles. f is passed by value so the
+	// next cycle cannot mutate the data while the write is in progress.
+	ageMap := graph.EdgeKeysToAges(ages)
+	credCache := resolver.SnapshotCache()
+	f := snapshot.File{
+		Devices:         newGraph.Devices,
+		Edges:           newGraph.Edges,
+		OutOfScope:      newGraph.OutOfScope,
+		CredentialCache: credCache,
+		UnconfirmedAges: ageMap,
+	}
+	if snapshotCh != nil {
+		select {
+		case snapshotCh <- f:
+			lc.M.SnapshotQueueDepth.Set(float64(len(snapshotCh)))
+		default:
+			// Rate-limit per path (issue #16): queue-full is the upstream
+			// symptom of the same chronic-NFS stall as the two branches
+			// in the writer goroutine. Keys are distinct so each path
+			// surfaces independently on first occurrence.
+			lc.M.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonQueueFull)).Inc()
+			lc.WarnSnapshot(ctx, "snapshot_queue_full",
+				"snapshot write queue full; dropping (previous write still in flight)")
+		}
+	}
+
+	// LD-16/LD-17: spoke mode — hand the pre-reconciled graph to the async
+	// pusher (#6). Enqueue never blocks; cycleCtx is captured so the eventual
+	// push still propagates the cycle's W3C traceparent to the hub (#68).
+	if pusher != nil {
+		pusher.Enqueue(cycleCtx, federation.SpokePayload{
+			SpokeID:    lc.Cfg.Federation.Spoke.SpokeID,
+			CycleAt:    time.Now(),
+			Devices:    newGraph.Devices,
+			Edges:      newGraph.Edges,
+			OutOfScope: newGraph.OutOfScope,
+			Ages:       ageMap,
+		})
+	}
+	return prevGraph, ages, ps
+}
+
 // RunDiscoveryLoop is the main discovery scheduler. It loads the LD-13
 // snapshot on startup, starts the credential resolver, and then runs
 // periodic cycles. Each cycle probes all configured targets concurrently
@@ -324,102 +458,10 @@ func RunDiscoveryLoop(ctx context.Context, lc LoopConfig) {
 			DeviceErrors: int64(deviceErrors),
 		})
 
-		// Admission control: reject local graph updates that exceed the
-		// configured size budget (mirrors hub-mode MaxGraph* enforcement).
-		maxDevices := lc.Cfg.Discovery.MaxGraphDevices
-		maxEdges := lc.Cfg.Discovery.MaxGraphEdges
-		if (maxDevices > 0 && len(newGraph.Devices) > maxDevices) ||
-			(maxEdges > 0 && len(newGraph.Edges) > maxEdges) {
-			lc.Logger.Warn("local graph update rejected: exceeds size budget",
-				"devices", len(newGraph.Devices), "max_devices", maxDevices,
-				"edges", len(newGraph.Edges), "max_edges", maxEdges)
-			ages = newAges // advance counters so unconfirmed edges can still expire
-			lc.M.GraphUpdatesRejectedTotal.WithLabelValues(string(metrics.RejectReasonSizeBudgetExceeded)).Inc()
-			// Keep prevGraph as the published graph; skip all downstream updates.
-			return
-		}
-
-		changes := graph.Diff(prevGraph.Edges, newGraph.Edges)
-		if len(changes) > 0 {
-			evLogger.Emit(ctx, changes)
-			for _, c := range changes {
-				var proto discovery.DiscoveryProtocol
-				if c.After != nil {
-					proto = c.After.DiscoveryProto
-				} else if c.Before != nil {
-					proto = c.Before.DiscoveryProto
-				}
-				lc.M.TopologyChangeTotal.WithLabelValues(string(c.Kind), string(proto)).Inc()
-			}
-			ch := changes
-			lc.Otlp.Push(func(ctx context.Context) error {
-				return lc.Otlp.exp.PushChanges(ctx, ch)
-			}, "otlp push changes failed")
-		}
-		if len(conflicts) > 0 {
-			evLogger.EmitConflicts(ctx, conflicts)
-			for _, c := range conflicts {
-				lc.M.TopologyConflictTotal.WithLabelValues(string(c.Kind)).Inc()
-			}
-		}
-		prevGraph = newGraph
-		ages = newAges
-		if lc.Otlp.Enabled() && (len(changes) > 0 || cycleNum%lc.Cfg.Output.OTLP.HeartbeatCycles == 0) {
-			g := newGraph
-			lc.Otlp.Push(func(ctx context.Context) error {
-				return lc.Otlp.exp.PushGraph(ctx, g)
-			}, "otlp push failed")
-		}
-		lc.M.GraphStale.Set(0)
-		lc.M.Topology.Update(newGraph)
-		if lc.Ready != nil {
-			lc.Ready.CompareAndSwap(false, true)
-		}
-		prevAboveThreshold, lastWarnCycle = MaybeWarnLargeTopology(
-			lc.Logger, len(newGraph.Edges), len(newGraph.Devices),
-			prevAboveThreshold, cycleNum, lastWarnCycle)
-		lc.M.DiscoveryCycleDuration.Observe(time.Since(start).Seconds())
-
-		// LD-13: write snapshot via the bounded writer channel so an NFS stall
-		// cannot accumulate goroutines across cycles. f is passed by value so the
-		// next cycle cannot mutate the data while the write is in progress.
-		ageMap := graph.EdgeKeysToAges(ages)
-		credCache := resolver.SnapshotCache()
-		f := snapshot.File{
-			Devices:         newGraph.Devices,
-			Edges:           newGraph.Edges,
-			OutOfScope:      newGraph.OutOfScope,
-			CredentialCache: credCache,
-			UnconfirmedAges: ageMap,
-		}
-		if snapshotCh != nil {
-			select {
-			case snapshotCh <- f:
-				lc.M.SnapshotQueueDepth.Set(float64(len(snapshotCh)))
-			default:
-				// Rate-limit per path (issue #16): queue-full is the upstream
-				// symptom of the same chronic-NFS stall as the two branches
-				// in the writer goroutine. Keys are distinct so each path
-				// surfaces independently on first occurrence.
-				lc.M.SnapshotDropsTotal.WithLabelValues(string(metrics.SnapshotDropReasonQueueFull)).Inc()
-				lc.WarnSnapshot(ctx, "snapshot_queue_full",
-					"snapshot write queue full; dropping (previous write still in flight)")
-			}
-		}
-
-		// LD-16/LD-17: spoke mode — hand the pre-reconciled graph to the async
-		// pusher (#6). Enqueue never blocks; cycleCtx is captured so the eventual
-		// push still propagates the cycle's W3C traceparent to the hub (#68).
-		if pusher != nil {
-			pusher.Enqueue(cycleCtx, federation.SpokePayload{
-				SpokeID:    lc.Cfg.Federation.Spoke.SpokeID,
-				CycleAt:    time.Now(),
-				Devices:    newGraph.Devices,
-				Edges:      newGraph.Edges,
-				OutOfScope: newGraph.OutOfScope,
-				Ages:       ageMap,
-			})
-		}
+		ps := publishState{prevAboveThreshold: prevAboveThreshold, lastWarnCycle: lastWarnCycle}
+		prevGraph, ages, ps = lc.publish(ctx, cycleCtx, evLogger, resolver, snapshotCh, pusher,
+			prevGraph, newGraph, newAges, conflicts, cycleNum, start, ps)
+		prevAboveThreshold, lastWarnCycle = ps.prevAboveThreshold, ps.lastWarnCycle
 	}
 
 	cycle()

--- a/internal/app/loop_test.go
+++ b/internal/app/loop_test.go
@@ -10,8 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/colinedwardwood/network-topology-exporter/internal/app/httpx"
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	"github.com/colinedwardwood/network-topology-exporter/internal/events"
+	"github.com/colinedwardwood/network-topology-exporter/internal/graph"
 	"github.com/colinedwardwood/network-topology-exporter/internal/loglimit"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 	"github.com/colinedwardwood/network-topology-exporter/internal/output/otlp"
@@ -120,6 +126,110 @@ func TestOtlpPushNoOpWhenDisabled(t *testing.T) {
 		t.Error("push fn ran on a disabled publisher")
 	}
 	p.Drain() // must not panic on a nil wg
+}
+
+// publishTestLoopConfig builds a minimal LoopConfig for exercising publish in
+// isolation: real metrics, a disabled (no-op) OTLP publisher, a real resolver,
+// and no snapshot channel / spoke pusher. Ready is wired so the happy path can
+// exercise the CAS without nil-deref.
+func publishTestLoopConfig(t *testing.T, m *metrics.Metrics) (LoopConfig, *credentials.Resolver) {
+	t.Helper()
+	cfg := testConfig(t, "TEST_COMM")
+	cfg.Output.OTLP.HeartbeatCycles = 1
+	resolver, err := credentials.New(cfg.Credentials)
+	if err != nil {
+		t.Fatalf("credentials.New: %v", err)
+	}
+	var ready atomic.Bool
+	return LoopConfig{
+		Logger: slogDiscard(),
+		Cfg:    cfg,
+		M:      m,
+		Ready:  &ready,
+		Otlp:   &otlpPublisher{}, // disabled: Push is a no-op
+	}, resolver
+}
+
+func edge(src, dst string) discovery.Edge {
+	return discovery.Edge{
+		SrcDevice: src, SrcPort: "p1", DstDevice: dst, DstPort: "p2",
+		DiscoveryProto: discovery.DiscoveryProtocolLLDP,
+	}
+}
+
+// TestPublishAdvancesAgesAndDiffsAgainstOldPrev pins condition C8: ages always
+// advance to newAges on BOTH the size-budget-reject path and the happy path,
+// and the diff is computed against the OLD prevGraph passed in (so a second
+// publish against the returned prevGraph sees no further change).
+func TestPublishAdvancesAgesAndDiffsAgainstOldPrev(t *testing.T) {
+	ctx := context.Background()
+	keyA := graph.EdgeKey{}
+	const lldp = string(discovery.DiscoveryProtocolLLDP)
+
+	t.Run("size-reject advances ages and publishes nothing", func(t *testing.T) {
+		m := metrics.New(false)
+		lc, resolver := publishTestLoopConfig(t, m)
+		lc.Cfg.Discovery.MaxGraphEdges = 1
+		ev := events.New(slogDiscard())
+
+		prev := discovery.Graph{Edges: []discovery.Edge{edge("a", "b")}}
+		newG := discovery.Graph{Edges: []discovery.Edge{edge("a", "b"), edge("c", "d")}} // 2 > budget 1
+		newAges := map[graph.EdgeKey]int{keyA: 7}
+
+		nextPrev, nextAges, _ := lc.publish(ctx, ctx, ev, resolver, nil, nil,
+			prev, newG, newAges, nil, 1, time.Now(), publishState{})
+
+		if nextAges[keyA] != 7 {
+			t.Fatalf("ages not advanced on reject path: got %v", nextAges)
+		}
+		// prevGraph must be unchanged (the rejected newG is not published).
+		if len(nextPrev.Edges) != 1 {
+			t.Fatalf("prevGraph changed on reject path: got %d edges, want 1", len(nextPrev.Edges))
+		}
+		if got := testutil.ToFloat64(m.GraphUpdatesRejectedTotal.WithLabelValues(string(metrics.RejectReasonSizeBudgetExceeded))); got != 1 {
+			t.Fatalf("reject metric = %v, want 1", got)
+		}
+		// Nothing published: no topology-change events recorded.
+		if got := testutil.ToFloat64(m.TopologyChangeTotal.WithLabelValues("added", lldp)); got != 0 {
+			t.Fatalf("change metric = %v on reject path, want 0", got)
+		}
+	})
+
+	t.Run("happy path advances ages, diffs old prev, reassigns prev", func(t *testing.T) {
+		m := metrics.New(false)
+		lc, resolver := publishTestLoopConfig(t, m)
+		ev := events.New(slogDiscard())
+
+		prev := discovery.Graph{Edges: []discovery.Edge{edge("a", "b")}}
+		newG := discovery.Graph{Edges: []discovery.Edge{edge("a", "b"), edge("c", "d")}}
+		newAges := map[graph.EdgeKey]int{keyA: 7}
+
+		nextPrev, nextAges, _ := lc.publish(ctx, ctx, ev, resolver, nil, nil,
+			prev, newG, newAges, nil, 1, time.Now(), publishState{})
+
+		if nextAges[keyA] != 7 {
+			t.Fatalf("ages not advanced on happy path: got %v", nextAges)
+		}
+		if len(nextPrev.Edges) != 2 {
+			t.Fatalf("prevGraph not reassigned to newGraph: got %d edges, want 2", len(nextPrev.Edges))
+		}
+		firstChanges := testutil.ToFloat64(m.TopologyChangeTotal.WithLabelValues("added", lldp))
+		if firstChanges == 0 {
+			t.Fatalf("expected an 'added' change vs old prevGraph, got 0")
+		}
+		if got := testutil.ToFloat64(m.GraphStale); got != 0 {
+			t.Fatalf("GraphStale = %v, want 0 after happy publish", got)
+		}
+
+		// Second publish against the returned prevGraph with an identical
+		// newGraph must produce NO further 'added' change — proving the diff
+		// ran against the OLD prevGraph, and the caller-owned reassignment took.
+		_, _, _ = lc.publish(ctx, ctx, ev, resolver, nil, nil,
+			nextPrev, newG, newAges, nil, 2, time.Now(), publishState{})
+		if got := testutil.ToFloat64(m.TopologyChangeTotal.WithLabelValues("added", lldp)); got != firstChanges {
+			t.Fatalf("second publish recorded extra changes: got %v, want %v", got, firstChanges)
+		}
+	})
 }
 
 // TestRunDiscoveryLoopShutsDownCleanly drives the full loop against an

--- a/internal/app/probe_target.go
+++ b/internal/app/probe_target.go
@@ -1,0 +1,253 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
+
+	"github.com/colinedwardwood/network-topology-exporter/internal/config"
+	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
+	"github.com/colinedwardwood/network-topology-exporter/internal/discovery"
+	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
+	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
+	"github.com/colinedwardwood/network-topology-exporter/internal/tracing"
+)
+
+// probeResult is the per-target output of a successful probe. RunCycle
+// aggregates these (under mu) into the cycle's device/edge/OOS sets. It carries
+// no shared state; the caller owns all aggregation (C6/C7).
+type probeResult struct {
+	targetIdx    int
+	device       *discovery.Device
+	edges        []discovery.Edge
+	outOfScope   []discovery.OutOfScopeNeighbour
+	mgmtIP       string
+	moduleStatus map[string]int // proto -> 0 ok | 1 degraded | 2 failed
+}
+
+// probeDeps bundles the read-only dependencies probeTarget needs. These are the
+// values the RunCycle probe closure captured before the #153 extraction; none
+// of them is cycle-shared mutable state (no mu/results/okCount/failByReason/
+// allARPMACs and no graph/ages handle — the caller owns all of that, C6/C7).
+type probeDeps struct {
+	cfg           *config.Config
+	m             *metrics.Metrics
+	walkerMetrics snmpwalk.WalkerMetrics
+	warnLimiter   snmpwalk.WarnLimiter
+	resolver      *credentials.Resolver
+	allowedNets   []*net.IPNet
+	pool          *snmpwalk.SessionPool
+	logger        *slog.Logger
+}
+
+// probeTarget runs the full per-device probe for one configured target and
+// returns its result. It does NOT touch the cycle's shared
+// mu/results/okCount/failByReason/allARPMACs (the caller aggregates under mu,
+// C7/C9) and takes no graph/ages handle (it is read-only w.r.t. the published
+// graph, C3).
+//
+// params is built (by the credential walk) AND zeroized here via
+// defer params.Zeroize() because its lifetime spans the module walk AND the ARP
+// step (spec C1); walkModules receives the already-mutated params and never
+// owns its Zeroize.
+//
+// On every early-exit fail path probeTarget returns ok=false plus the
+// metrics.DiscoveryFailReason the caller records into failByReason — matching
+// the pre-extraction inline behaviour for DNS failure, allow-list reject, and
+// auth/timeout. Fail paths that fire their own inline metrics (the system-walk
+// failure layer's DiscoveryHardFailTotal/CredentialTrialsTotal/SNMPWalksTotal)
+// fire them here so they remain identical. The goroutine panic-recover and the
+// cycle-budget admission are admission-shell concerns and stay in the caller's
+// closure (C7).
+//
+// cycleCtx is the (optionally budget-bounded) cycle context; the per-target
+// span descends from it so span parenting is unchanged (C4).
+func probeTarget(cycleCtx context.Context, deps probeDeps, target config.TargetConfig, idx int) (res probeResult, arp map[string]string, ok bool, failReason metrics.DiscoveryFailReason) {
+	cfg := deps.cfg
+	m := deps.m
+	logger := deps.logger
+
+	// Issue #68: per-target span, child of discovery.cycle. targetCtx
+	// flows into the credential resolve and every module walk so they
+	// nest under target.poll. No-op when tracing is disabled.
+	targetStart := time.Now()
+	targetCtx, targetSpan := tracing.Tracer().Start(cycleCtx, "target.poll",
+		trace.WithAttributes(attribute.String("target.ip", target.Host)))
+	defer func() {
+		targetSpan.SetAttributes(
+			attribute.Float64("target.latency_seconds", time.Since(targetStart).Seconds()))
+		targetSpan.End()
+	}()
+
+	ip := net.ParseIP(target.Host)
+	if ip == nil {
+		addrs, err := net.DefaultResolver.LookupHost(targetCtx, target.Host)
+		if err != nil || len(addrs) == 0 {
+			logger.Warn("host resolution failed", "host", target.Host, "error", err)
+			targetSpan.SetStatus(codes.Error, "dns resolution failed")
+			return probeResult{}, nil, false, metrics.DiscoveryReasonDNSFailed
+		}
+		ip = net.ParseIP(addrs[0])
+	}
+
+	// LD-11: enforce CIDR allow-list for hostname-based targets whose
+	// IP is only known after DNS resolution.
+	if len(deps.allowedNets) > 0 && !snmpwalk.IPInNets(ip, deps.allowedNets) {
+		logger.Warn("resolved target outside allow-list, skipping",
+			"host", target.Host, "ip", ip)
+		targetSpan.SetStatus(codes.Error, "outside allow-list")
+		return probeResult{}, nil, false, metrics.DiscoveryReasonOutsideAllowList
+	}
+
+	dev, params, profileName, err := WalkSystemWithCredentials(targetCtx, cfg, deps.resolver, ip, target, logger)
+	targetSpan.SetAttributes(attribute.String("credential.profile", profileName))
+	if err != nil {
+		logger.Warn("snmp walk failed", "target", target.Host, "error", err)
+		targetSpan.RecordError(err)
+		targetSpan.SetStatus(codes.Error, "credential resolve / system walk failed")
+		m.DiscoveryHardFailTotal.WithLabelValues("system", "system_group_walk_error").Inc()
+		m.CredentialTrialsTotal.WithLabelValues("failed").Inc()
+		// Issue #20: partition the walk-failure counter by
+		// sub-reason. Timeouts surface via status="timeout"
+		// (reason=n/a — the status is the reason). Non-timeout
+		// failures from this layer are attributed to auth: the
+		// credential-rotation loop in WalkSystemWithCredentials
+		// only returns a non-timeout error when at least one
+		// candidate was rejected non-silently (DeadlineExceeded
+		// is the silent-drop / unreachable case).
+		if errors.Is(err, context.DeadlineExceeded) {
+			m.SNMPWalksTotal.WithLabelValues("timeout", metrics.ReasonNA).Inc()
+			return probeResult{}, nil, false, metrics.DiscoveryReasonTimeout
+		}
+		m.SNMPWalksTotal.WithLabelValues("error", string(metrics.WalkReasonAuthFailed)).Inc()
+		return probeResult{}, nil, false, metrics.DiscoveryReasonAuthFailed
+	}
+	// Zeroize the winning credential bytes as soon as this device's
+	// modules are finished, before the goroutine exits and params
+	// becomes unreachable to a sensible cleanup. Issue #5.
+	defer params.Zeroize()
+
+	devCtx, cancel := context.WithTimeout(targetCtx, cfg.Discovery.TimeoutPerDevice)
+	defer cancel()
+	devCtx = snmpwalk.ContextWithDecodeIssueReporter(devCtx, func(issue snmpwalk.DecodeIssue) {
+		m.DiscoveryDecodeIssues.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
+		m.DiscoveryQuarantinedRowsTotal.WithLabelValues(issue.Module, string(issue.OID), issue.Reason).Add(float64(issue.Count))
+	})
+	// Nil-tolerant panic-reporter seam for the raw SNMP transport
+	// goroutines (snmpwalk.BulkWalk / Walk spawn their own goroutine
+	// stacks for BulkWalkAll/WalkAll/Get; this per-device recover does
+	// not cover them). On a recovered transport panic the walk returns a
+	// normal error and bumps network_topology_panics_total{site="snmp_walk"}
+	// without the discovery package importing the prometheus client.
+	devCtx = snmpwalk.ContextWithPanicReporter(devCtx, func(site string) {
+		m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
+	})
+
+	// Issue #72: per-target SNMP PDU rate limiter. When configured, cap
+	// the steady-state request rate against this single device so a high
+	// parallelism + all-modules run cannot self-DoS its SNMP daemon. One
+	// limiter per device per cycle (per-target isolation — never shared
+	// across devices). Burst is set equal to the rate so a freshly-built
+	// limiter starts with a full 1-second bucket (no artificial stall on
+	// the first walk) while still pacing sustained throughput to the
+	// configured ceiling. Unset/0 injects nothing — zero overhead,
+	// unchanged behaviour.
+	if rps := cfg.Discovery.PerTargetPDURatePerSecond; rps > 0 {
+		lim := rate.NewLimiter(rate.Limit(rps), rps)
+		devCtx = snmpwalk.ContextWithRateLimiter(devCtx, lim)
+		devCtx = snmpwalk.ContextWithRateLimitWaitObserver(devCtx, func(d time.Duration) {
+			m.SNMPRateLimitWaitSeconds.Observe(d.Seconds())
+		})
+	}
+
+	deps.resolver.RecordSuccess(ip.String(), profileName)
+	m.CredentialTrialsTotal.WithLabelValues("ok").Inc()
+	m.SNMPWalksTotal.WithLabelValues("ok", metrics.ReasonNA).Inc()
+
+	dev.Site = target.Site
+	for k, v := range target.Labels {
+		if dev.Labels == nil {
+			dev.Labels = make(map[string]string)
+		}
+		dev.Labels[k] = v
+	}
+
+	// Propagate module-specific tuning into params. MaxVlans is only
+	// consumed by fdb.Walk; Vendor and UseBGPV2MIB are only consumed
+	// by bgp.Walk; other modules ignore them. UseBGPV2MIB is the
+	// inverse of the operator-facing DisableV2MIB knob (default false
+	// = v2 enabled). WalkerMetrics is read by bgp.Walk via the
+	// recordWalkerOutcome helper; nil is tolerated (drops the
+	// increment) so unit tests that build Params inline don't need
+	// to wire a fake sink unless they care about the counter.
+	params.MaxVlans = cfg.Modules.FDB.MaxVlans
+	params.Vendor = dev.Vendor
+	params.UseBGPV2MIB = !cfg.Modules.BGP.DisableV2MIB
+	params.WalkerMetrics = deps.walkerMetrics
+	params.WarnLimiter = deps.warnLimiter
+	// Nil-tolerant panic-reporter seam (ops hardening): the FDB module
+	// spawns one goroutine per VLAN and recovers a panic locally so one
+	// bad VLAN can't crash discovery; this closure lets it bump
+	// network_topology_panics_total{site} without the discovery package
+	// importing the prometheus client (mirrors the WalkerMetrics seam).
+	params.PanicReporter = func(site string) {
+		m.PanicsRecoveredTotal.WithLabelValues(site).Inc()
+	}
+	// Issue #83: opt-in per-target SNMP session pool. When pool is nil
+	// (the default), params.Pool stays nil and snmpwalk.Acquire uses the
+	// fresh open+close path — byte-identical to pre-#83 behaviour. When a
+	// pool is wired, the (IP, CredentialProfile) key lets a target reuse
+	// one session across its sequential module walks. CredentialProfile
+	// is the winning profile from WalkSystemWithCredentials above; it
+	// must be part of the key so a credential change yields a new entry
+	// and InvalidateProfile can evict a rotated profile's sessions.
+	params.Pool = deps.pool
+	params.CredentialProfile = profileName
+
+	// Issue #153: the per-module walk loop (module list → #74 per-IP
+	// scope intersection → per-module span/metrics → outcome classify)
+	// is shared with /admin/rediscover via walkModules. The cycle
+	// supplies FULL instrumentation (metrics + tracer + logger) so its
+	// behaviour is byte-identical to the pre-extraction inline loop.
+	allEdges, allOOS, modStatus := walkModules(devCtx, cfg, *dev, ip, params, deps.allowedNets,
+		moduleInstrumentation{metrics: m, tracer: tracing.Tracer(), logger: logger, host: target.Host})
+
+	// Walk ARP table for MAC→IP enrichment when modules.arp.enabled
+	// is true (default). The returned map feeds SynthesizeEdges (via the
+	// caller's mu-guarded allARPMACs first-wins merge, C9) as a fallback
+	// for FDB-only edges where LLDP did not provide the neighbour
+	// identity. Failures are non-fatal: LLDP-based correlation still
+	// works without ARP data.
+	if cfg.Modules.ARP.Enabled {
+		arpClient, arpRelease, arpErr := snmpwalk.Acquire(params)
+		if arpErr != nil {
+			logger.Debug("ARP table walk failed; MAC→IP resolution unavailable for this device",
+				"device", dev.ID, "err", arpErr)
+		} else {
+			arpMACToIP, arpErr := snmpwalk.WalkARPTable(devCtx, arpClient)
+			arpRelease()
+			if arpErr != nil {
+				logger.Debug("ARP table walk failed; MAC→IP resolution unavailable for this device",
+					"device", dev.ID, "err", arpErr)
+			} else {
+				arp = arpMACToIP
+			}
+		}
+	}
+
+	return probeResult{
+		targetIdx:    idx,
+		device:       dev,
+		edges:        allEdges,
+		outOfScope:   allOOS,
+		mgmtIP:       ip.String(),
+		moduleStatus: modStatus,
+	}, arp, true, ""
+}

--- a/internal/app/rediscover.go
+++ b/internal/app/rediscover.go
@@ -13,13 +13,6 @@ import (
 
 	"github.com/colinedwardwood/network-topology-exporter/internal/config"
 	"github.com/colinedwardwood/network-topology-exporter/internal/credentials"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/bgp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/cdp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/fdb"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/isis"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/lldp"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/mpls"
-	"github.com/colinedwardwood/network-topology-exporter/internal/discovery/ospf"
 	snmpwalk "github.com/colinedwardwood/network-topology-exporter/internal/discovery/snmp"
 	"github.com/colinedwardwood/network-topology-exporter/internal/metrics"
 )
@@ -275,42 +268,21 @@ func (rd *Rediscoverer) walkOne(ctx context.Context, ip net.IP) (RediscoverOutco
 	params.Vendor = dev.Vendor
 	params.UseBGPV2MIB = !rd.cfg.Modules.BGP.DisableV2MIB
 
-	mods := []Module{
-		{"lldp", rd.cfg.Modules.LLDP.Enabled, lldp.Walk},
-		{"cdp", rd.cfg.Modules.CDP.Enabled, cdp.Walk},
-		{"fdb", rd.cfg.Modules.FDB.Enabled, fdb.Walk},
-		{"ospf", rd.cfg.Modules.OSPF.Enabled, ospf.Walk},
-		{"bgp", rd.cfg.Modules.BGP.Enabled, bgp.Walk},
-		{"isis", rd.cfg.Modules.ISIS.Enabled, isis.Walk},
-		{"mpls_te", rd.cfg.Modules.MPLSTE.Enabled, mpls.Walk},
-	}
-
-	// Issue #74: honour the same per-target protocol scope as the regular
-	// cycle so a forced rediscover does not walk a module (e.g. bgp) against a
-	// target an override has scoped it out of.
-	allowedMods, overrideMatched := rd.cfg.ModulesForIP(ip)
-
-	var edgeCount int
-	for _, mod := range mods {
-		if !mod.Enabled {
-			continue
-		}
-		if overrideMatched && !allowedMods[mod.Proto] {
-			continue
-		}
-		modCtx := devCtx
-		var modCancel context.CancelFunc = func() {}
-		if rd.cfg.Discovery.TimeoutPerModule > 0 {
-			modCtx, modCancel = context.WithTimeout(devCtx, rd.cfg.Discovery.TimeoutPerModule)
-		}
-		edges, _, werr := mod.Walk(modCtx, params, dev.ID, rd.allowedNets)
-		modCancel()
-		if werr != nil {
-			rd.logger.Debug("rediscover module walk failed", "module", mod.Proto, "ip", ip, "error", werr)
-			continue
-		}
-		edgeCount += len(edges)
-	}
+	// Route the per-module walk through the shared walkModules helper (issue
+	// #153) so the rediscover and regular-cycle module sets can no longer
+	// drift. walkModules applies the same #74 cfg.ModulesForIP(ip) per-target
+	// scope intersection the inline loop used to, so behaviour is unchanged.
+	//
+	// Intentionally minimal instrumentation (issue #153 / spec C2): the admin
+	// rediscover path passes nil metrics+tracer and leaves params.WalkerMetrics
+	// unset, so it emits no per-cycle walker/decode/module-duration metrics
+	// (feeding them would corrupt the per-cycle series) and installs no #72
+	// rate limiter (keeps the forced diagnostic walk fast). This is deliberate
+	// isolation, not drift. The returned oos/moduleStatus are ignored: a forced
+	// walk only reports its edge count and outcome, it does not publish.
+	edges, _, _ := walkModules(devCtx, rd.cfg, *dev, ip, params, rd.allowedNets,
+		moduleInstrumentation{logger: rd.logger, host: ip.String()})
+	edgeCount := len(edges)
 	return RediscoverSuccess, edgeCount, nil
 }
 

--- a/internal/app/rediscover_app_test.go
+++ b/internal/app/rediscover_app_test.go
@@ -141,6 +141,57 @@ func TestRediscoverHappyPath(t *testing.T) {
 	}
 }
 
+// TestRediscoverEmitsNoPerCycleMetrics pins the intentional instrumentation
+// gap (issue #153, spec C2): the /admin/rediscover forced walk must return the
+// same (outcome, edgeCount) as the inline loop did AND emit ZERO per-cycle
+// walker/decode/module-duration metric series. Feeding those series from the
+// out-of-cycle path would corrupt the cycle's rate(...) dashboards, so routing
+// walkOne through the shared walkModules helper must keep passing nil
+// metrics + nil tracer and leave params.WalkerMetrics unset. This test locks
+// that invariant; it passed against the pre-refactor inline loop too.
+func TestRediscoverEmitsNoPerCycleMetrics(t *testing.T) {
+	t.Setenv("TEST_COMM", "public")
+	cfg := testConfig(t, "TEST_COMM")
+	m := metrics.New(false)
+
+	remoteIP := net.ParseIP("127.0.0.2")
+	addr := snmptest.Start(t, "public", systemAndLLDPPDUs("sw-a", remoteIP))
+	ip, port := snmptest.ParseAddr(addr)
+
+	rd := newTestRediscoverer(t, cfg, m, []string{"127.0.0.0/8"}, true)
+	rd.targetPortOverride = map[string]uint16{ip.String(): port}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	results := rd.Rediscover(ctx, []string{ip.String()})
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Outcome != RediscoverSuccess {
+		t.Fatalf("outcome = %q (err=%q), want success", results[0].Outcome, results[0].Error)
+	}
+	if results[0].Edges != 1 {
+		t.Errorf("edges = %d, want 1", results[0].Edges)
+	}
+
+	// No per-cycle walker-outcome series (driven by params.WalkerMetrics, left
+	// unset by rediscover).
+	if got := testutil.CollectAndCount(m.WalkerOutcomeTotal); got != 0 {
+		t.Errorf("walker_outcome_total series = %d, want 0 (rediscover emits none)", got)
+	}
+	if got := testutil.CollectAndCount(m.BGPWalkerOutcomeTotal); got != 0 {
+		t.Errorf("bgp_walker_outcome_total series = %d, want 0 (rediscover emits none)", got)
+	}
+	// No per-module SNMP-walk counter (driven by inst.metrics, passed nil).
+	if got := testutil.CollectAndCount(m.SNMPWalksTotal); got != 0 {
+		t.Errorf("snmp_walks_total series = %d, want 0 (rediscover emits none)", got)
+	}
+	// No per-module duration histogram observations.
+	if got := testutil.CollectAndCount(m.DiscoveryModuleDuration); got != 0 {
+		t.Errorf("discovery_module_duration_seconds series = %d, want 0 (rediscover emits none)", got)
+	}
+}
+
 // TestRediscoverInvalidIPRejected verifies a non-IP target string is rejected
 // with the error outcome and never walked.
 func TestRediscoverInvalidIPRejected(t *testing.T) {


### PR DESCRIPTION
Closes #153. **Pure refactor — zero behavior change** for both the discovery cycle and `/admin/rediscover` (verified end-to-end by per-task + whole-branch review; the existing cycle/rediscover/goleak/`-race` suites are the regression gate). `cycle.go` 527 → 274 lines.

## What
- **New `device_walk.go`:** `enabledModules(cfg)` (the 7-element module list, now defined **once**) + a `walkModules(...)` helper **parameterized on instrumentation** (`moduleInstrumentation{metrics, tracer, logger, host}`, nil-able). Output-only `(edges, oos, moduleStatus)`.
- **T1:** `RunCycle`'s per-module loop → `walkModules` with FULL instrumentation (identical: every metric/span still fires).
- **T2:** `rediscover.walkOne` → `walkModules` with MINIMAL instrumentation — deletes the duplicated module slice+loop. **Deliberately** emits no per-cycle metrics/spans and installs no #72 rate limiter (adding them would corrupt the per-cycle metric series and slow the diagnostic — see the spec; a test pins zero `walker_outcome_total` increments).
- **New `probe_target.go`:** `probeTarget(...)` extracts the rest of the giant closure (DNS, allow-list, system walk, `params` build + `defer Zeroize`, ARP). The goroutine `defer recover`, sem/cycle-budget admission, and `mu`-guarded aggregation (incl. `allARPMACs` first-wins) stay in `RunCycle`. It now reads as walk → synthesize → reconcile → age.
- **T4:** `loop.go` publish sequence → `publish(...)`; the caller owns `prevGraph`/`ages` reassignment, diff is computed before reassign, and `ages` advances on both the happy and size-budget-reject paths.

## Process
Brainstorm → **2 adversarial design reviews** (which flipped the scope: "closing rediscover's gap" was a regression, not a fix — so this is pure-refactor, gap left as intentional isolation) → spec → plan → subagent-driven TDD with spec + code-quality review per task (T3, the riskiest, was race+goleak-verified at `-count=3`).

## Known cosmetic delta
Routing `rediscover.walkOne` through the shared helper changes the per-module *Debug-log* line's text/keys (`"<proto> walk failed"` with `target`/`error` vs the old `"rediscover module walk failed"` with `module`/`ip`). Debug-level only — no metric, span, edge, status, or return-value impact.

## Test plan
- [x] `go test ./... -race` — green (cycle + rediscover + goleak + OTLP cap/drain)
- [x] `golangci-lint run` — 0 issues; `gofmt -l` empty; `go vet` clean
- [x] New tests: `walkModules` (ok + failure-path under nil instrumentation); rediscover no-per-cycle-metrics (mutation-tested); `publish` C8 invariants
- [x] `enabledModules` is the sole `[]Module` list; no duplication remains