### PR TITLE
chore(release): drop Docker Hub mirror; keep GHCR + offline tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,6 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-test, integration-test, lint, helm-lint, docker]
-    env:
-      # Secrets cannot be referenced directly in `if:` expressions, so derive a
-      # plain env flag from the Docker Hub token. When the DOCKERHUB_TOKEN secret
-      # is absent this is 'false' and the release stays GHCR-only; once the secret
-      # is provisioned it flips to 'true' and the image is mirrored to Docker Hub.
-      DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     permissions:
       contents: write       # create GitHub release
       packages: write       # push to ghcr.io
@@ -345,38 +339,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Gated on DOCKERHUB_ENABLED: skipped (not failed) when the secret is absent.
-      - name: log in to Docker Hub
-        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      # Build the metadata-action images list: GHCR always, Docker Hub appended
-      # only when the mirror is enabled. Emitting a multiline value via a heredoc
-      # to $GITHUB_OUTPUT lets metadata-action push every tag to both registries
-      # from a single build-push, so the cosign loop and binary steps stay shared.
-      - name: compute image registries
-        id: imgs
-        run: |
-          {
-            echo "images<<EOF"
-            echo "ghcr.io/${{ github.repository }}"
-            if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
-              echo "docker.io/${{ github.repository }}"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: docker metadata
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
-          images: ${{ steps.imgs.outputs.images }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -411,15 +380,6 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.build_push.outputs.digest }}
-          push-to-registry: true
-
-      # Same digest, mirrored to Docker Hub; only runs when the mirror is enabled.
-      - name: attest container image build provenance (Docker Hub)
-        if: ${{ env.DOCKERHUB_ENABLED == 'true' }}
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-name: docker.io/${{ github.repository }}
           subject-digest: ${{ steps.build_push.outputs.digest }}
           push-to-registry: true
 
@@ -472,10 +432,6 @@ jobs:
         run: |
           cosign attest --yes --type spdxjson --predicate "${SBOM}" \
             "ghcr.io/${{ github.repository }}@${DIGEST}"
-          if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
-            cosign attest --yes --type spdxjson --predicate "${SBOM}" \
-              "docker.io/${{ github.repository }}@${DIGEST}"
-          fi
 
       - name: sign SBOM (cosign keyless)
         env:
@@ -486,8 +442,8 @@ jobs:
             --output-certificate "${SBOM}.cert" \
             "${SBOM}"
 
-      # Offline install bundle for air-gapped / proxy-restricted shops that can
-      # reach neither ghcr.io nor docker.io. Contains the static binaries plus
+      # Offline install bundle for air-gapped / proxy-restricted shops that
+      # cannot reach ghcr.io. Contains the static binaries plus
       # their cosign sigs/certs, the example config, the Helm chart, and the
       # Helm-free Kustomize overlay tree.
       - name: assemble offline tarball

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -424,14 +424,13 @@ v1.3.1 lands under this milestone instead, renamed to
   device's edges land in `/metrics` on the next regular cycle. New audit metric
   `network_topology_admin_rediscovery_total{outcome}`. See
   `docs/operator/troubleshooting.md` § 4a. Closes #73.
-- **#78 — Release artefacts mirrored beyond GHCR.** The release pipeline now
-  mirrors the multi-arch image to Docker Hub
-  (`docker.io/colinedwardwood/network-topology-exporter`) alongside GHCR, and
-  publishes a cosign-signed offline tarball (static binaries + sigs, example
-  config, Helm chart, Kustomize overlays) attached to each GitHub Release for
-  air-gapped / proxy-restricted environments. The Docker Hub push is gated on the
-  `DOCKERHUB_TOKEN` secret, so releases stay GHCR-complete until the repo owner
-  provisions the Docker Hub repo + secrets (remaining steps on #78).
+- **Offline release tarball for air-gapped installs.** Each GitHub Release now
+  attaches a cosign-signed `network-topology-exporter-<version>-offline.tar.gz`
+  bundling the static binaries (with sigs/certs), the example config, the Helm
+  chart, the Kustomize overlays, and the SBOM — for `curl`-and-untar deployment
+  in environments that cannot reach `ghcr.io`. (Docker Hub mirroring was
+  considered under #78 but dropped — image distribution will be handled at the
+  organisation level; #78 closed not-planned.)
 - **#79 — Kustomize manifests.** New `deploy/kustomize/` (base + `standalone` /
   `hub` / `spoke` overlays) lets the exporter be installed with `kubectl apply
   -k`, Argo CD, or Flux without Helm. The manifests mirror the Helm chart's

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -118,9 +118,7 @@ docker run --rm -p 9100:9100 \
 ```
 
 The container reads `/etc/topology-exporter/config.yaml` by default (the
-flag default), so no extra args are needed. A Docker Hub mirror is also
-available: `docker.io/colinedwardwood/network-topology-exporter:latest`.
-Then go to **2.3 Verify**.
+flag default), so no extra args are needed. Then go to **2.3 Verify**.
 
 ### 2.2c Run path — Kubernetes (Kustomize)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run --rm -p 9100:9100 \
 ## Installation
 
 Released images are multi-arch (`linux/amd64`, `linux/arm64`), cosign-keyless
-signed, and carry SLSA build-provenance attestations. Three install paths cover
+signed, and carry SLSA build-provenance attestations. Two install paths cover
 registry-restricted and air-gapped environments:
 
 1. **GHCR (default):**
@@ -63,14 +63,7 @@ registry-restricted and air-gapped environments:
    docker pull ghcr.io/colinedwardwood/network-topology-exporter:latest
    ```
 
-2. **Docker Hub (mirror)** — for shops that cannot reach `ghcr.io`. The same
-   image (identical digest) is mirrored from each release:
-
-   ```bash
-   docker pull docker.io/colinedwardwood/network-topology-exporter:latest
-   ```
-
-3. **Offline tarball (air-gapped)** — each GitHub Release attaches a
+2. **Offline tarball (air-gapped)** — each GitHub Release attaches a
    cosign-signed `network-topology-exporter-<version>-offline.tar.gz` bundling
    the static binaries (with sigs/certs), the example config, the Helm chart,
    and the Kustomize overlays for `curl`-and-untar deployment.

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,7 +32,6 @@ The release job (`.github/workflows/ci.yml::release`) builds a multi-arch image,
 
 - Workflow run succeeded — `gh run list --workflow=ci.yml --limit 3`
 - Image is on GHCR — `ghcr.io/colinedwardwood/network-topology-exporter:X.Y.Z` (and `:latest` for non-prerelease tags)
-- Image is also on the Docker Hub mirror — `docker.io/colinedwardwood/network-topology-exporter:X.Y.Z`
 - GitHub Release exists with both `topology-exporter-linux-amd64` and `topology-exporter-linux-arm64` attached
 - Each release binary has its cosign keyless `.sig` and `.cert` attachments alongside it
 - The SBOM (SPDX JSON, `network-topology-exporter-vX.Y.Z.spdx.json`) is attached and attested to the registry, with its own `.sig`/`.cert`


### PR DESCRIPTION
Refs #78 (closed not-planned). Removes the Docker Hub mirroring that was wired but never activated — image distribution will be handled at the organisation level once the repo moves to the Grafana org. Also removes the **misleading README/docs promise** of a Docker Hub image that was never published (the push was gated on an unset `DOCKERHUB_TOKEN`).

## Removed
- `ci.yml` release job: the `DOCKERHUB_ENABLED` env, the Docker Hub `docker/login-action`, the GHCR-or-both registry heredoc (now GHCR-only `images:`), the Docker Hub build-provenance attest, and the Docker Hub SBOM attest.
- `README.md`: the "Docker Hub (mirror)" install path (two paths now: GHCR + offline tarball).
- `GETTING_STARTED.md` + `docs/release.md`: the Docker Hub mirror mentions / release-checklist line.
- `CHANGELOG.md`: reworded the entry to describe the offline tarball (kept) and note Docker Hub was dropped.

## Kept (unchanged)
- GHCR multi-arch push + cosign keyless + SLSA provenance + SBOM attest.
- The cosign-signed **offline tarball** (binaries+sigs, config, Helm chart, Kustomize overlays, SBOM) attached to each GitHub Release — the genuinely useful air-gapped path.

## Test plan
- [x] `ci.yml` parses as valid YAML; release job still pushes to GHCR, signs, attests, assembles + uploads the tarball
- [x] No stale `docker.io`/Docker Hub references remain (repo-wide grep clean except the CHANGELOG note explaining the removal)